### PR TITLE
fix(docker): copy store/ package into image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY *.py ./
+COPY store/ store/
 COPY templates/ templates/
 COPY static/ static/
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -218,7 +218,7 @@
           <div class="flex items-center gap-2 mb-4">
             <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-emerald-500 text-white text-sm font-bold" aria-hidden="true">&#9733;</span>
             <h3 class="text-lg font-bold">Vorbilder</h3>
-            <span class="text-sm text-ink-muted">hÃ¶chste Solarnutzung</span>
+            <span class="text-sm text-ink-muted">höchste Solarnutzung</span>
           </div>
           <ul class="space-y-2">
             {% for m in ranking_best %}
@@ -237,8 +237,8 @@
         <div class="rounded-2xl border border-rose-200 bg-rose-50/60 p-5">
           <div class="flex items-center gap-2 mb-4">
             <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-rose-500 text-white text-sm font-bold" aria-hidden="true">&uarr;</span>
-            <h3 class="text-lg font-bold">GrÃ¶sste Chancen</h3>
-            <span class="text-sm text-ink-muted">meiste ungenutzte DÃ¤cher</span>
+            <h3 class="text-lg font-bold">Grösste Chancen</h3>
+            <span class="text-sm text-ink-muted">meiste ungenutzte Dächer</span>
           </div>
           <ul class="space-y-2">
             {% for m in ranking_worst %}


### PR DESCRIPTION
## Why

`database.py` imports `store.ranking` (store refactor, #53), but the Dockerfile only ran `COPY *.py ./`, so the `store/` package never made it into the image. A full deploy surfaced this: gunicorn crashed at import with `ModuleNotFoundError: No module named 'store'` and prod returned 502.

## Fix

Add `COPY store/ store/` to the Dockerfile. Already applied to prod to restore service; this lands it in the repo so image builds (GHCR + deploys) work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)