### PR TITLE
feat: improve reach, mobile UX, and codebase docs

### DIFF
--- a/app.py
+++ b/app.py
@@ -486,6 +486,8 @@ def sitemap_xml():
         ("/pricing", "0.7", "monthly", current_date),
         ("/gemeinde/verzeichnis", "0.9", "weekly", current_date),
         ("/rangliste", "0.9", "daily", current_date),
+        ("/rangliste/fortschritte", "0.8", "daily", current_date),
+        ("/rangliste/vergleich", "0.7", "weekly", current_date),
         ("/rangliste/methodik", "0.6", "monthly", current_date),
         ("/api/v1/docs", "0.8", "weekly", current_date),
         ("/gemeinde/onboarding", "0.9", "weekly", current_date),

--- a/app.py
+++ b/app.py
@@ -442,6 +442,11 @@ def fuer_gemeinden():
     return render_city_template("fuer_gemeinden.html")
 
 
+@app.route("/open-source")
+def open_source():
+    return render_city_template("open_source.html")
+
+
 @app.route("/leg-gruenden")
 def leg_gruenden():
     return render_city_template("leg_gruenden.html")
@@ -484,6 +489,7 @@ def sitemap_xml():
         ("/leg-gruenden", "0.9", "weekly", current_date),
         ("/leg-kalkulator", "0.9", "weekly", current_date),
         ("/pricing", "0.7", "monthly", current_date),
+        ("/open-source", "0.8", "weekly", current_date),
         ("/gemeinde/verzeichnis", "0.9", "weekly", current_date),
         ("/rangliste", "0.9", "daily", current_date),
         ("/rangliste/fortschritte", "0.8", "daily", current_date),

--- a/templates/api_docs.html
+++ b/templates/api_docs.html
@@ -1,9 +1,14 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="de">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenLEG API Documentation</title>
+    <title>Offene Schweizer Energiedaten API | OpenLEG</title>
+    <meta name="description" content="OpenLEG API: offene Schweizer Energiedaten zu Gemeinden, ElCom Tarifen, Solarpotenzial und LEG-Potenzial. Kein API-Key nötig.">
+    <link rel="canonical" href="https://openleg.ch/api/v1/docs">
+    <meta property="og:title" content="Offene Schweizer Energiedaten API | OpenLEG">
+    <meta property="og:description" content="REST API für Schweizer Gemeindedaten, Tarife, Solarpotenzial und LEG-Analysen.">
+    <meta property="og:url" content="https://openleg.ch/api/v1/docs">
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
     <style>
         body { margin: 0; padding: 0; }

--- a/templates/fuer_gemeinden.html
+++ b/templates/fuer_gemeinden.html
@@ -4,6 +4,11 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Für Gemeinden | OpenLEG</title>
+  <meta name="description" content="OpenLEG für Gemeinden: Solarnutzungs-Rangliste, eigene Gemeinde-Seite, LEG-Onboarding, Selbsthosting und optionaler Projektsupport.">
+  <link rel="canonical" href="{{ site_url }}/fuer-gemeinden">
+  <meta property="og:title" content="OpenLEG für Gemeinden">
+  <meta property="og:description" content="Vergleichen Sie die Solarnutzung Ihrer Gemeinde und starten Sie lokale Stromgemeinschaften mit freier Open Source Infrastruktur.">
+  <meta property="og:url" content="{{ site_url }}/fuer-gemeinden">
   {% include 'partials/tailwind_brand.html' %}
 </head>
 <body class="bg-[#f6f4ef] text-ink">
@@ -39,7 +44,10 @@
         <pre class="bg-ink text-slate-300 rounded-lg p-4 text-sm overflow-x-auto mb-4"><code>git clone https://github.com/Open-LEG-ch/openleg.git
 cd openleg
 docker compose up -d</code></pre>
-        <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="block text-center border border-ink/20 text-ink py-3 rounded-lg font-semibold hover:bg-slate-50">Code auf GitHub</a>
+        <div class="grid gap-2">
+          <a href="/open-source" class="block text-center bg-brand text-white py-3 rounded-lg font-semibold hover:bg-brand-dark">Codebase verstehen</a>
+          <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="block text-center border border-ink/20 text-ink py-3 rounded-lg font-semibold hover:bg-slate-50">Code auf GitHub</a>
+        </div>
       </section>
 
       <section class="bg-white rounded-xl shadow-md p-6 border-t-4 border-brand flex flex-col">

