### PR TITLE
refactor: extract PV/ranking storage into store/ranking (connection-seam slice)

### DIFF
--- a/database.py
+++ b/database.py
@@ -2332,188 +2332,6 @@ def get_municipality_profile(bfs_number: int) -> Optional[Dict]:
         return None
 
 
-def upsert_municipality_pv(profile: Dict) -> bool:
-    """Upsert PV-Nutzungs-Kennzahlen auf ein Gemeindeprofil.
-
-    Setzt nur PV- und Geo-Spalten plus Name/Kanton/Einwohner. ElCom-, Solar-
-    und Energiewende-Felder bleiben unberührt, damit der Massenimport reichere
-    bestehende Profile nicht überschreibt.
-    """
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO municipality_profiles (
-                        bfs_number, name, kanton, population,
-                        density_per_km2, area_km2,
-                        pv_score_pct, pv_estimated_potential_kw, pv_installed_kw,
-                        pv_untapped_kw, pv_annual_potential_gwh, pv_snapshot_year,
-                        pv_plant_match_rate)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (bfs_number) DO UPDATE SET
-                        name = EXCLUDED.name, kanton = EXCLUDED.kanton,
-                        population = EXCLUDED.population,
-                        density_per_km2 = EXCLUDED.density_per_km2,
-                        area_km2 = EXCLUDED.area_km2,
-                        pv_score_pct = EXCLUDED.pv_score_pct,
-                        pv_estimated_potential_kw = EXCLUDED.pv_estimated_potential_kw,
-                        pv_installed_kw = EXCLUDED.pv_installed_kw,
-                        pv_untapped_kw = EXCLUDED.pv_untapped_kw,
-                        pv_annual_potential_gwh = EXCLUDED.pv_annual_potential_gwh,
-                        pv_snapshot_year = EXCLUDED.pv_snapshot_year,
-                        pv_plant_match_rate = EXCLUDED.pv_plant_match_rate,
-                        updated_at = CURRENT_TIMESTAMP
-                """,
-                    (
-                        profile["bfs_number"],
-                        profile["name"],
-                        profile.get("kanton", "ZH"),
-                        profile.get("population"),
-                        profile.get("density_per_km2"),
-                        profile.get("area_km2"),
-                        profile.get("pv_score_pct"),
-                        profile.get("pv_estimated_potential_kw"),
-                        profile.get("pv_installed_kw"),
-                        profile.get("pv_untapped_kw"),
-                        profile.get("pv_annual_potential_gwh"),
-                        profile.get("pv_snapshot_year"),
-                        profile.get("pv_plant_match_rate"),
-                    ),
-                )
-                return True
-    except Exception as e:
-        logger.error(f"[DB] Error upserting municipality PV: {e}")
-        return False
-
-
-def save_municipality_pv_panel(rows: List[Dict]) -> int:
-    """Bulk-Upsert von Panel-Zeilen (bfs_number, year). Gibt Zeilenzahl zurück."""
-    if not rows:
-        return 0
-    try:
-        from psycopg2.extras import execute_values
-
-        values = [
-            (
-                r["bfs_number"],
-                r["year"],
-                r.get("added_kw"),
-                r.get("added_plants"),
-                r.get("cumulative_kw"),
-                r.get("estimated_potential_kw"),
-                r.get("score_pct"),
-                r.get("untapped_kw"),
-            )
-            for r in rows
-        ]
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                execute_values(
-                    cur,
-                    """
-                    INSERT INTO municipality_pv_panel (
-                        bfs_number, year, added_kw, added_plants, cumulative_kw,
-                        estimated_potential_kw, score_pct, untapped_kw)
-                    VALUES %s
-                    ON CONFLICT (bfs_number, year) DO UPDATE SET
-                        added_kw = EXCLUDED.added_kw,
-                        added_plants = EXCLUDED.added_plants,
-                        cumulative_kw = EXCLUDED.cumulative_kw,
-                        estimated_potential_kw = EXCLUDED.estimated_potential_kw,
-                        score_pct = EXCLUDED.score_pct,
-                        untapped_kw = EXCLUDED.untapped_kw
-                """,
-                    values,
-                )
-                return len(values)
-    except Exception as e:
-        logger.error(f"[DB] Error saving PV panel rows: {e}")
-        return 0
-
-
-def get_pv_profiles(kanton: Optional[str] = None) -> List[Dict]:
-    """Alle Gemeinden mit berechnetem PV-Score, für die Rangliste."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                if kanton:
-                    cur.execute(
-                        """
-                        SELECT bfs_number, name, kanton, population, density_per_km2,
-                               area_km2, pv_score_pct, pv_estimated_potential_kw,
-                               pv_installed_kw, pv_untapped_kw, pv_annual_potential_gwh,
-                               pv_snapshot_year, pv_plant_match_rate
-                        FROM municipality_profiles
-                        WHERE pv_score_pct IS NOT NULL AND kanton = %s
-                        ORDER BY pv_score_pct DESC
-                        """,
-                        (kanton,),
-                    )
-                else:
-                    cur.execute(
-                        """
-                        SELECT bfs_number, name, kanton, population, density_per_km2,
-                               area_km2, pv_score_pct, pv_estimated_potential_kw,
-                               pv_installed_kw, pv_untapped_kw, pv_annual_potential_gwh,
-                               pv_snapshot_year, pv_plant_match_rate
-                        FROM municipality_profiles
-                        WHERE pv_score_pct IS NOT NULL
-                        ORDER BY pv_score_pct DESC
-                        """
-                    )
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting PV profiles: {e}")
-        return []
-
-
-def get_pv_movers() -> List[Dict]:
-    """Fortschritt je Gemeinde: Delta des Panel-Scores im letzten vollen Jahr.
-
-    Nur aus dem Panel berechnet, nie mit dem Snapshot vermischt.
-    """
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT cur.bfs_number, mp.name, mp.kanton, mp.population,
-                           mp.density_per_km2, cur.year AS year,
-                           cur.score_pct AS score_now,
-                           prev.score_pct AS score_prev,
-                           (cur.score_pct - prev.score_pct) AS delta
-                    FROM municipality_pv_panel cur
-                    JOIN municipality_pv_panel prev
-                      ON prev.bfs_number = cur.bfs_number
-                     AND prev.year = cur.year - 1
-                    JOIN municipality_profiles mp
-                      ON mp.bfs_number = cur.bfs_number
-                    WHERE cur.year = (SELECT MAX(year) FROM municipality_pv_panel)
-                    ORDER BY delta DESC
-                    """
-                )
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting PV movers: {e}")
-        return []
-
-
-def get_municipality_pv_panel(bfs_number: int) -> List[Dict]:
-    """Panel-Zeilen einer Gemeinde, nach Jahr aufsteigend."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    "SELECT * FROM municipality_pv_panel WHERE bfs_number = %s ORDER BY year",
-                    (bfs_number,),
-                )
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting PV panel: {e}")
-        return []
-
-
 def get_all_municipality_profiles(
     kanton: Optional[str] = None, order_by: str = "name"
 ) -> List[Dict]:
