### PR TITLE
test(security): enforce admin dashboard privacy invariants

### DIFF
--- a/app.py
+++ b/app.py
@@ -412,7 +412,7 @@ def sitemap_xml():
 def _require_admin():
     if not ADMIN_TOKEN:
         abort(404)
-    token = request.headers.get('X-Admin-Token') or request.args.get('token') or ''
+    token = request.headers.get('X-Admin-Token', '')
     if token != ADMIN_TOKEN:
         log_security_event("ADMIN_ACCESS_DENIED", "Invalid admin token", 'WARNING')
         abort(403)

--- a/dashboards-v2-plan.md
+++ b/dashboards-v2-plan.md
@@ -1,0 +1,71 @@
+# Dashboards V2 Robust Adaptation
+
+## Summary
+- Goal: portable dashboard modules with explicit admin privacy invariants.
+- Branch/worktree model: independent `codex/*` branches from `origin/main`.
+- No public route removals in this pass.
+- Keep `/admin/pipeline` active and protected.
+
+## Branches
+1. `codex/dashboards-v2-0-admin-guard`
+2. `codex/dashboards-v2-1-gemeinde-foundation`
+3. `codex/dashboards-v2-2-utility`
+4. `codex/dashboards-v2-3-resident-blueprint`
+5. `codex/dashboards-v2-4-admin-blueprint`
+
+## PR0: Admin Guard
+- Add admin privacy guard tests for:
+  - `/admin/overview`
+  - `/admin/pipeline`
+  - `/admin/export`
+  - `/admin/lea-reports`
+  - `/api/email/stats`
+  - `/api/billing/community/<community_id>/period/<period_id>`
+- Enforce header-only admin auth (`X-Admin-Token`) in app/admin surfaces.
+- Keep fail-closed behavior when `ADMIN_TOKEN` missing (`404`).
+
+## PR1: Foundation + Gemeinde
+- Add shared dashboard partials:
+  - `templates/partials/dashboard_head.html`
+  - `templates/partials/dashboard_nav.html`
+- Migrate `templates/gemeinde/dashboard.html` to shared partials.
+- Ensure noindex robots meta through shared head.
+- Keep `subdomain`/`bfs` query behavior.
+- Pass `ga4_id` explicitly in municipality dashboard route.
+- Add Gemeinde dashboard tests for routing + rendering invariants.
+
+## PR2: Utility
+- Migrate `templates/utility/dashboard.html` to shared partials.
+- Keep auth flow unchanged (`/utility/dashboard` requires session).
+- Remove stale onboarding copy: `White-Label Branding konfigurieren`.
+- Add first direct utility dashboard tests (auth redirect + UI invariants).
+
+## PR3: Resident Blueprint
+- Extract resident routes from `app.py` into `resident_dashboard.py`:
+  - `/dashboard`
+  - `/api/referral/stats/<building_id>`
+  - `/api/referral/leaderboard`
+- Register blueprint in app.
+- Preserve route paths and behavior.
+- Add parity tests for readiness score, referral link, noindex, leaderboard behavior.
+
+## PR4: Admin Blueprint
+- Extract admin routes from `app.py` into `admin_dashboard.py`:
+  - `/admin/overview`
+  - `/admin/pipeline`
+  - `/admin/export`
+  - `/admin/lea-reports`
+- Register blueprint in app.
+- Keep `/admin/pipeline` available and protected.
+- Add admin dashboard tests for auth and response contracts.
+
+## Test Protocol
+- Per PR: run impacted tests first.
+- Then run broader suite (`pytest tests/ -v`) before merge when infra allows.
+- Mandatory gate: no unauthenticated `200` on admin surfaces.
+
+## Acceptance Criteria
+- Admin dashboard surfaces are not public.
+- Dashboard shells are portable via shared partials.
+- Route contracts remain stable per PR scope.
+- No broad B2B archival in this pass.