--- a/templates/index.html
+++ b/templates/index.html
@@ -207,7 +207,10 @@
             <li>Kein Vendor Lock-in: jederzeit selbst hosten oder migrieren</li>
             <li>Community-Beiträge willkommen</li>
           </ul>
-          <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="inline-block mt-6 border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-slate-50">Code auf GitHub ansehen</a>
+          <div class="mt-6 flex flex-col sm:flex-row gap-3">
+            <a href="/open-source" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Codebase verstehen</a>
+            <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="inline-block border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-slate-50 text-center">GitHub ansehen</a>
+          </div>
         </div>
         <div class="space-y-4">
           <div class="rounded-xl border border-slate-200 bg-[#f6f4ef] p-5">

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Open Source und Codebase | OpenLEG</title>
+  <meta name="description" content="Wie OpenLEG als offene Infrastruktur funktioniert: Public App Repo, Private Ops Repo, Flask, PostgreSQL, Redis, Caddy und offene Energiedaten.">
+  <link rel="canonical" href="{{ site_url }}/open-source">
+  <meta property="og:title" content="Open Source und Codebase | OpenLEG">
+  <meta property="og:description" content="Architektur, Datenpipeline, Repo-Grenzen und Selbsthosting der freien OpenLEG Infrastruktur.">
+  <meta property="og:url" content="{{ site_url }}/open-source">
+  {% include 'partials/tailwind_brand.html' %}
+</head>
+<body class="bg-[#f6f4ef] text-ink">
+  {% include 'partials/site_nav.html' %}
+
+  <main class="max-w-6xl mx-auto px-4 py-12">
+    <header class="max-w-3xl mb-10">
+      <p class="text-sm font-semibold text-brand mb-2">Open Source</p>
+      <h1 class="text-4xl font-bold mb-4">Freie Energieinfrastruktur, die man prüfen und selbst betreiben kann.</h1>
+      <p class="text-lg text-ink-muted">OpenLEG ist das Public App Repo für Schweizer Lokale Elektrizitätsgemeinschaften. Der Code ist offen, die Datenquellen sind nachvollziehbar, und produktive Geheimnisse bleiben ausserhalb des öffentlichen Repos.</p>
+      <div class="mt-6 flex flex-col sm:flex-row gap-3">
+        <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">GitHub öffnen</a>
+        <a href="/api/v1/docs" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">API ansehen</a>
+      </div>
+    </header>
+
+    <section class="grid md:grid-cols-2 gap-6 mb-10">
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-xl font-bold mb-3">Public App Repo</h2>
+        <p class="text-ink-muted mb-4">Hier liegen Produktcode, Tests, Templates, öffentliche Datenmodelle, API und CI. Dieses Repo ist dafür gedacht, gelesen, geprüft und geforkt zu werden.</p>
+        <ul class="space-y-2 text-sm text-ink-muted list-disc list-inside">
+          <li>Flask App und öffentliche API</li>
+          <li>PostgreSQL Schema und idempotente Migrationen</li>
+          <li>Templates, statische Assets und Tests</li>
+          <li>AGPL-3.0-or-later Lizenz</li>
+        </ul>
+      </div>
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-xl font-bold mb-3">Private Ops Repo</h2>
+        <p class="text-ink-muted mb-4">Produktionsbetrieb, Host-Inventar, Secrets, Incident-Notizen und interne Strategie bleiben privat. So bleibt der App-Code offen, ohne produktive Infrastruktur offenzulegen.</p>
+        <ul class="space-y-2 text-sm text-ink-muted list-disc list-inside">
+          <li>Deployment-Runbooks und Hostnamen</li>
+          <li>Secret-Handling und Rotation</li>
+          <li>Incident Response und interne Planung</li>
+          <li>Keine Bürgerdaten im öffentlichen Repo</li>
+        </ul>
+      </div>
+    </section>
+
+    <section class="bg-white border border-slate-200 rounded-xl p-6 mb-10">
+      <h2 class="text-2xl font-bold mb-4">Architektur</h2>
+      <div class="grid md:grid-cols-4 gap-4 text-sm">
+        <div class="border border-slate-200 rounded-lg p-4">
+          <h3 class="font-semibold mb-1">Flask</h3>
+          <p class="text-ink-muted">Routen, Formulare, Gemeindeprofile, Rangliste und JSON API.</p>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-4">
+          <h3 class="font-semibold mb-1">PostgreSQL</h3>
+          <p class="text-ink-muted">Gemeindedaten, PV Panel, Tarife, Registrierungen und Audit-Daten.</p>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-4">
+          <h3 class="font-semibold mb-1">Redis</h3>
+          <p class="text-ink-muted">Cache und kurzfristige technische Zustände.</p>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-4">
+          <h3 class="font-semibold mb-1">Caddy</h3>
+          <p class="text-ink-muted">TLS, Domains und Reverse Proxy vor der Flask App.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="grid md:grid-cols-2 gap-6 mb-10">
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-xl font-bold mb-3">Datenpipeline</h2>
+        <p class="text-ink-muted mb-4">OpenLEG verbindet öffentliche Energiedaten mit nachvollziehbarer Logik. Die Solarnutzungs-Rangliste nutzt einen deterministischen Export aus BFE Anlagenregister, BFE Sonnendach und BFS Regionalporträts.</p>
+        <ul class="space-y-2 text-sm text-ink-muted list-disc list-inside">
+          <li>ElCom Tarife für H4 und weitere Kategorien</li>
+          <li>BFE Sonnendach für geschätztes Dachpotenzial</li>
+          <li>BFS Regionalporträts für Bevölkerung, Fläche und Dichte</li>
+          <li>CSV Seeds in <code>data/public</code>, Import über <code>scripts/load_pv_data.py</code></li>
+        </ul>
+      </div>
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-xl font-bold mb-3">Selbst betreiben</h2>
+        <p class="text-ink-muted mb-4">Die lokale Entwicklung braucht Python, Docker und eine `.env` aus der öffentlichen Vorlage.</p>
+        <pre class="bg-ink text-slate-300 rounded-lg p-4 text-sm overflow-x-auto"><code>git clone https://github.com/Open-LEG-ch/openleg.git
+cd openleg
+cp .env.example .env
+docker compose up -d</code></pre>
+      </div>
+    </section>
+
+    <section class="bg-brand/5 border border-brand/20 rounded-xl p-6">
+      <h2 class="text-xl font-bold mb-2">Warum offen?</h2>
+      <p class="text-ink-muted">Lokale Stromgemeinschaften brauchen Vertrauen. Gemeinden, Bewohner und Entwickler sollen prüfen können, welche Daten genutzt werden, welche Annahmen in Berechnungen stecken und wie die Plattform betrieben werden kann. OpenLEG verkauft keine Bürgerdaten.</p>
+    </section>
+  </main>
+
+  {% include 'partials/site_footer.html' %}
+</body>
+</html>

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -9,6 +9,20 @@
   <meta property="og:title" content="Open Source und Codebase | OpenLEG">
   <meta property="og:description" content="Architektur, Datenpipeline, Repo-Grenzen und Selbsthosting der freien OpenLEG Infrastruktur.">
   <meta property="og:url" content="{{ site_url }}/open-source">
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "OpenLEG",
+    "applicationCategory": "EnergyApplication",
+    "operatingSystem": "Web",
+    "softwareRequirements": "Python 3.11, PostgreSQL 16, Redis 7, Caddy",
+    "license": "https://www.gnu.org/licenses/agpl-3.0.html",
+    "codeRepository": "https://github.com/Open-LEG-ch/openleg",
+    "url": "{{ site_url }}/open-source",
+    "description": "Open Source Infrastruktur für Schweizer Lokale Elektrizitätsgemeinschaften."
+  }
+  </script>
   {% include 'partials/tailwind_brand.html' %}
 </head>
 <body class="bg-[#f6f4ef] text-ink">

