### PR TITLE
feat(utility): standardize dashboard shell and add auth/ui tests

### DIFF
--- a/templates/partials/dashboard_head.html
+++ b/templates/partials/dashboard_head.html
@@ -1,0 +1,15 @@
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex, nofollow">
+<title>{{ dashboard_title or 'Dashboard' }} | OpenLEG</title>
+<link rel="icon" type="image/x-icon" href="{{ site_url }}/static/favicon.ico">
+{% include 'partials/tailwind_brand.html' %}
+{% if ga4_id %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ ga4_id }}"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', '{{ ga4_id }}');
+</script>
+{% endif %}

--- a/templates/partials/dashboard_nav.html
+++ b/templates/partials/dashboard_nav.html
@@ -1,0 +1,14 @@
+<nav class="bg-white shadow-sm">
+  <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
+    <a href="/" class="text-2xl font-bold text-indigo-600">OpenLEG</a>
+    <div class="flex items-center gap-4">
+      <span id="dashboard-title" class="text-sm text-gray-500">{{ dashboard_title or 'Dashboard' }}</span>
+      {% if back_url %}
+      <a href="{{ back_url }}" class="text-sm text-gray-500 hover:text-gray-700">Zurück</a>
+      {% endif %}
+      {% if logout_url %}
+      <a href="{{ logout_url }}" class="text-sm text-gray-500 hover:text-red-600">Abmelden</a>
+      {% endif %}
+    </div>
+  </div>
+</nav>

--- a/templates/utility/dashboard.html
+++ b/templates/utility/dashboard.html
@@ -1,22 +1,12 @@
 <!DOCTYPE html>
 <html lang="de">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Dashboard | OpenLEG Utility Portal</title>
-    <script src="https://cdn.tailwindcss.com"></script>
+    {% set dashboard_title = "Utility Dashboard" %}
+    {% include 'partials/dashboard_head.html' %}
 </head>
 <body class="bg-gray-50 min-h-screen">
-    <nav class="bg-white shadow-sm">
-        <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
-            <a href="/" class="text-2xl font-bold text-indigo-600">OpenLEG</a>
-            <div class="flex items-center space-x-4 text-sm">
-                <span class="text-gray-600">{{ client.company_name }}</span>
-                <span class="px-2 py-1 bg-indigo-100 text-indigo-700 rounded text-xs font-medium uppercase">{{ client.tier }}</span>
-                <a href="/utility/logout" class="text-gray-500 hover:text-red-600">Abmelden</a>
-            </div>
-        </div>
-    </nav>
+    {% set logout_url = "/utility/logout" %}
+    {% include 'partials/dashboard_nav.html' %}
 
     <div class="max-w-6xl mx-auto px-4 py-8">
         <div class="flex justify-between items-start mb-8">
@@ -88,7 +78,7 @@
                     </div>
                     <div class="flex items-center">
                         <span class="w-6 h-6 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs mr-3">3</span>
-                        <span class="text-sm">White-Label Branding konfigurieren</span>
+                        <span class="text-sm">Technische Integration prüfen</span>
                     </div>
                     <div class="flex items-center">
                         <span class="w-6 h-6 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs mr-3">4</span>

--- a/tests/test_utility_dashboard.py
+++ b/tests/test_utility_dashboard.py
@@ -1,0 +1,92 @@
+"""Utility dashboard coverage for auth and UI contract."""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+
+def _dashboard_response(client_data=None):
+    env = {
+        'DATABASE_URL': 'postgresql://x:x@localhost/x',
+        'REDIS_URL': 'memory://',
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with (
+            patch('database.init_db', return_value=True),
+            patch('database._connection_pool', MagicMock()),
+            patch('database.is_db_available', return_value=True),
+            patch('database.get_stats', return_value={'total_buildings': 0}),
+            patch('database.get_utility_client', return_value=client_data),
+        ):
+            import app as app_module
+
+            importlib.reload(app_module)
+            app_module.app.config['TESTING'] = True
+            client = app_module.app.test_client()
+
+            if client_data:
+                with client.session_transaction() as session:
+                    session['utility_client_id'] = client_data.get('client_id', 'cid-1')
+
+            return client.get('/utility/dashboard')
+
+
+def _sample_client(status='active', api_key_hash='hash'):
+    return {
+        'client_id': 'cid-1',
+        'company_name': 'Stadtwerke Test',
+        'tier': 'pro',
+        'status': status,
+        'vnb_name': 'EKZ',
+        'population': 25000,
+        'api_key_hash': api_key_hash,
+        'kanton': 'ZH',
+        'contact_name': 'Max',
+        'contact_email': 'max@test.ch',
+        'contact_phone': '+41790000000',
+        'created_at': None,
+        'last_login_at': None,
+    }
+
+
+def test_dashboard_requires_auth_redirect():
+    response = _dashboard_response(client_data=None)
+    assert response.status_code == 302
+    assert '/utility/login' in response.headers.get('Location', '')
+
+
+def test_dashboard_renders_company_name():
+    response = _dashboard_response(client_data=_sample_client())
+    html = response.data.decode('utf-8', errors='ignore')
+    assert response.status_code == 200
+    assert 'Stadtwerke Test' in html
+
+
+def test_dashboard_has_noindex_meta():
+    response = _dashboard_response(client_data=_sample_client())
+    html = response.data.decode('utf-8', errors='ignore')
+    assert 'name="robots" content="noindex, nofollow"' in html
+
+
+def test_dashboard_status_badge_active_and_trial():
+    active_html = _dashboard_response(client_data=_sample_client(status='active')).data.decode('utf-8', errors='ignore')
+    trial_html = _dashboard_response(client_data=_sample_client(status='trial')).data.decode('utf-8', errors='ignore')
+
+    assert 'Active' in active_html
+    assert 'Trial' in trial_html
+
+
+def test_dashboard_api_key_section_present():
+    response = _dashboard_response(client_data=_sample_client(api_key_hash='abc'))
+    html = response.data.decode('utf-8', errors='ignore')
+    assert 'API-Zugang' in html
+    assert 'API-Schluessel aktiv' in html
+
+
+def test_dashboard_onboarding_steps_render_without_stale_white_label():
+    response = _dashboard_response(client_data=_sample_client(api_key_hash=None))
+    html = response.data.decode('utf-8', errors='ignore')
+
+    assert 'Onboarding' in html
+    assert 'Technische Integration prüfen' in html
+    assert 'White-Label Branding' not in html


### PR DESCRIPTION
## Summary\n- add shared dashboard partials\n- migrate utility dashboard to shared shell with noindex meta\n- remove stale "White-Label Branding" onboarding step\n- add first direct utility dashboard test suite\n\n## Validation\n- pytest -q tests/test_utility_dashboard.py