@@ -3233,3 +3051,21 @@ def is_db_available() -> bool:
             except Exception as e:
                 logger.warning(f"[DB] Could not seed default tenant: {e}")
     return _db_initialized and _connection_pool is not None
+
+
+# ---------------------------------------------------------------------------
+# Per-domain repository re-exports.
+#
+# Storage code for self-contained domains lives in `store/` and resolves the
+# connection seam via `database.get_connection`. We re-export here so legacy
+# callers (`import database as db; db.get_pv_profiles()`) and existing tests
+# that monkeypatch `database.get_connection` keep working unchanged. The import
+# is at module end to avoid a circular import (store.ranking imports database).
+# ---------------------------------------------------------------------------
+from store.ranking import (  # noqa: E402, F401
+    upsert_municipality_pv,
+    save_municipality_pv_panel,
+    get_pv_profiles,
+    get_pv_movers,
+    get_municipality_pv_panel,
+)

--- a/store/__init__.py
+++ b/store/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Per-domain storage repositories sharing the database connection seam.
+
+Each module here owns one domain's persistence code. Functions resolve the
+connection seam via ``database.get_connection`` at call time, so existing
+test monkeypatches on ``database.get_connection`` keep working and callers
+that use ``import database as db; db.<func>()`` are unaffected.
+"""

--- a/store/ranking.py
+++ b/store/ranking.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""PV-Nutzungs- und Rangliste-Speicher (municipality_profiles PV columns + panel).
+
+Repository module for the PV/ranking domain. The connection seam is resolved
+via ``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working unchanged
+and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Optional, Dict, List
+
+import database
+
+logger = logging.getLogger(__name__)
+
+
+def upsert_municipality_pv(profile: Dict) -> bool:
+    """Upsert PV-Nutzungs-Kennzahlen auf ein Gemeindeprofil.
+
+    Setzt nur PV- und Geo-Spalten plus Name/Kanton/Einwohner. ElCom-, Solar-
+    und Energiewende-Felder bleiben unberührt, damit der Massenimport reichere
+    bestehende Profile nicht überschreibt.
+    """
+    try:
+        with database.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO municipality_profiles (
+                        bfs_number, name, kanton, population,
+                        density_per_km2, area_km2,
+                        pv_score_pct, pv_estimated_potential_kw, pv_installed_kw,
+                        pv_untapped_kw, pv_annual_potential_gwh, pv_snapshot_year,
+                        pv_plant_match_rate)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (bfs_number) DO UPDATE SET
+                        name = EXCLUDED.name, kanton = EXCLUDED.kanton,
+                        population = EXCLUDED.population,
+                        density_per_km2 = EXCLUDED.density_per_km2,
+                        area_km2 = EXCLUDED.area_km2,
+                        pv_score_pct = EXCLUDED.pv_score_pct,
+                        pv_estimated_potential_kw = EXCLUDED.pv_estimated_potential_kw,
+                        pv_installed_kw = EXCLUDED.pv_installed_kw,
+                        pv_untapped_kw = EXCLUDED.pv_untapped_kw,
+                        pv_annual_potential_gwh = EXCLUDED.pv_annual_potential_gwh,
+                        pv_snapshot_year = EXCLUDED.pv_snapshot_year,
+                        pv_plant_match_rate = EXCLUDED.pv_plant_match_rate,
+                        updated_at = CURRENT_TIMESTAMP
+                """,
+                    (
+                        profile["bfs_number"],
+                        profile["name"],
+                        profile.get("kanton", "ZH"),
+                        profile.get("population"),
+                        profile.get("density_per_km2"),
+                        profile.get("area_km2"),
+                        profile.get("pv_score_pct"),
+                        profile.get("pv_estimated_potential_kw"),
+                        profile.get("pv_installed_kw"),
+                        profile.get("pv_untapped_kw"),
+                        profile.get("pv_annual_potential_gwh"),
+                        profile.get("pv_snapshot_year"),
+                        profile.get("pv_plant_match_rate"),
+                    ),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error upserting municipality PV: {e}")
+        return False
+
+
+def save_municipality_pv_panel(rows: List[Dict]) -> int:
+    """Bulk-Upsert von Panel-Zeilen (bfs_number, year). Gibt Zeilenzahl zurück."""
+    if not rows:
+        return 0
+    try:
+        from psycopg2.extras import execute_values
+
+        values = [
+            (
+                r["bfs_number"],
+                r["year"],
+                r.get("added_kw"),
+                r.get("added_plants"),
+                r.get("cumulative_kw"),
+                r.get("estimated_potential_kw"),
+                r.get("score_pct"),
+                r.get("untapped_kw"),
+            )
+            for r in rows
+        ]
+        with database.get_connection() as conn:
+            with conn.cursor() as cur:
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO municipality_pv_panel (
+                        bfs_number, year, added_kw, added_plants, cumulative_kw,
+                        estimated_potential_kw, score_pct, untapped_kw)
+                    VALUES %s
+                    ON CONFLICT (bfs_number, year) DO UPDATE SET
+                        added_kw = EXCLUDED.added_kw,
+                        added_plants = EXCLUDED.added_plants,
+                        cumulative_kw = EXCLUDED.cumulative_kw,
+                        estimated_potential_kw = EXCLUDED.estimated_potential_kw,
+                        score_pct = EXCLUDED.score_pct,
+                        untapped_kw = EXCLUDED.untapped_kw
+                """,
+                    values,
+                )
+                return len(values)
+    except Exception as e:
+        logger.error(f"[DB] Error saving PV panel rows: {e}")
+        return 0
+
+
+def get_pv_profiles(kanton: Optional[str] = None) -> List[Dict]:
+    """Alle Gemeinden mit berechnetem PV-Score, für die Rangliste."""
+    try:
+        with database.get_connection() as conn:
+            with conn.cursor() as cur:
+                if kanton:
+                    cur.execute(
+                        """
+                        SELECT bfs_number, name, kanton, population, density_per_km2,
+                               area_km2, pv_score_pct, pv_estimated_potential_kw,
+                               pv_installed_kw, pv_untapped_kw, pv_annual_potential_gwh,
+                               pv_snapshot_year, pv_plant_match_rate
+                        FROM municipality_profiles
+                        WHERE pv_score_pct IS NOT NULL AND kanton = %s
+                        ORDER BY pv_score_pct DESC
+                        """,
+                        (kanton,),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        SELECT bfs_number, name, kanton, population, density_per_km2,
+                               area_km2, pv_score_pct, pv_estimated_potential_kw,
+                               pv_installed_kw, pv_untapped_kw, pv_annual_potential_gwh,
+                               pv_snapshot_year, pv_plant_match_rate
+                        FROM municipality_profiles
+                        WHERE pv_score_pct IS NOT NULL
+                        ORDER BY pv_score_pct DESC
+                        """
+                    )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting PV profiles: {e}")
+        return []
+
+
+def get_pv_movers() -> List[Dict]:
+    """Fortschritt je Gemeinde: Delta des Panel-Scores im letzten vollen Jahr.
+
+    Nur aus dem Panel berechnet, nie mit dem Snapshot vermischt.
+    """
+    try:
+        with database.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT cur.bfs_number, mp.name, mp.kanton, mp.population,
+                           mp.density_per_km2, cur.year AS year,
+                           cur.score_pct AS score_now,
+                           prev.score_pct AS score_prev,
+                           (cur.score_pct - prev.score_pct) AS delta
+                    FROM municipality_pv_panel cur
+                    JOIN municipality_pv_panel prev
+                      ON prev.bfs_number = cur.bfs_number
+                     AND prev.year = cur.year - 1
+                    JOIN municipality_profiles mp
+                      ON mp.bfs_number = cur.bfs_number
+                    WHERE cur.year = (SELECT MAX(year) FROM municipality_pv_panel)
+                    ORDER BY delta DESC
+                    """
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting PV movers: {e}")
+        return []
+
+
+def get_municipality_pv_panel(bfs_number: int) -> List[Dict]:
+    """Panel-Zeilen einer Gemeinde, nach Jahr aufsteigend."""
+    try:
+        with database.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM municipality_pv_panel WHERE bfs_number = %s ORDER BY year",
+                    (bfs_number,),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting PV panel: {e}")
+        return []

--- a/tests/test_store_ranking.py
+++ b/tests/test_store_ranking.py
@@ -1,0 +1,80 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the PV/ranking repository module (store.ranking).
+
+Verifies the extracted module resolves the connection seam via
+`database.get_connection` and that `database` re-exports the identical objects,
+so legacy callers and existing monkeypatches keep working unchanged.
+"""
+
+from contextlib import contextmanager
+
+import database
+from store import ranking
+
+
+class _FakeCursor:
+    def __init__(self, rows=None):
+        self.rows = rows or []
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    # The re-export shim must expose the exact same function objects.
+    assert database.upsert_municipality_pv is ranking.upsert_municipality_pv
+    assert database.save_municipality_pv_panel is ranking.save_municipality_pv_panel
+    assert database.get_pv_profiles is ranking.get_pv_profiles
+    assert database.get_pv_movers is ranking.get_pv_movers
+    assert database.get_municipality_pv_panel is ranking.get_municipality_pv_panel
+
+
+def test_ranking_uses_database_connection_seam(monkeypatch):
+    # Monkeypatching database.get_connection must affect store.ranking calls,
+    # proving the seam is shared (not a stale direct import binding).
+    cur = _FakeCursor(rows=[{"bfs_number": 4021, "pv_score_pct": 12.5}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = ranking.get_pv_profiles()
+    assert rows == [{"bfs_number": 4021, "pv_score_pct": 12.5}]
+    assert "pv_score_pct IS NOT NULL" in cur.executed[0][0]
+
+
+def test_get_pv_profiles_filters_by_kanton(monkeypatch):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    ranking.get_pv_profiles(kanton="AG")
+    query, params = cur.executed[0]
+    assert "kanton = %s" in query
+    assert params == ("AG",)
+
+
+def test_save_municipality_pv_panel_empty_returns_zero():
+    assert ranking.save_municipality_pv_panel([]) == 0


### PR DESCRIPTION
First bounded slice of architecture candidate #4 (per-domain repositories). Proves the connection-seam pattern on the smallest cohesive cluster.

## Was
- New `store/ranking.py`: the 5 PV/ranking storage functions (`upsert_municipality_pv`, `save_municipality_pv_panel`, `get_pv_profiles`, `get_pv_movers`, `get_municipality_pv_panel`), verbatim SQL, resolving the connection seam via `database.get_connection`.
- `database.py`: function bodies removed; re-exports `store.ranking` at module end (avoids the circular import). No caller edits, no behaviour change.
- `tests/test_store_ranking.py`: re-export identity, seam monkeypatch reach, kanton filter, empty-panel short-circuit.

## Why
`database.py` was one 3,235-line / 92-function module for every domain (no per-domain locality). This gives one domain its own home + test, with a compatibility shim so all 11 importers keep working.

## Test
367 passed, 2 skipped (was 363/2; +4 new). `ruff check` + `ruff format --check` clean.

Produced by an isolated explorer sub-agent; reviewed and verified against the real main baseline before merge. Next extraction order documented in `prd/architecture-deepening.md` (email queue → token/referral → utility/VNB → building last).

🤖 Generated with [Claude Code](https://claude.com/claude-code)