--- a/templates/partials/site_nav.html
+++ b/templates/partials/site_nav.html
@@ -2,15 +2,46 @@
   <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
     <a href="/" class="text-2xl font-bold text-ink">OpenLEG</a>
     <div class="hidden md:flex items-center gap-6 text-sm text-ink">
-      <a href="#bewohner" class="hover:text-brand">Stromgemeinschaft gründen</a>
+      <a href="/#bewohner" class="hover:text-brand">Stromgemeinschaft gründen</a>
       <a href="/fuer-gemeinden" class="hover:text-brand">Für Gemeinden</a>
       <a href="/rangliste" class="hover:text-brand">Rangliste</a>
       <a href="/how-it-works" class="hover:text-brand">So funktioniert's</a>
-      <a href="https://github.com/Open-LEG-ch/openleg" class="hover:text-brand" target="_blank" rel="noopener">Open Source</a>
+      <a href="/open-source" class="hover:text-brand">Open Source</a>
       <a href="/api/v1/docs" class="hover:text-brand">API</a>
     </div>
     <div class="flex items-center gap-2">
-      <a href="/fuer-gemeinden" class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-dark">Wie Ihre Gemeinde teilnimmt</a>
+      <a href="/fuer-gemeinden" class="hidden sm:inline-flex bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-dark">Wie Ihre Gemeinde teilnimmt</a>
+      <button id="mobile-menu-toggle" type="button" class="md:hidden inline-flex h-10 w-10 items-center justify-center rounded-lg border border-slate-200 bg-white text-ink" aria-controls="mobile-menu" aria-expanded="false" aria-label="Navigation öffnen">
+        <span class="sr-only">Navigation öffnen</span>
+        <span class="block w-5 space-y-1">
+          <span class="block h-0.5 bg-ink"></span>
+          <span class="block h-0.5 bg-ink"></span>
+          <span class="block h-0.5 bg-ink"></span>
+        </span>
+      </button>
+    </div>
+  </div>
+  <div id="mobile-menu" class="hidden md:hidden border-t border-slate-200 bg-white">
+    <div class="max-w-6xl mx-auto px-4 py-3 grid gap-3 text-sm">
+      <a href="/#bewohner" class="py-2 text-ink hover:text-brand">Stromgemeinschaft gründen</a>
+      <a href="/fuer-gemeinden" class="py-2 text-ink hover:text-brand">Für Gemeinden</a>
+      <a href="/rangliste" class="py-2 text-ink hover:text-brand">Rangliste</a>
+      <a href="/how-it-works" class="py-2 text-ink hover:text-brand">So funktioniert's</a>
+      <a href="/open-source" class="py-2 text-ink hover:text-brand">Open Source</a>
+      <a href="/api/v1/docs" class="py-2 text-ink hover:text-brand">API</a>
+      <a href="/fuer-gemeinden" class="mt-1 bg-brand text-white px-4 py-2 rounded-lg text-center font-medium hover:bg-brand-dark">Wie Ihre Gemeinde teilnimmt</a>
     </div>
   </div>
 </nav>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    const toggle = document.getElementById('mobile-menu-toggle');
