### PR TITLE
refactor(dashboard): extract resident routes into blueprint

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ import email_automation
 from municipality import municipality_bp
 from api_public import public_api_bp
 from health import health_bp
+from resident_dashboard import resident_bp
 from utility_portal import utility_bp
 
 # --- Cron Secret ---
@@ -122,6 +123,7 @@ else:
 app.register_blueprint(municipality_bp)
 app.register_blueprint(public_api_bp)
 app.register_blueprint(health_bp)
+app.register_blueprint(resident_bp)
 app.register_blueprint(utility_bp)
 
 # --- Multi-tenant middleware ---
@@ -836,78 +838,6 @@ def unsubscribe_token(token):
     db.delete_building(building_id)
     db.cancel_emails_for_building(building_id)
     return "<h1>Abmeldung erfolgreich</h1><p>Ihre Daten wurden gelöscht.</p>"
-
-
-# --- Dashboard ---
-@app.route("/dashboard")
-def dashboard():
-    building_id = request.args.get('bid', '').strip()
-    if not building_id:
-        return render_city_template('dashboard.html', error="Kein Profil angegeben.", user=None)
-
-    user = db.get_building_for_dashboard(building_id)
-    if not user:
-        return render_city_template('dashboard.html', error="Profil nicht gefunden.", user=None)
-
-    score = 0
-    checks = []
-    if user.get('verified'):
-        score += 25
-        checks.append(('E-Mail bestätigt', True))
-    else:
-        checks.append(('E-Mail bestätigt', False))
-    if user.get('annual_consumption_kwh'):
-        score += 25
-        checks.append(('Verbrauchsdaten hinterlegt', True))
-    else:
-        checks.append(('Verbrauchsdaten hinterlegt', False))
-    if user.get('share_with_utility'):
-        score += 25
-        checks.append(('EVU-Einwilligung erteilt', True))
-    else:
-        checks.append(('EVU-Einwilligung erteilt', False))
-    if user.get('share_with_neighbors'):
-        score += 25
-        checks.append(('Nachbar-Einwilligung erteilt', True))
-    else:
-        checks.append(('Nachbar-Einwilligung erteilt', False))
-
-    neighbor_count = 0
-    referral_link = ''
-    lat = user.get('lat')
-    lon = user.get('lon')
-    city_id = g.tenant.get('territory') if hasattr(g, 'tenant') else None
-    if lat and lon:
-        neighbor_count = db.get_neighbor_count_near(float(lat), float(lon), city_id=city_id)
-    ref_code = db.get_referral_code(building_id)
-    if ref_code:
-        referral_link = f"{APP_BASE_URL}/?ref={ref_code}"
-
-    return render_city_template('dashboard.html',
-        user=user, readiness_score=score, checks=checks,
-        neighbor_count=neighbor_count, referral_link=referral_link, error=None)
-
-
-# --- Referral System ---
-@app.route("/api/referral/stats/<building_id>")
-def api_referral_stats(building_id):
-    stats = db.get_referral_stats(building_id)
-    referral_code = db.get_referral_code(building_id)
-    return jsonify({
-        "referral_code": referral_code,
-        "referral_link": f"{APP_BASE_URL}/?ref={referral_code}" if referral_code else None,
-        "total_referrals": stats.get('total_referrals', 0)
-    })
-
-
-@app.route("/api/referral/leaderboard")
-def api_referral_leaderboard():
-    city_id = g.tenant.get('territory') if hasattr(g, 'tenant') else None
-    leaderboard = db.get_referral_leaderboard(limit=10, city_id=city_id)
-    for entry in leaderboard:
-        street = entry.get('street', '')
-        entry['display_name'] = street[:15] + '...' if len(street) > 15 else street
-    return jsonify({"leaderboard": leaderboard})
 
 
 @app.route("/api/stats/public")

