### PR TITLE
fix(deploy): make rsync mirror safe by default

### DIFF
--- a/deploy.example.sh
+++ b/deploy.example.sh
@@ -6,6 +6,10 @@ usage() {
 Usage:
   deploy.example.sh [--dry-run]
 
+Public-safe deploy template. Production host inventory and runbooks live in the
+private openleg-ops repo. Connect with the user your host allows (many setups
+disable root login, e.g. DEPLOY_HOST=ubuntu@1.2.3.4).
+
 Required env vars:
   DEPLOY_HOST   (e.g. ubuntu@1.2.3.4)
   REMOTE_DIR    (e.g. /opt/openleg)
@@ -18,6 +22,15 @@ Optional env vars:
   HEALTH_URL             (optional post-deploy check URL)
   COMPOSE_CMD            (defaults to: docker compose)
   BUILD_PRIMARY_SERVICE  (defaults to: flask)
+  RSYNC_DELETE           (0 default; set 1 to mirror and remove remote-only files)
+  PROTECT_PATHS          (space-separated extra rsync excludes, always preserved)
+
+Safety:
+  rsync runs WITHOUT --delete by default, so remote-only files (database
+  backups, generated assets, private dirs) are never removed. Enable
+  RSYNC_DELETE=1 only when you have verified the remote has no unmanaged data.
+  Even then, PROTECT_PATHS entries are always excluded. Run --dry-run first to
+  preview every change, including any deletions.
 USAGE
 }
 
@@ -42,6 +55,8 @@ TEST_CMD="${TEST_CMD:-pytest tests/ -q}"
 HEALTH_URL="${HEALTH_URL:-}"
 COMPOSE_CMD="${COMPOSE_CMD:-docker compose}"
 BUILD_PRIMARY_SERVICE="${BUILD_PRIMARY_SERVICE:-flask}"
+RSYNC_DELETE="${RSYNC_DELETE:-0}"
+PROTECT_PATHS="${PROTECT_PATHS:-}"
 
 if [[ -z "$DEPLOY_HOST" || -z "$REMOTE_DIR" ]]; then
   echo "DEPLOY_HOST and REMOTE_DIR are required." >&2
@@ -54,6 +69,34 @@ if [[ -n "$SSH_KEY" ]]; then
   SSH_ARGS=(-i "$SSH_KEY")
 fi
 
+# Build rsync options. --delete is opt-in. Runtime/data paths that the repo does
+# not own are always excluded so a mirror can never wipe production state.
+RSYNC_OPTS=(-az)
+if [[ "$RSYNC_DELETE" == "1" ]]; then
+  RSYNC_OPTS+=(--delete)
+fi
+RSYNC_OPTS+=(
+  --exclude='.git'
+  --exclude='.env'
+  --exclude='__pycache__'
+  --exclude='*.pyc'
+  --exclude='.pytest_cache'
+  --exclude='node_modules'
+  --exclude='.venv'
+  --exclude='backups/'
+  --exclude='*.sql'
+  --exclude='*.sql.gz'
+  --exclude='output/'
+  --exclude='tmp/'
+  --exclude='overnight/'
+  --exclude='prd/'
+  --exclude='grants/'
+  --exclude='outreach/'
+)
+for p in $PROTECT_PATHS; do
+  RSYNC_OPTS+=(--exclude="$p")
+done
+
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "Dry-run:"
   echo "  host=$DEPLOY_HOST"
@@ -61,6 +104,11 @@ if [[ "$DRY_RUN" == "1" ]]; then
   echo "  local_dir=$LOCAL_DIR"
   echo "  compose_cmd=$COMPOSE_CMD"
   echo "  build_primary_service=$BUILD_PRIMARY_SERVICE"
+  echo "  rsync_delete=$RSYNC_DELETE"
+  echo "==> rsync preview (no changes written)"
+  rsync "${RSYNC_OPTS[@]}" --dry-run --itemize-changes \
+    -e "ssh ${SSH_KEY:+-i $SSH_KEY}" \
+    "$LOCAL_DIR/" "$DEPLOY_HOST:$REMOTE_DIR/"
   exit 0
 fi
 
@@ -72,15 +120,8 @@ fi
 echo "==> Ensure remote dir"
 ssh "${SSH_ARGS[@]}" "$DEPLOY_HOST" "mkdir -p '$REMOTE_DIR'"
 
-echo "==> Sync project"
-rsync -az --delete \
-  --exclude='.git' \
-  --exclude='.env' \
-  --exclude='__pycache__' \
-  --exclude='*.pyc' \
-  --exclude='.pytest_cache' \
-  --exclude='node_modules' \
-  --exclude='.venv' \
+echo "==> Sync project (delete=$RSYNC_DELETE)"
+rsync "${RSYNC_OPTS[@]}" \
   -e "ssh ${SSH_KEY:+-i $SSH_KEY}" \
   "$LOCAL_DIR/" "$DEPLOY_HOST:$REMOTE_DIR/"
 

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -84,7 +84,16 @@ class TestDeployScript:
         assert "REMOTE_DIR" in self.content
 
     def test_uses_rsync(self):
-        assert "rsync -az --delete" in self.content
+        assert "rsync" in self.content
+        assert "-az" in self.content
+
+    def test_delete_is_opt_in_and_protects_data(self):
+        # --delete must not be unconditional; it is gated behind RSYNC_DELETE.
+        assert "rsync -az --delete" not in self.content
+        assert "RSYNC_DELETE" in self.content
+        # Production-only data must always be excluded from the mirror.
+        for protected in ("backups/", "*.sql", "*.sql.gz"):
+            assert protected in self.content
 
     def test_runs_compose_build(self):
         assert "docker compose" in self.content


### PR DESCRIPTION
## Why

The deploy template used \`rsync -az --delete\` unconditionally. Against a real prod tree that accumulates remote-only data (DB backups, generated assets, private dirs), a mirror would **delete** them. Caught during the logo deploy: \`--delete\` would have removed \`backups/pre_site_quality_*.sql.gz\`, \`grants/\`, \`prd/\`, \`outreach/\`, \`output/\`, \`tmp/\`.

## What

- \`--delete\` is now **opt-in** via \`RSYNC_DELETE\` (default \`0\`).
- Always exclude prod-only data: \`backups/\`, \`*.sql\`, \`*.sql.gz\`, \`output/\`, \`tmp/\`, \`overnight/\`, \`prd/\`, \`grants/\`, \`outreach/\`.
- New \`PROTECT_PATHS\` env for extra excludes.
- \`--dry-run\` now previews the **real** rsync (\`--itemize-changes\`), so deletions are visible before they happen.
- Usage documents non-root login (many hosts disable root; use \`ubuntu@\`).
- Tests updated to the safer contract (19 pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)