+    const menu = document.getElementById('mobile-menu');
+    if (!toggle || !menu) return;
+    toggle.addEventListener('click', () => {
+      const expanded = toggle.getAttribute('aria-expanded') === 'true';
+      toggle.setAttribute('aria-expanded', String(!expanded));
+      menu.classList.toggle('hidden', expanded);
+    });
+  });
+</script>

--- a/tests/test_api_public.py
+++ b/tests/test_api_public.py
@@ -286,3 +286,13 @@ class TestApiDocs:
             in html
         )
         assert "/api/cron/" not in html
+
+    def test_api_docs_has_share_metadata(self, client):
+        resp = client.get("/api/v1/docs")
+        assert resp.status_code == 200
+        html = resp.data.decode("utf-8", errors="ignore")
+        assert '<html lang="de">' in html
+        assert '<meta name="description"' in html
+        assert 'rel="canonical"' in html
+        assert 'property="og:title"' in html
+        assert "Offene Schweizer Energiedaten API" in html

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -69,6 +69,8 @@ def test_sitemap_contains_directory_docs_and_profile_urls(full_app_module, monke
     xml = resp.data.decode("utf-8", errors="ignore")
     assert "/gemeinde/verzeichnis" in xml
     assert "/api/v1/docs" in xml
+    assert "/rangliste/fortschritte" in xml
+    assert "/rangliste/vergleich" in xml
     assert "/gemeinde/profil/261" in xml
     assert "/gemeinde/profil/247" in xml
     assert "/admin/" not in xml

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -77,6 +77,24 @@ def test_sitemap_contains_directory_docs_and_profile_urls(full_app_module, monke
     assert "/api/v1/municipalities" not in xml
 
 
+def test_open_source_page_explains_codebase(full_app_module):
+    client = full_app_module.app.test_client()
+
+    resp = client.get("/open-source")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "Open Source" in html
+    assert "Flask" in html
+    assert "PostgreSQL" in html
+    assert "Redis" in html
+    assert "Caddy" in html
+    assert "Datenpipeline" in html
+    assert "Public App Repo" in html
+    assert "Private Ops Repo" in html
+    assert "git clone https://github.com/Open-LEG-ch/openleg.git" in html
+    assert "github.com/Open-LEG-ch/openleg" in html
+
+
 def test_backfill_elcom_invalid_secret_returns_403_and_no_mutation(
     full_app_module, monkeypatch
 ):

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -93,6 +93,9 @@ def test_open_source_page_explains_codebase(full_app_module):
     assert "Private Ops Repo" in html
     assert "git clone https://github.com/Open-LEG-ch/openleg.git" in html
     assert "github.com/Open-LEG-ch/openleg" in html
+    assert 'type="application/ld+json"' in html
+    assert '"@type": "SoftwareApplication"' in html
+    assert '"applicationCategory": "EnergyApplication"' in html
 
 
 def test_backfill_elcom_invalid_secret_returns_403_and_no_mutation(

--- a/tests/test_fuer_gemeinden_page.py
+++ b/tests/test_fuer_gemeinden_page.py
@@ -74,3 +74,41 @@ class TestFuerGemeindenPage:
             content = handle.read()
         assert "Rangliste ansehen" in content
         assert 'href="/rangliste"' in content
+
+    def test_homepage_links_to_open_source_explainer(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "templates",
+            "index.html",
+        )
+        with open(path, encoding="utf-8") as handle:
+            content = handle.read()
+        assert 'href="/open-source"' in content
+        assert "Codebase verstehen" in content
+
+    def test_fuer_gemeinden_has_share_metadata_and_open_source_link(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "templates",
+            "fuer_gemeinden.html",
+        )
+        with open(path, encoding="utf-8") as handle:
+            content = handle.read()
+        assert '<meta name="description"' in content
+        assert 'rel="canonical"' in content
+        assert 'property="og:title"' in content
+        assert 'href="/open-source"' in content
+
+    def test_site_nav_has_mobile_menu_controls(self):
+        path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "templates",
+            "partials",
+            "site_nav.html",
+        )
+        with open(path, encoding="utf-8") as handle:
+            content = handle.read()
+        assert 'id="mobile-menu-toggle"' in content
+        assert 'id="mobile-menu"' in content
+        assert 'aria-controls="mobile-menu"' in content
+        assert 'href="/open-source"' in content


### PR DESCRIPTION
## Summary
- Add ranking subpages to sitemap for organic reach
- Add `/open-source` explainer for architecture, repo boundary, data pipeline, and self-hosting
- Add mobile navigation and clearer codebase links from homepage and municipality page
- Add share metadata for municipality and API docs pages plus SoftwareApplication JSON-LD

## Thin slices
- `fix(seo): include ranking pages in sitemap`
- `feat(docs): add open source explainer page`
- `feat(ux): add mobile nav and source links`
- `feat(seo): add API and source metadata`

## Verification
- `pytest tests/ -q`
- `ruff check .`
- `ruff format --check .`
- Local Playwright smoke: `/open-source`, `/fuer-gemeinden`, mobile menu

## Notes
- Local browser console still shows existing Tailwind CDN warning and missing favicon 404.