--- a/resident_dashboard.py
+++ b/resident_dashboard.py
@@ -1,0 +1,103 @@
+"""Resident dashboard blueprint with route parity to legacy app routes."""
+
+import os
+
+from flask import Blueprint, g, jsonify, render_template, request
+from jinja2 import TemplateNotFound
+
+import database as db
+import tenant as tenant_module
+
+resident_bp = Blueprint('resident_dashboard', __name__)
+APP_BASE_URL = os.getenv('APP_BASE_URL', 'http://localhost:5003')
+SITE_URL = APP_BASE_URL.rstrip('/')
+
+
+def _render_city_template(template_name, **kwargs):
+    tenant = getattr(g, 'tenant', tenant_module.DEFAULT_TENANT)
+    kwargs.setdefault('tenant', tenant)
+    kwargs.setdefault('site_url', SITE_URL)
+    kwargs.setdefault('ga4_id', tenant.get('ga4_id') or os.getenv('GA4_MEASUREMENT_ID', ''))
+    city_path = f"cities/{tenant['territory']}/{template_name}"
+    try:
+        return render_template(city_path, **kwargs)
+    except TemplateNotFound:
+        return render_template(template_name, **kwargs)
+
+
+@resident_bp.route('/dashboard')
+def dashboard():
+    building_id = request.args.get('bid', '').strip()
+    if not building_id:
+        return _render_city_template('dashboard.html', error='Kein Profil angegeben.', user=None)
+
+    user = db.get_building_for_dashboard(building_id)
+    if not user:
+        return _render_city_template('dashboard.html', error='Profil nicht gefunden.', user=None)
+
+    score = 0
+    checks = []
+    if user.get('verified'):
+        score += 25
+        checks.append(('E-Mail bestätigt', True))
+    else:
+        checks.append(('E-Mail bestätigt', False))
+    if user.get('annual_consumption_kwh'):
+        score += 25
+        checks.append(('Verbrauchsdaten hinterlegt', True))
+    else:
+        checks.append(('Verbrauchsdaten hinterlegt', False))
+    if user.get('share_with_utility'):
+        score += 25
+        checks.append(('EVU-Einwilligung erteilt', True))
+    else:
+        checks.append(('EVU-Einwilligung erteilt', False))
+    if user.get('share_with_neighbors'):
+        score += 25
+        checks.append(('Nachbar-Einwilligung erteilt', True))
+    else:
+        checks.append(('Nachbar-Einwilligung erteilt', False))
+
+    neighbor_count = 0
+    referral_link = ''
+    lat = user.get('lat')
+    lon = user.get('lon')
+    city_id = g.tenant.get('territory') if hasattr(g, 'tenant') else None
+    if lat and lon:
+        neighbor_count = db.get_neighbor_count_near(float(lat), float(lon), city_id=city_id)
+    ref_code = db.get_referral_code(building_id)
+    if ref_code:
+        referral_link = f'{APP_BASE_URL}/?ref={ref_code}'
+
+    return _render_city_template(
+        'dashboard.html',
+        user=user,
+        readiness_score=score,
+        checks=checks,
+        neighbor_count=neighbor_count,
+        referral_link=referral_link,
+        error=None,
+    )
+
+
+@resident_bp.route('/api/referral/stats/<building_id>')
+def api_referral_stats(building_id):
+    stats = db.get_referral_stats(building_id)
+    referral_code = db.get_referral_code(building_id)
+    return jsonify(
+        {
+            'referral_code': referral_code,
+            'referral_link': f'{APP_BASE_URL}/?ref={referral_code}' if referral_code else None,
+            'total_referrals': stats.get('total_referrals', 0),
+        }
+    )
+
+
+@resident_bp.route('/api/referral/leaderboard')
+def api_referral_leaderboard():
+    city_id = g.tenant.get('territory') if hasattr(g, 'tenant') else None
+    leaderboard = db.get_referral_leaderboard(limit=10, city_id=city_id)
+    for entry in leaderboard:
+        street = entry.get('street', '')
+        entry['display_name'] = street[:15] + '...' if len(street) > 15 else street
+    return jsonify({'leaderboard': leaderboard})

--- a/tests/test_resident_dashboard.py
+++ b/tests/test_resident_dashboard.py
@@ -1,0 +1,88 @@
+"""Resident dashboard blueprint extraction parity tests."""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+
+BASE_USER = {
+    'building_id': 'b1',
+    'address': 'Musterstrasse 1, 8000 Zürich',
+    'verified': True,
+    'annual_consumption_kwh': 4200,
+    'share_with_utility': True,
+    'share_with_neighbors': True,
+    'lat': 47.37,
+    'lon': 8.54,
+}
+
+
+def _get(path, *, user=None, referral_code='abc123', referral_stats=None, leaderboard=None):
+    env = {
+        'DATABASE_URL': 'postgresql://x:x@localhost/x',
+        'REDIS_URL': 'memory://',
+        'APP_BASE_URL': 'http://openleg.ch',
+    }
+    with patch.dict(os.environ, env, clear=False):
+        with (
+            patch('database.init_db', return_value=True),
+            patch('database._connection_pool', MagicMock()),
+            patch('database.is_db_available', return_value=True),
+            patch('database.get_stats', return_value={'total_buildings': 0, 'registrations_today': 0}),
+            patch('database.get_building_for_dashboard', return_value=user),
+            patch('database.get_neighbor_count_near', return_value=2),
+            patch('database.get_referral_code', return_value=referral_code),
+            patch('database.get_referral_stats', return_value=referral_stats or {'total_referrals': 4}),
+            patch(
+                'database.get_referral_leaderboard',
+                return_value=leaderboard
+                or [
+                    {'street': 'Lange Musterstrasse 123', 'count': 3},
+                    {'street': 'Kurzweg', 'count': 1},
+                ],
+            ),
+        ):
+            import app as app_module
+
+            importlib.reload(app_module)
+            app_module.app.config['TESTING'] = True
+            client = app_module.app.test_client()
+            return client.get(path)
+
+
+def test_dashboard_requires_bid_query_param():
+    response = _get('/dashboard', user=None)
+    assert response.status_code == 200
+    html = response.data.decode('utf-8', errors='ignore')
+    assert 'Kein Profil angegeben.' in html
+
+
+def test_dashboard_renders_with_valid_bid_and_score():
+    response = _get('/dashboard?bid=b1', user=BASE_USER)
+    assert response.status_code == 200
+    html = response.data.decode('utf-8', errors='ignore')
+    assert '100%' in html
+    assert 'Ihre LEG-Bereitschaft' in html
+
+
+def test_dashboard_renders_referral_link_and_noindex():
+    response = _get('/dashboard?bid=b1', user=BASE_USER)
+    html = response.data.decode('utf-8', errors='ignore')
+    assert 'http://openleg.ch/?ref=abc123' in html
+    assert 'name="robots" content="noindex, nofollow"' in html
+
+
+def test_referral_stats_route_preserved():
+    response = _get('/api/referral/stats/b1', referral_stats={'total_referrals': 7}, referral_code='code7')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['referral_code'] == 'code7'
+    assert data['total_referrals'] == 7
+
+
+def test_referral_leaderboard_truncates_display_names():
+    response = _get('/api/referral/leaderboard')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert data['leaderboard'][0]['display_name'].endswith('...')
+    assert data['leaderboard'][1]['display_name'] == 'Kurzweg'


### PR DESCRIPTION
## Summary\n- extract resident routes into resident_dashboard blueprint\n- preserve existing route paths and behavior\n- register blueprint in app and remove inlined resident routes\n- add resident dashboard parity tests\n\n## Validation\n- pytest -q tests/test_resident_dashboard.py