--- a/tests/test_admin_guard.py
+++ b/tests/test_admin_guard.py
@@ -1,0 +1,78 @@
+"""Guardrail tests: admin surface must stay private."""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+ADMIN_ROUTES = [
+    '/admin/overview',
+    '/admin/pipeline',
+    '/admin/export',
+    '/admin/lea-reports',
+    '/api/email/stats',
+    '/api/billing/community/c1/period/1',
+]
+
+
+def _request(path, *, headers=None, admin_token='test-admin-token'):
+    env = {
+        'DATABASE_URL': 'postgresql://x:x@localhost/x',
+        'REDIS_URL': 'memory://',
+        'ADMIN_TOKEN': admin_token,
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with (
+            patch('database.init_db', return_value=True),
+            patch('database._connection_pool', MagicMock()),
+            patch('database.is_db_available', return_value=True),
+            patch('database.get_stats', return_value={'total_buildings': 0, 'registrations_today': 0}),
+            patch('database.get_email_stats', return_value={'pending': 0, 'sent': 0, 'failed': 0}),
+            patch('database.count_consented_buildings', return_value=0),
+            patch('database.get_all_municipalities', return_value=[]),
+            patch('database.get_vnb_pipeline', return_value=[]),
+            patch('database.get_vnb_pipeline_stats', return_value={'total': 0, 'funnel': {}}),
+            patch('database.get_all_building_profiles', return_value=[]),
+            patch('database.get_lea_reports', return_value=[]),
+            patch('database.get_billing_period', return_value={'id': 1, 'community_id': 'c1'}),
+            patch('database.get_all_utility_clients', return_value=[]),
+            patch('database.get_utility_client_stats', return_value={}),
+        ):
+            import app as app_module
+
+            importlib.reload(app_module)
+            app_module.app.config['TESTING'] = True
+            client = app_module.app.test_client()
+            return client.get(path, headers=headers or {})
+
+
+@pytest.mark.parametrize('route', ADMIN_ROUTES)
+def test_admin_routes_require_header_token(route):
+    unauthorized = _request(route)
+    assert unauthorized.status_code == 403
+
+    query_only = _request(f'{route}?token=test-admin-token')
+    assert query_only.status_code == 403
+
+
+@pytest.mark.parametrize('route', ADMIN_ROUTES)
+def test_admin_routes_accept_valid_header(route):
+    authorized = _request(route, headers={'X-Admin-Token': 'test-admin-token'})
+    assert authorized.status_code not in (403, 404)
+
+
+def test_admin_routes_return_404_when_admin_token_missing():
+    response = _request('/admin/overview', headers={'X-Admin-Token': 'any'}, admin_token='')
+    assert response.status_code == 404
+
+
+def test_utility_admin_clients_header_only_auth():
+    unauthorized = _request('/utility/admin/clients')
+    assert unauthorized.status_code == 403
+
+    query_only = _request('/utility/admin/clients?token=test-admin-token')
+    assert query_only.status_code == 403
+
+    authorized = _request('/utility/admin/clients', headers={'X-Admin-Token': 'test-admin-token'})
+    assert authorized.status_code == 200

--- a/utility_portal.py
+++ b/utility_portal.py
@@ -222,7 +222,7 @@ def admin_clients():
     admin_token = os.getenv('ADMIN_TOKEN', '').strip()
     if not admin_token:
         return jsonify({"error": "not found"}), 404
-    token = request.headers.get('X-Admin-Token') or request.args.get('token') or ''
+    token = request.headers.get('X-Admin-Token', '')
     if token != admin_token:
         return jsonify({"error": "forbidden"}), 403
 


### PR DESCRIPTION
## Summary\n- enforce header-only admin auth for app and utility admin endpoints\n- keep fail-closed behavior when ADMIN_TOKEN is missing (404)\n- add admin guardrail tests for all admin-like routes\n- add robust dashboards-v2 implementation plan doc\n\n## Validation\n- pytest -q tests/test_admin_guard.py tests/test_lea_reports.py tests/test_e2e_integration.py::TestAdminPipelineHTML::test_pipeline_returns_html_with_accept