### PR TITLE
fix: handle decimal PV ranking thresholds

### DIFF
--- a/pv_ranking.py
+++ b/pv_ranking.py
@@ -121,10 +121,11 @@ def improvement_target(row: Dict, threshold_score: Optional[float]) -> Optional[
     installed = row.get("pv_installed_kw")
     if potential is None or installed is None:
         return None
-    target_kw = threshold_score / 100.0 * float(potential)
+    threshold = float(threshold_score)
+    target_kw = threshold / 100.0 * float(potential)
     needed_kw = max(0.0, target_kw - float(installed))
     return {
-        "target_score": round(threshold_score, 1),
+        "target_score": round(threshold, 1),
         "needed_kw": round(needed_kw, 1),
         "roofs": round(needed_kw / AVG_ROOF_KWP),
     }

--- a/tests/test_pv_ranking.py
+++ b/tests/test_pv_ranking.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Tests für die Ranglisten-Logik."""
 
+from decimal import Decimal
+
 import pv_ranking
 
 
@@ -68,6 +70,17 @@ def test_improvement_target_zero_when_above_threshold():
     row = {"pv_estimated_potential_kw": 1000.0, "pv_installed_kw": 400.0}
     target = pv_ranking.improvement_target(row, threshold_score=30.0)
     assert target["needed_kw"] == 0.0
+
+
+def test_improvement_target_accepts_postgres_decimal_values():
+    row = {
+        "pv_estimated_potential_kw": Decimal("7345.45"),
+        "pv_installed_kw": Decimal("5000.00"),
+    }
+    target = pv_ranking.improvement_target(row, threshold_score=Decimal("80.00"))
+    assert target["target_score"] == 80.0
+    assert target["needed_kw"] == 876.4
+    assert target["roofs"] == 88
 
 
 def test_league_standings_ranks_in_each_league():


### PR DESCRIPTION
## Summary
- Convert PV ranking threshold values to float before improvement-target math
- Add regression coverage for Postgres Decimal values returned from production

## Verification
- `pytest tests/test_pv_ranking.py -q`
- `pytest tests/test_pv_ranking.py tests/test_municipality_organic.py tests/test_rangliste.py -q`
- `ruff check pv_ranking.py tests/test_pv_ranking.py`

## Deploy note
- Hotfix already deployed to production after `/gemeinde/profil/4221` returned 500 from Decimal/float arithmetic.
- Post-deploy smoke now passes for `/rangliste*`, `/gemeinde/profil/4221`, `/health`, and `/livez`.