### PR TITLE
feat: ranking refactor + ops/AgentMail wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ GA4_MEASUREMENT_ID=G-XXXXXXXXXX
 
 # === Admin Access ===
 ADMIN_TOKEN=your-secure-admin-token
+INTERNAL_TOKEN=your-secure-internal-token
 
 # === OpenClaw (optional) ===
 MODEL_BASE_URL=https://api.example.com/v1
@@ -34,6 +35,16 @@ OPENCLAW_GATEWAY_BIND=loopback
 OPENCLAW_GATEWAY_PORT=18789
 OPENCLAW_READONLY=true
 BRAVE_API_KEY=
+FLASK_URL=http://flask:5000
+
+# === LEA AgentMail (private ops) ===
+AGENTMAIL_API_BASE=https://api.agentmail.to/v0
+AGENTMAIL_API_KEY=
+AGENTMAIL_WEBHOOK_SECRET=
+AGENTMAIL_WEBHOOK_URL=
+AGENTMAIL_HUMAN_EMAIL=hallo@mail.openleg.ch
+LEA_INBOX_ADDRESS=lea@mail.openleg.ch
+LEA_AGENT_ID=openleg-lea
 
 # === Session Settings ===
 SESSION_COOKIE_SECURE=True

--- a/app.py
+++ b/app.py
@@ -4,6 +4,7 @@ import os
 import time
 import uuid
 import math
+import json
 import hashlib
 import threading
 import logging
@@ -38,6 +39,13 @@ try:
     HAS_SCIPY = True
 except ImportError:
     HAS_SCIPY = False
+
+try:
+    from svix.webhooks import Webhook, WebhookVerificationError
+
+    HAS_SVIX = True
+except ImportError:
+    HAS_SVIX = False
 
 # --- Security imports ---
 try:
@@ -113,6 +121,7 @@ ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "hallo@openleg.ch")
 ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "").strip()
 # PUBLIC-SNAPSHOT-PRIVATE-START: internal-report-token
 INTERNAL_TOKEN = os.getenv("INTERNAL_TOKEN", "").strip()
+AGENTMAIL_WEBHOOK_SECRET = os.getenv("AGENTMAIL_WEBHOOK_SECRET", "").strip()
 # PUBLIC-SNAPSHOT-PRIVATE-END: internal-report-token
 
 # --- Rate Limiting & Security ---
@@ -578,6 +587,98 @@ def _require_admin():
         abort(403)
 
 
+def _latest_snapshot_by_category(snapshots):
+    latest = {}
+    for snapshot in snapshots:
+        latest.setdefault(snapshot.get("category", "uncategorized"), snapshot)
+    return latest
+
+
+def _first_email_identity(value):
+    if isinstance(value, list):
+        value = value[0] if value else ""
+    if isinstance(value, dict):
+        return {"email": value.get("email", ""), "name": value.get("name", "")}
+    if isinstance(value, str):
+        return {"email": value, "name": ""}
+    return {"email": "", "name": ""}
+
+
+def _sanitize_agentmail_payload(data):
+    message = data.get("message") or {}
+    if not isinstance(message, dict):
+        message = {}
+    headers = message.get("headers") or {}
+    if not isinstance(headers, dict):
+        headers = {}
+    sender = _first_email_identity(message.get("from") or message.get("from_") or {})
+    recipients = message.get("to") or []
+    preview = (
+        message.get("text_preview")
+        or message.get("extracted_text")
+        or message.get("snippet")
+        or message.get("text")
+        or data.get("text_preview")
+        or ""
+    )
+    if isinstance(recipients, dict):
+        recipients = [recipients]
+    normalized_to = []
+    for recipient in recipients[:5]:
+        if isinstance(recipient, dict):
+            normalized_to.append(
+                {
+                    "email": recipient.get("email", ""),
+                    "name": recipient.get("name", ""),
+                }
+            )
+        elif isinstance(recipient, str):
+            normalized_to.append({"email": recipient, "name": ""})
+    return {
+        "event_type": (
+            data.get("event_type") or data.get("type") or data.get("event") or "unknown"
+        ),
+        "event_id": data.get("event_id"),
+        "inbox_id": message.get("inbox_id"),
+        "message_id": (
+            message.get("message_id") or message.get("id") or data.get("message_id")
+        ),
+        "thread_id": message.get("thread_id") or data.get("thread_id"),
+        "from_email": sender.get("email") or headers.get("from") or "",
+        "from_name": sender.get("name") or "",
+        "to": normalized_to,
+        "subject": message.get("subject") or headers.get("subject") or "",
+        "received_at": (
+            message.get("received_at")
+            or message.get("timestamp")
+            or data.get("received_at")
+            or data.get("timestamp")
+        ),
+        "text_preview": preview[:280],
+    }
+
+
+def _verify_agentmail_request():
+    if AGENTMAIL_WEBHOOK_SECRET:
+        if not HAS_SVIX:
+            abort(503)
+        try:
+            Webhook(AGENTMAIL_WEBHOOK_SECRET).verify(
+                request.get_data(),
+                {
+                    "svix-id": request.headers.get("svix-id", ""),
+                    "svix-timestamp": request.headers.get("svix-timestamp", ""),
+                    "svix-signature": request.headers.get("svix-signature", ""),
+                },
+            )
+            return
+        except WebhookVerificationError:
+            abort(403)
+    token = request.headers.get("X-Internal-Token") or ""
+    if not INTERNAL_TOKEN or token != INTERNAL_TOKEN:
+        abort(403)
+
+
 @app.route("/admin/overview")
 def admin_overview():
     _require_admin()
@@ -676,6 +777,76 @@ def admin_strategy():
             computed_at=data.get("computed_at"),
         )
     return jsonify({"signals": signals_sorted, "computed_at": data.get("computed_at")})
+
+
+@app.route("/api/internal/ops-snapshot", methods=["POST"])
+def api_internal_ops_snapshot():
+    token = request.headers.get("X-Internal-Token") or ""
+    if not INTERNAL_TOKEN or token != INTERNAL_TOKEN:
+        abort(403)
+    data = request.get_json(silent=True) or {}
+    db.save_ops_snapshot(
+        source=data.get("source", "unknown"),
+        category=data.get("category", "general"),
+        summary_text=data.get("summary", ""),
+        status=data.get("status", "ok"),
+        payload=data.get("payload") if isinstance(data.get("payload"), dict) else {},
+    )
+    return jsonify({"ok": True})
+
+
+@app.route("/api/internal/agentmail", methods=["POST"])
+def api_internal_agentmail():
+    _verify_agentmail_request()
+    data = request.get_json(silent=True) or {}
+    event_type = data.get("event_type") or data.get("type") or data.get("event") or ""
+    if event_type not in {
+        "message.received",
+        "message.received.unauthenticated",
+        "inbound_email.received",
+    }:
+        return jsonify({"ok": True, "ignored": True})
+    payload = _sanitize_agentmail_payload(data)
+    summary = payload.get("subject") or payload.get("from_email") or "Inbound LEA mail"
+    db.save_ops_snapshot(
+        source="agentmail",
+        category="lea_inbox",
+        summary_text=summary,
+        status="received",
+        payload=payload,
+    )
+    return jsonify({"ok": True})
+
+
+@app.route("/admin/ops")
+def admin_ops():
+    _require_admin()
+    snapshots = db.get_ops_snapshots(limit=100)
+    reports = db.get_lea_reports(limit=20)
+    latest = _latest_snapshot_by_category(snapshots)
+    response = {
+        "latest": latest,
+        "snapshots": snapshots[:20],
+        "reports": reports,
+        "counts": {
+            "lea_inbox": sum(1 for s in snapshots if s.get("category") == "lea_inbox"),
+            "github_monitor": sum(
+                1 for s in snapshots if s.get("category") == "github_monitor"
+            ),
+            "vnb_monitor": sum(
+                1 for s in snapshots if s.get("category") == "vnb_monitor"
+            ),
+            "stuck_formations": sum(
+                1 for s in snapshots if s.get("category") == "stuck_formations"
+            ),
+        },
+    }
+    if "text/html" in (request.headers.get("Accept") or ""):
+        return render_template("admin/ops.html", **response)
+    return Response(
+        json.dumps(response, default=str),
+        mimetype="application/json",
+    )
 
 
 # PUBLIC-SNAPSHOT-PRIVATE-END: private-operator-routes

--- a/cantons.py
+++ b/cantons.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Shared Swiss canton constants for OpenLEG."""
+
+SWISS_CANTON_OPTIONS = [
+    ("all", "Alle Kantone"),
+    ("AG", "Aargau"),
+    ("AI", "Appenzell Innerrhoden"),
+    ("AR", "Appenzell Ausserrhoden"),
+    ("BE", "Bern"),
+    ("BL", "Basel-Landschaft"),
+    ("BS", "Basel-Stadt"),
+    ("FR", "Freiburg"),
+    ("GE", "Genf"),
+    ("GL", "Glarus"),
+    ("GR", "Graubünden"),
+    ("JU", "Jura"),
+    ("LU", "Luzern"),
+    ("NE", "Neuenburg"),
+    ("NW", "Nidwalden"),
+    ("OW", "Obwalden"),
+    ("SG", "St. Gallen"),
+    ("SH", "Schaffhausen"),
+    ("SO", "Solothurn"),
+    ("SZ", "Schwyz"),
+    ("TG", "Thurgau"),
+    ("TI", "Tessin"),
+    ("UR", "Uri"),
+    ("VD", "Waadt"),
+    ("VS", "Wallis"),
+    ("ZG", "Zug"),
+    ("ZH", "Zürich"),
+]
+
+SWISS_CANTONS = {code for code, _ in SWISS_CANTON_OPTIONS if code != "all"}

--- a/database.py
+++ b/database.py
@@ -3098,7 +3098,7 @@ def get_ops_snapshots(
         with get_connection() as conn:
             with conn.cursor() as cur:
                 where = []
-                params = []
+                params: list = []
                 if source:
                     where.append("source = %s")
                     params.append(source)

--- a/database.py
+++ b/database.py
@@ -4,6 +4,7 @@ PostgreSQL Database Layer for OpenLEG
 Replaces JSON file persistence with proper database storage.
 """
 
+import json
 import os
 import time
 import logging
@@ -789,6 +790,26 @@ def _create_tables():
             )
             cur.execute(
                 "CREATE INDEX IF NOT EXISTS idx_lea_reports_created ON lea_reports(created_at DESC)"
+            )
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS ops_snapshots (
+                    id SERIAL PRIMARY KEY,
+                    source VARCHAR(64) NOT NULL,
+                    category VARCHAR(64) NOT NULL,
+                    status VARCHAR(32) DEFAULT 'ok',
+                    summary_text TEXT,
+                    payload JSONB DEFAULT '{}'::jsonb,
+                    created_at TIMESTAMPTZ DEFAULT NOW()
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ops_snapshots_source ON ops_snapshots(source)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ops_snapshots_category ON ops_snapshots(category)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_ops_snapshots_created ON ops_snapshots(created_at DESC)"
             )
             # PUBLIC-SNAPSHOT-PRIVATE-END: operator-pipeline-indexes
 
@@ -3034,6 +3055,68 @@ def get_lea_reports(limit: int = 50) -> List[Dict]:
                 return [dict(row) for row in cur.fetchall()]
     except Exception as e:
         logger.error(f"[DB] Error getting LEA reports: {e}")
+        return []
+
+
+def save_ops_snapshot(
+    source: str,
+    category: str,
+    summary_text: str = "",
+    status: str = "ok",
+    payload: Optional[Dict] = None,
+) -> bool:
+    """Save a structured operator snapshot for the admin ops dashboard."""
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO ops_snapshots (source, category, status, summary_text, payload)
+                    VALUES (%s, %s, %s, %s, %s::jsonb)
+                """,
+                    (
+                        source,
+                        category,
+                        status,
+                        summary_text,
+                        json.dumps(payload or {}),
+                    ),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error saving ops snapshot: {e}")
+        return False
+
+
+def get_ops_snapshots(
+    limit: int = 50,
+    source: Optional[str] = None,
+    category: Optional[str] = None,
+) -> List[Dict]:
+    """Get structured operator snapshots, newest first."""
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                where = []
+                params = []
+                if source:
+                    where.append("source = %s")
+                    params.append(source)
+                if category:
+                    where.append("category = %s")
+                    params.append(category)
+                query = """
+                    SELECT id, source, category, status, summary_text, payload, created_at
+                    FROM ops_snapshots
+                """
+                if where:
+                    query += " WHERE " + " AND ".join(where)
+                query += " ORDER BY created_at DESC LIMIT %s"
+                params.append(limit)
+                cur.execute(query, tuple(params))
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting ops snapshots: {e}")
         return []
 
 

--- a/municipality.py
+++ b/municipality.py
@@ -8,6 +8,7 @@ Public profile pages and directory for municipalities.
 import logging
 from flask import Blueprint, request, jsonify, render_template, abort
 
+from cantons import SWISS_CANTON_OPTIONS, SWISS_CANTONS
 import database as db
 import pv_ranking
 import security_utils
@@ -15,37 +16,6 @@ import security_utils
 logger = logging.getLogger(__name__)
 
 municipality_bp = Blueprint("municipality", __name__, url_prefix="/gemeinde")
-
-SWISS_CANTON_OPTIONS = [
-    ("all", "Alle Kantone"),
-    ("AG", "Aargau"),
-    ("AI", "Appenzell Innerrhoden"),
-    ("AR", "Appenzell Ausserrhoden"),
-    ("BE", "Bern"),
-    ("BL", "Basel-Landschaft"),
-    ("BS", "Basel-Stadt"),
-    ("FR", "Freiburg"),
-    ("GE", "Genf"),
-    ("GL", "Glarus"),
-    ("GR", "Graubünden"),
-    ("JU", "Jura"),
-    ("LU", "Luzern"),
-    ("NE", "Neuenburg"),
-    ("NW", "Nidwalden"),
-    ("OW", "Obwalden"),
-    ("SG", "St. Gallen"),
-    ("SH", "Schaffhausen"),
-    ("SO", "Solothurn"),
-    ("SZ", "Schwyz"),
-    ("TG", "Thurgau"),
-    ("TI", "Tessin"),
-    ("UR", "Uri"),
-    ("VD", "Waadt"),
-    ("VS", "Wallis"),
-    ("ZG", "Zug"),
-    ("ZH", "Zürich"),
-]
-SWISS_CANTONS = {code for code, _ in SWISS_CANTON_OPTIONS if code != "all"}
 
 
 @municipality_bp.route("/onboarding")

--- a/openclaw/Dockerfile
+++ b/openclaw/Dockerfile
@@ -12,11 +12,12 @@ RUN npm install --production
 COPY mcp-openleg-server/ ./
 
 # Set up config directory and entrypoint
-COPY config/openclaw.example.json /home/node/.openclaw/openclaw.json
+COPY config/ /opt/openclaw-config/
 COPY entrypoint.sh /opt/entrypoint.sh
 
 # Permissions
-RUN chown -R node:node /home/node /opt/mcp-openleg-server /opt/entrypoint.sh \
+RUN mkdir -p /home/node/.openclaw \
+    && chown -R node:node /home/node /opt/mcp-openleg-server /opt/openclaw-config /opt/entrypoint.sh \
     && chmod +x /opt/entrypoint.sh
 
 USER node

--- a/openclaw/README.md
+++ b/openclaw/README.md
@@ -25,6 +25,7 @@ Public-safe OpenClaw bundle for OpenLEG.
 - `OPENCLAW_GATEWAY_TOKEN`
 - `OPENCLAW_GATEWAY_PASSWORD`
 - `DATABASE_URL`
+- `INTERNAL_TOKEN`
 
 ## Optional env
 
@@ -32,6 +33,14 @@ Public-safe OpenClaw bundle for OpenLEG.
 - `OPENCLAW_GATEWAY_PORT`
 - `OPENCLAW_READONLY`
 - `BRAVE_API_KEY`
+- `FLASK_URL`
+- `AGENTMAIL_API_BASE`
+- `AGENTMAIL_API_KEY`
+- `AGENTMAIL_WEBHOOK_SECRET`
+- `AGENTMAIL_WEBHOOK_URL`
+- `AGENTMAIL_HUMAN_EMAIL`
+- `LEA_INBOX_ADDRESS`
+- `LEA_AGENT_ID`
 
 ## Local run
 
@@ -49,3 +58,26 @@ docker run --rm \
 - Keep `OPENCLAW_GATEWAY_BIND=loopback` unless you have a deliberate remote-access design.
 - If you reverse-proxy the Control UI, configure `gateway.trustedProxies` in your private `openclaw.json`.
 - Switch `OPENCLAW_READONLY=false` only for workflows that must write to the OpenLEG database.
+- LEA mail ingestion belongs in your private OpenClaw config and should post structured events to `/api/internal/agentmail`.
+- Use `/api/internal/ops-snapshot` for GitHub monitor, VNB monitor, stuck formation, and health snapshots.
+
+## Private AgentMail activation
+
+Keep the script and resulting keys in private ops only. For the OpenLEG LEA inbox:
+
+```bash
+AGENTMAIL_HUMAN_EMAIL=hallo@openleg.ch \
+LEA_AGENT_ID=openleg-lea \
+openclaw/config/cron/register_agentmail_webhook.sh sign-up
+
+AGENTMAIL_API_KEY=am_... \
+AGENTMAIL_OTP_CODE=123456 \
+openclaw/config/cron/register_agentmail_webhook.sh verify
+
+APP_BASE_URL=https://openleg.ch \
+AGENTMAIL_API_KEY=am_... \
+LEA_INBOX_ADDRESS=hallo@openleg.ch \
+openclaw/config/cron/register_agentmail_webhook.sh bootstrap
+```
+
+Store the returned webhook `secret` as `AGENTMAIL_WEBHOOK_SECRET`.

--- a/openclaw/entrypoint.sh
+++ b/openclaw/entrypoint.sh
@@ -5,7 +5,21 @@ OPENCLAW_GATEWAY_BIND="${OPENCLAW_GATEWAY_BIND:-loopback}"
 OPENCLAW_GATEWAY_PORT="${OPENCLAW_GATEWAY_PORT:-18789}"
 OPENCLAW_READONLY="${OPENCLAW_READONLY:-true}"
 
-mkdir -p /home/node/.openclaw /home/node/.openclaw/workspace
+mkdir -p /home/node/.openclaw /home/node/.openclaw/workspace /home/node/.openclaw/cron
+
+if [ -f /opt/openclaw-config/openclaw.json ]; then
+  cp /opt/openclaw-config/openclaw.json /home/node/.openclaw/openclaw.json
+else
+  cp /opt/openclaw-config/openclaw.example.json /home/node/.openclaw/openclaw.json
+fi
+
+if [ -d /opt/openclaw-config/cron ]; then
+  cp -R /opt/openclaw-config/cron/. /home/node/.openclaw/cron/
+fi
+
+if [ -d /opt/openclaw-config/workspace ]; then
+  cp -R /opt/openclaw-config/workspace/. /home/node/.openclaw/workspace/
+fi
 
 # Write Docker env vars to OpenClaw's .env so ${VAR} interpolation works in openclaw.json
 cat > /home/node/.openclaw/.env <<EOF
@@ -20,6 +34,15 @@ BRAVE_API_KEY=${BRAVE_API_KEY}
 OPENCLAW_GATEWAY_BIND=${OPENCLAW_GATEWAY_BIND}
 OPENCLAW_GATEWAY_PORT=${OPENCLAW_GATEWAY_PORT}
 OPENCLAW_READONLY=${OPENCLAW_READONLY}
+INTERNAL_TOKEN=${INTERNAL_TOKEN}
+FLASK_URL=${FLASK_URL}
+AGENTMAIL_API_BASE=${AGENTMAIL_API_BASE}
+AGENTMAIL_API_KEY=${AGENTMAIL_API_KEY}
+AGENTMAIL_WEBHOOK_SECRET=${AGENTMAIL_WEBHOOK_SECRET}
+AGENTMAIL_WEBHOOK_URL=${AGENTMAIL_WEBHOOK_URL}
+AGENTMAIL_HUMAN_EMAIL=${AGENTMAIL_HUMAN_EMAIL}
+LEA_INBOX_ADDRESS=${LEA_INBOX_ADDRESS}
+LEA_AGENT_ID=${LEA_AGENT_ID}
 EOF
 
 exec openclaw gateway \

--- a/openclaw/mcp-openleg-server/server.mjs
+++ b/openclaw/mcp-openleg-server/server.mjs
@@ -13,6 +13,8 @@ const pool = new Pool({
 
 const BRAVE_API_KEY = process.env.BRAVE_API_KEY || '';
 const READONLY = (process.env.OPENCLAW_READONLY || 'false').toLowerCase() === 'true';
+const INTERNAL_TOKEN = process.env.INTERNAL_TOKEN || '';
+const FLASK_URL = process.env.FLASK_URL || 'http://flask:5000';
 
 function readonlyGuard() {
   if (READONLY) return { content: [{ type: 'text', text: 'Write access disabled (OPENCLAW_READONLY=true)' }] };
@@ -28,6 +30,19 @@ async function query(sql, params = []) {
 
 function txt(data) {
   return { content: [{ type: 'text', text: JSON.stringify(data, null, 2) }] };
+}
+
+async function postInternal(path, body) {
+  const res = await fetch(`${FLASK_URL}${path}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Token': INTERNAL_TOKEN
+    },
+    body: JSON.stringify(body)
+  });
+  const text = await res.text();
+  return { ok: res.ok, status: res.status, body: text };
 }
 
 const server = new McpServer({
@@ -1385,6 +1400,64 @@ server.tool(
       LIMIT $1
     `, [limit]);
     return txt({ count: result.rowCount, candidates: result.rows });
+  }
+);
+
+server.tool(
+  'get_ops_snapshots',
+  'Get recent structured ops snapshots for the LEA/OpenClaw operator dashboard.',
+  {
+    limit: z.number().default(20).describe('Max results'),
+    source: z.string().optional().describe('Optional source filter'),
+    category: z.string().optional().describe('Optional category filter')
+  },
+  async ({ limit, source, category }) => {
+    let sql = `
+      SELECT id, source, category, status, summary_text, payload, created_at
+      FROM ops_snapshots
+    `;
+    const params = [];
+    const where = [];
+    if (source) {
+      params.push(source);
+      where.push(`source = $${params.length}`);
+    }
+    if (category) {
+      params.push(category);
+      where.push(`category = $${params.length}`);
+    }
+    if (where.length) {
+      sql += ` WHERE ${where.join(' AND ')}`;
+    }
+    params.push(limit);
+    sql += ` ORDER BY created_at DESC LIMIT $${params.length}`;
+    const result = await query(sql, params);
+    return txt({ count: result.rowCount, snapshots: result.rows });
+  }
+);
+
+server.tool(
+  'post_ops_snapshot',
+  'Post a structured operator snapshot to the private OpenLEG dashboard endpoint.',
+  {
+    source: z.string().describe('Producer name, e.g. openclaw, github-monitor, agentmail'),
+    category: z.string().describe('Category, e.g. openclaw_health, github_monitor, vnb_monitor'),
+    status: z.string().default('ok').describe('Status label'),
+    summary: z.string().default('').describe('Short operator summary'),
+    payload: z.record(z.any()).default({}).describe('Structured payload')
+  },
+  async ({ source, category, status, summary, payload }) => {
+    const guard = readonlyGuard();
+    if (guard) return guard;
+    if (!INTERNAL_TOKEN) return txt({ error: 'INTERNAL_TOKEN missing' });
+    const result = await postInternal('/api/internal/ops-snapshot', {
+      source,
+      category,
+      status,
+      summary,
+      payload
+    });
+    return txt(result);
   }
 );
 

--- a/rangliste.py
+++ b/rangliste.py
@@ -125,8 +125,9 @@ def vergleich():
     bfs_a = _bfs_arg("a")
     bfs_b = _bfs_arg("b")
 
-    all_pv = db.get_pv_profiles()
-    rank_map = {r["bfs_number"]: r["rank"] for r in pv_ranking.assign_ranks(all_pv)}
+    ranking = Ranking.load()
+    national = ranking.national()
+    rank_map = {r["bfs_number"]: r["rank"] for r in national}
 
     def enrich(bfs):
         if not bfs:
@@ -145,7 +146,7 @@ def vergleich():
     municipalities = sorted(
         (
             {"bfs_number": r["bfs_number"], "name": r["name"], "kanton": r["kanton"]}
-            for r in all_pv
+            for r in national
         ),
         key=lambda m: m["name"] or "",
     )
@@ -182,7 +183,8 @@ def movers():
     except ValueError:
         limit = 100
 
-    rows = db.get_pv_movers()
+    ranking = Ranking([])
+    rows = ranking.movers()
     league = pv_ranking.filter_league(
         rows, kanton=kanton.upper() if kanton else None, size=size, density=density
     )

--- a/rangliste.py
+++ b/rangliste.py
@@ -12,7 +12,7 @@ from flask import Blueprint, Response, render_template, request
 import database as db
 import pv_badge
 import pv_ranking
-from municipality import SWISS_CANTON_OPTIONS
+from cantons import SWISS_CANTON_OPTIONS
 
 logger = logging.getLogger(__name__)
 

--- a/rangliste.py
+++ b/rangliste.py
@@ -13,6 +13,7 @@ import database as db
 import pv_badge
 import pv_ranking
 from cantons import SWISS_CANTON_OPTIONS
+from ranking import Ranking
 
 logger = logging.getLogger(__name__)
 
@@ -41,20 +42,6 @@ def _clean_param(name):
     return value
 
 
-def _filtered_league(kanton, size, density):
-    rows = db.get_pv_profiles()
-    return pv_ranking.filter_league(rows, kanton=kanton, size=size, density=density)
-
-
-def _with_display(ranked):
-    """Gedeckelten Score und Überschreitungs-Flag je Zeile ergänzen."""
-    enriched = []
-    for row in ranked:
-        score, over_100 = pv_ranking.capped_score(row.get("pv_score_pct"))
-        enriched.append({**row, "display_score": score, "score_over_100": over_100})
-    return enriched
-
-
 def _common_context(kanton, size, density):
     return {
         "kanton": kanton or "",
@@ -76,14 +63,16 @@ def hub():
     except ValueError:
         limit = 250
 
-    league = _filtered_league(kanton.upper() if kanton else None, size, density)
-    ranked = _with_display(pv_ranking.assign_ranks(league))
+    ranking = Ranking.load()
+    rows = ranking.standings(
+        kanton=kanton.upper() if kanton else None, size=size, density=density
+    )
 
     context = _common_context(kanton, size, density)
     context.update(
         {
-            "rows": ranked[:limit],
-            "total": len(ranked),
+            "rows": rows[:limit],
+            "total": len(rows),
             "limit": limit,
             "active_tab": "rangliste",
             "canonical_url": f"{request.url_root.rstrip('/')}/rangliste",

--- a/rangliste.py
+++ b/rangliste.py
@@ -10,7 +10,6 @@ import logging
 from flask import Blueprint, Response, render_template, request
 
 import database as db
-import pv_badge
 import pv_ranking
 from cantons import SWISS_CANTON_OPTIONS
 from ranking import Ranking
@@ -86,21 +85,13 @@ def _bfs_arg(name):
     return int(raw) if raw.isdigit() else None
 
 
-def _rank_for(bfs):
-    rank_map = {
-        r["bfs_number"]: r["rank"]
-        for r in pv_ranking.assign_ranks(db.get_pv_profiles())
-    }
-    return rank_map.get(bfs)
-
-
 @rangliste_bp.route("/rangliste/badge/<int:bfs>.svg")
 def badge(bfs):
     profile = db.get_municipality_profile(bfs)
     if not profile:
         return Response(status=404)
-    score, _ = pv_ranking.capped_score(profile.get("pv_score_pct"))
-    svg = pv_badge.badge_svg(profile.get("name"), score, _rank_for(bfs))
+    ranking = Ranking.load()
+    svg = ranking.badge_svg(bfs, profile=profile)
     return Response(svg, mimetype="image/svg+xml")
 
 
@@ -109,14 +100,8 @@ def og_card(bfs):
     profile = db.get_municipality_profile(bfs)
     if not profile:
         return Response(status=404)
-    score, _ = pv_ranking.capped_score(profile.get("pv_score_pct"))
-    svg = pv_badge.og_card_svg(
-        profile.get("name"),
-        profile.get("kanton"),
-        score,
-        _rank_for(bfs),
-        profile.get("pv_untapped_kw"),
-    )
+    ranking = Ranking.load()
+    svg = ranking.og_card_svg(bfs, profile=profile)
     return Response(svg, mimetype="image/svg+xml")
 
 

--- a/ranking.py
+++ b/ranking.py
@@ -91,20 +91,46 @@ class Ranking:
             return mover_rows
         return store_ranking.get_pv_movers()
 
-    def badge_svg(self, bfs: int) -> str:
-        """SVG badge for one municipality."""
-        profile = None
-        for row in self._profiles:
+    def _rank_for_bfs(self, bfs: int) -> Optional[int]:
+        for row in pv_ranking.assign_ranks(self._profiles):
             if row.get("bfs_number") == bfs:
-                profile = row
-                break
+                return row.get("rank")
+        return None
+
+    def badge_svg(self, bfs: int, profile: Optional[Dict] = None) -> str:
+        """SVG badge for one municipality.
+
+        If ``profile`` is provided, it is used as the data source and only the
+        national rank is resolved against the loaded ranking. This supports
+        municipalities that exist in the profile table but are not part of the
+        PV ranking because they have no score yet.
+        """
         if profile is None:
-            return ""
-        ranked = pv_ranking.assign_ranks(self._profiles)
-        rank = None
-        for row in ranked:
-            if row.get("bfs_number") == bfs:
-                rank = row.get("rank")
-                break
+            for row in self._profiles:
+                if row.get("bfs_number") == bfs:
+                    profile = row
+                    break
+            if profile is None:
+                return ""
         display_score, _ = pv_ranking.capped_score(profile.get("pv_score_pct"))
+        rank = self._rank_for_bfs(bfs)
         return pv_badge.badge_svg(profile.get("name"), display_score, rank)
+
+    def og_card_svg(self, bfs: int, profile: Optional[Dict] = None) -> str:
+        """SVG OpenGraph card for one municipality."""
+        if profile is None:
+            for row in self._profiles:
+                if row.get("bfs_number") == bfs:
+                    profile = row
+                    break
+            if profile is None:
+                return ""
+        display_score, _ = pv_ranking.capped_score(profile.get("pv_score_pct"))
+        rank = self._rank_for_bfs(bfs)
+        return pv_badge.og_card_svg(
+            profile.get("name"),
+            profile.get("kanton"),
+            display_score,
+            rank,
+            profile.get("pv_untapped_kw"),
+        )

--- a/ranking.py
+++ b/ranking.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""High-level Ranking facade over PV profiles.
+
+The class works with an injected profile list, so it stays pure and easy to
+unit-test. Database access is only performed through ``Ranking.load()``.
+"""
+
+from typing import Dict, List, Optional
+
+import pv_ranking
+from store import ranking as store_ranking
+
+
+class Ranking:
+    """Ranking facade over a list of PV municipality profiles."""
+
+    def __init__(self, profiles: List[Dict]):
+        self._profiles = profiles
+
+    @classmethod
+    def load(cls, kanton: Optional[str] = None) -> "Ranking":
+        """Profile aus dem Store laden. Ruft ``get_pv_profiles`` genau einmal auf."""
+        profiles = (
+            store_ranking.get_pv_profiles(kanton)
+            if kanton is not None
+            else store_ranking.get_pv_profiles()
+        )
+        return cls(profiles)
+
+    def national(self) -> List[Dict]:
+        """National ranking with display score and over-100 flag."""
+        ranked = pv_ranking.assign_ranks(self._profiles)
+        enriched = []
+        for row in ranked:
+            display_score, score_over_100 = pv_ranking.capped_score(
+                row.get("pv_score_pct")
+            )
+            enriched.append(
+                {
+                    **row,
+                    "display_score": display_score,
+                    "score_over_100": score_over_100,
+                }
+            )
+        return enriched
+
+    def league_chips(self, profile: Dict) -> List[Dict]:
+        """League chips for a single profile."""
+        return pv_ranking.league_standings(self._profiles, profile)

--- a/ranking.py
+++ b/ranking.py
@@ -7,6 +7,7 @@ unit-test. Database access is only performed through ``Ranking.load()``.
 
 from typing import Dict, List, Optional
 
+import pv_badge
 import pv_ranking
 from store import ranking as store_ranking
 
@@ -29,7 +30,10 @@ class Ranking:
 
     def national(self) -> List[Dict]:
         """National ranking with display score and over-100 flag."""
-        ranked = pv_ranking.assign_ranks(self._profiles)
+        return self._with_display(pv_ranking.assign_ranks(self._profiles))
+
+    @staticmethod
+    def _with_display(ranked: List[Dict]) -> List[Dict]:
         enriched = []
         for row in ranked:
             display_score, score_over_100 = pv_ranking.capped_score(
@@ -47,3 +51,60 @@ class Ranking:
     def league_chips(self, profile: Dict) -> List[Dict]:
         """League chips for a single profile."""
         return pv_ranking.league_standings(self._profiles, profile)
+
+    def standings(
+        self,
+        kanton: Optional[str] = None,
+        size: Optional[str] = None,
+        density: Optional[str] = None,
+    ) -> List[Dict]:
+        """Gefilterte Rangliste mit nationaler Darstellungsform.
+
+        Wendet ``filter_league`` an und ergänzt anschliessend Rang,
+        display_score und score_over_100.
+        """
+        filtered = pv_ranking.filter_league(
+            self._profiles, kanton=kanton, size=size, density=density
+        )
+        return self._with_display(pv_ranking.assign_ranks(filtered))
+
+    def improvement_target(self, profile: Dict) -> Optional[Dict]:
+        """Verbesserungsziel für die Grössen-Liga eines Profils."""
+        size = pv_ranking.size_band(profile.get("population"))
+        if size is None:
+            return None
+        league = pv_ranking.filter_league(self._profiles, size=size)
+        threshold = pv_ranking.top_quartile_threshold(league)
+        return pv_ranking.improvement_target(profile, threshold)
+
+    def leaders(self, kanton: str, exclude_bfs: Optional[int] = None) -> List[Dict]:
+        """Vorbilder eines Kantons."""
+        canton_profiles = pv_ranking.filter_league(self._profiles, kanton=kanton)
+        return pv_ranking.league_leaders(canton_profiles, exclude_bfs=exclude_bfs)
+
+    def movers(self, mover_rows: Optional[List[Dict]] = None) -> List[Dict]:
+        """Gemeinden mit dem grössten Score-Delta.
+
+        Nutzt injizierte Zeilen, falls vorhanden, sonst ``store_ranking.get_pv_movers``.
+        """
+        if mover_rows is not None:
+            return mover_rows
+        return store_ranking.get_pv_movers()
+
+    def badge_svg(self, bfs: int) -> str:
+        """SVG badge for one municipality."""
+        profile = None
+        for row in self._profiles:
+            if row.get("bfs_number") == bfs:
+                profile = row
+                break
+        if profile is None:
+            return ""
+        ranked = pv_ranking.assign_ranks(self._profiles)
+        rank = None
+        for row in ranked:
+            if row.get("bfs_number") == bfs:
+                rank = row.get("rank")
+                break
+        display_score, _ = pv_ranking.capped_score(profile.get("pv_score_pct"))
+        return pv_badge.badge_svg(profile.get("name"), display_score, rank)

--- a/scripts/package_public.sh
+++ b/scripts/package_public.sh
@@ -65,6 +65,7 @@ copy_tracked_tree static
 copy_tracked_tree templates
 rm -f "${DEST}/templates/admin/pipeline.html"
 rm -f "${DEST}/templates/admin/strategy.html"
+rm -f "${DEST}/templates/admin/ops.html"
 rm -f "${DEST}/templates/emails/municipality_outreach.html"
 
 # Slice 3: public docs, CI policy, and tests.
@@ -81,6 +82,7 @@ copy_tracked_tree tests
 rm -f "${DEST}/tests/test_agents_md.py"
 rm -f "${DEST}/tests/test_admin_pipeline.py"
 rm -f "${DEST}/tests/test_admin_strategy.py"
+rm -f "${DEST}/tests/test_admin_ops.py"
 rm -f "${DEST}/tests/test_demand_signal.py"
 rm -f "${DEST}/tests/test_docs_boundary_contract.py"
 rm -f "${DEST}/tests/test_e2e_integration.py"

--- a/store/ranking.py
+++ b/store/ranking.py
@@ -10,9 +10,13 @@ and ``database`` can re-export these functions for legacy callers.
 import logging
 from typing import Optional, Dict, List
 
-import database
-
 logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
 
 
 def upsert_municipality_pv(profile: Dict) -> bool:
@@ -23,7 +27,7 @@ def upsert_municipality_pv(profile: Dict) -> bool:
     bestehende Profile nicht überschreibt.
     """
     try:
-        with database.get_connection() as conn:
+        with _get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -90,7 +94,7 @@ def save_municipality_pv_panel(rows: List[Dict]) -> int:
             )
             for r in rows
         ]
-        with database.get_connection() as conn:
+        with _get_connection() as conn:
             with conn.cursor() as cur:
                 execute_values(
                     cur,
@@ -118,7 +122,7 @@ def save_municipality_pv_panel(rows: List[Dict]) -> int:
 def get_pv_profiles(kanton: Optional[str] = None) -> List[Dict]:
     """Alle Gemeinden mit berechnetem PV-Score, für die Rangliste."""
     try:
-        with database.get_connection() as conn:
+        with _get_connection() as conn:
             with conn.cursor() as cur:
                 if kanton:
                     cur.execute(
@@ -157,7 +161,7 @@ def get_pv_movers() -> List[Dict]:
     Nur aus dem Panel berechnet, nie mit dem Snapshot vermischt.
     """
     try:
-        with database.get_connection() as conn:
+        with _get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
@@ -185,7 +189,7 @@ def get_pv_movers() -> List[Dict]:
 def get_municipality_pv_panel(bfs_number: int) -> List[Dict]:
     """Panel-Zeilen einer Gemeinde, nach Jahr aufsteigend."""
     try:
-        with database.get_connection() as conn:
+        with _get_connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     "SELECT * FROM municipality_pv_panel WHERE bfs_number = %s ORDER BY year",

--- a/templates/admin/ops.html
+++ b/templates/admin/ops.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html>
+<html lang="de">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>OpenLEG Admin: Ops</title>
+<script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-950 text-white min-h-screen">
+<div class="max-w-7xl mx-auto px-4 py-8">
+  <div class="flex items-center justify-between mb-6">
+    <h1 class="text-2xl font-bold">Ops Dashboard</h1>
+    <span class="text-xs text-gray-500">Private operator view</span>
+  </div>
+
+  <div class="grid md:grid-cols-4 gap-4 mb-8">
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">LEA Inbox</div>
+      <div class="text-3xl font-bold">{{ counts.lea_inbox }}</div>
+    </div>
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">GitHub Monitor</div>
+      <div class="text-3xl font-bold">{{ counts.github_monitor }}</div>
+    </div>
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">VNB Monitor</div>
+      <div class="text-3xl font-bold">{{ counts.vnb_monitor }}</div>
+    </div>
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">Stuck Formations</div>
+      <div class="text-3xl font-bold">{{ counts.stuck_formations }}</div>
+    </div>
+  </div>
+
+  <div class="grid lg:grid-cols-2 gap-6 mb-8">
+    {% for category, label in [
+      ('openclaw_health', 'OpenClaw Health'),
+      ('lea_inbox', 'LEA Inbox'),
+      ('github_monitor', 'GitHub Monitor'),
+      ('vnb_monitor', 'VNB Monitor'),
+      ('stuck_formations', 'Stuck Formations')
+    ] %}
+    {% set snapshot = latest.get(category) %}
+    <section class="bg-gray-900 rounded-lg p-4 border border-gray-800">
+      <div class="flex items-center justify-between mb-2">
+        <h2 class="font-semibold">{{ label }}</h2>
+        {% if snapshot %}
+        <span class="text-xs px-2 py-1 rounded bg-gray-800 text-gray-300 uppercase">{{ snapshot.status }}</span>
+        {% else %}
+        <span class="text-xs text-gray-600">No data</span>
+        {% endif %}
+      </div>
+      {% if snapshot %}
+      <p class="text-sm text-gray-300 mb-2">{{ snapshot.summary_text or 'No summary' }}</p>
+      <p class="text-xs text-gray-500 mb-3">{{ snapshot.created_at if snapshot.created_at else '' }}</p>
+      <pre class="text-xs text-gray-400 bg-gray-950 rounded p-3 overflow-x-auto">{{ snapshot.payload | tojson(indent=2) }}</pre>
+      {% else %}
+      <p class="text-sm text-gray-500">No snapshot recorded yet.</p>
+      {% endif %}
+    </section>
+    {% endfor %}
+  </div>
+
+  <div class="grid lg:grid-cols-2 gap-6">
+    <section class="bg-gray-900 rounded-lg overflow-hidden">
+      <div class="px-4 py-3 border-b border-gray-800">
+        <h2 class="font-semibold">Recent Ops Snapshots</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead class="bg-gray-800">
+          <tr>
+            <th class="px-4 py-3 text-left">Source</th>
+            <th class="px-4 py-3 text-left">Category</th>
+            <th class="px-4 py-3 text-left">Summary</th>
+            <th class="px-4 py-3 text-right">Created</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          {% for snapshot in snapshots %}
+          <tr class="hover:bg-gray-800/40">
+            <td class="px-4 py-3">{{ snapshot.source }}</td>
+            <td class="px-4 py-3 text-gray-400">{{ snapshot.category }}</td>
+            <td class="px-4 py-3 text-gray-300">{{ snapshot.summary_text or '' }}</td>
+            <td class="px-4 py-3 text-right text-xs text-gray-500">{{ snapshot.created_at if snapshot.created_at else '' }}</td>
+          </tr>
+          {% endfor %}
+          {% if not snapshots %}
+          <tr><td colspan="4" class="px-4 py-8 text-center text-gray-500">Keine Snapshots</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </section>
+
+    <section class="bg-gray-900 rounded-lg overflow-hidden">
+      <div class="px-4 py-3 border-b border-gray-800">
+        <h2 class="font-semibold">Recent LEA Reports</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead class="bg-gray-800">
+          <tr>
+            <th class="px-4 py-3 text-left">Job</th>
+            <th class="px-4 py-3 text-left">Status</th>
+            <th class="px-4 py-3 text-left">Summary</th>
+            <th class="px-4 py-3 text-right">Created</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          {% for report in reports %}
+          <tr class="hover:bg-gray-800/40">
+            <td class="px-4 py-3">{{ report.job_name }}</td>
+            <td class="px-4 py-3 text-gray-400 uppercase">{{ report.status }}</td>
+            <td class="px-4 py-3 text-gray-300">{{ report.summary_text or '' }}</td>
+            <td class="px-4 py-3 text-right text-xs text-gray-500">{{ report.created_at if report.created_at else '' }}</td>
+          </tr>
+          {% endfor %}
+          {% if not reports %}
+          <tr><td colspan="4" class="px-4 py-8 text-center text-gray-500">Keine Berichte</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </section>
+  </div>
+</div>
+</body>
+</html>

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -1,0 +1,208 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for private ops dashboard and internal snapshot ingestion."""
+
+import os
+import json
+import pytest
+from unittest.mock import patch, MagicMock
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class TestAdminOpsRoutes:
+    def test_admin_ops_requires_admin(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.get("/admin/ops")
+                    assert resp.status_code == 403
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_admin_ops_returns_json(self):
+        snapshots = [
+            {
+                "id": 1,
+                "source": "openclaw",
+                "category": "openclaw_health",
+                "status": "ok",
+                "summary_text": "Gateway healthy",
+                "payload": {"sessions": 1},
+                "created_at": "2026-06-14T10:00:00",
+            },
+            {
+                "id": 2,
+                "source": "agentmail",
+                "category": "lea_inbox",
+                "status": "received",
+                "summary_text": "New LEA inbox item",
+                "payload": {"subject": "Hello"},
+                "created_at": "2026-06-14T10:05:00",
+            },
+        ]
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.get_ops_snapshots", return_value=snapshots),
+                patch("database.get_lea_reports", return_value=[]),
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.get(
+                        "/admin/ops",
+                        headers={"X-Admin-Token": "test123"},
+                    )
+                    assert resp.status_code == 200
+                    data = json.loads(resp.data)
+                    assert "latest" in data
+                    assert "counts" in data
+                    assert data["counts"]["lea_inbox"] == 1
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_internal_ops_snapshot_accepts_valid_token(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.save_ops_snapshot", return_value=True),
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post(
+                        "/api/internal/ops-snapshot",
+                        json={
+                            "source": "openclaw",
+                            "category": "openclaw_health",
+                            "summary": "Gateway healthy",
+                            "payload": {"sessions": 1},
+                        },
+                        headers={"X-Internal-Token": "secret-internal"},
+                    )
+                    assert resp.status_code == 200
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_internal_agentmail_ignores_non_inbound_events(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.save_ops_snapshot", return_value=True) as save_snapshot,
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post(
+                        "/api/internal/agentmail",
+                        json={"type": "message.sent"},
+                        headers={"X-Internal-Token": "secret-internal"},
+                    )
+                    assert resp.status_code == 200
+                    assert resp.get_json()["ignored"] is True
+                    save_snapshot.assert_not_called()
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_internal_agentmail_accepts_agentmail_event_type_payload(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.save_ops_snapshot", return_value=True) as save_snapshot,
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post(
+                        "/api/internal/agentmail",
+                        json={
+                            "event_type": "message.received",
+                            "event_id": "evt_123",
+                            "message": {
+                                "message_id": "msg_123",
+                                "thread_id": "thd_123",
+                                "inbox_id": "hallo@openleg.ch",
+                                "from_": ["sender@example.com"],
+                                "to": ["hallo@openleg.ch"],
+                                "subject": "LEG Anfrage",
+                                "timestamp": "2026-06-14T10:05:00Z",
+                                "text": "Bitte um Informationen zur LEG.",
+                            },
+                        },
+                        headers={"X-Internal-Token": "secret-internal"},
+                    )
+                    assert resp.status_code == 200
+                    save_snapshot.assert_called_once()
+                    kwargs = save_snapshot.call_args.kwargs
+                    assert kwargs["source"] == "agentmail"
+                    assert kwargs["category"] == "lea_inbox"
+                    assert kwargs["summary_text"] == "LEG Anfrage"
+                    assert kwargs["payload"]["event_type"] == "message.received"
+                    assert kwargs["payload"]["message_id"] == "msg_123"
+                    assert kwargs["payload"]["inbox_id"] == "hallo@openleg.ch"
+                    assert kwargs["payload"]["from_email"] == "sender@example.com"
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+
+class TestAdminOpsRouteExists:
+    def test_admin_ops_routes_in_source(self):
+        with open(os.path.join(PROJECT_ROOT, "app.py")) as f:
+            content = f.read()
+        assert "/admin/ops" in content
+        assert "/api/internal/ops-snapshot" in content
+        assert "/api/internal/agentmail" in content

--- a/tests/test_agents_md.py
+++ b/tests/test_agents_md.py
@@ -119,10 +119,13 @@ class TestEnvExample:
             "MODEL_BASE_URL",
             "MODEL_API_KEY",
             "MODEL_ID",
+            "INTERNAL_TOKEN",
             "OPENCLAW_GATEWAY_TOKEN",
             "OPENCLAW_GATEWAY_PASSWORD",
             "OPENCLAW_GATEWAY_BIND",
             "OPENCLAW_GATEWAY_PORT",
             "OPENCLAW_READONLY",
+            "FLASK_URL",
+            "AGENTMAIL_WEBHOOK_SECRET",
         ):
             assert key in content

--- a/tests/test_cantons_refactor.py
+++ b/tests/test_cantons_refactor.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract tests for the shared Swiss canton constants."""
+
+import ast
+from pathlib import Path
+
+import cantons
+import municipality
+import rangliste
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SKIP_DIRS = {
+    ".git",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+    ".venv",
+    "__pycache__",
+    "node_modules",
+}
+
+
+def _python_files():
+    for path in PROJECT_ROOT.rglob("*.py"):
+        if SKIP_DIRS.intersection(path.relative_to(PROJECT_ROOT).parts):
+            continue
+        yield path
+
+
+def test_cantons_exports_options_and_code_set():
+    assert cantons.SWISS_CANTON_OPTIONS[0] == ("all", "Alle Kantone")
+    assert cantons.SWISS_CANTON_OPTIONS[-1] == ("ZH", "Zürich")
+    assert cantons.SWISS_CANTONS == {
+        code for code, _ in cantons.SWISS_CANTON_OPTIONS if code != "all"
+    }
+
+
+def test_route_modules_use_shared_canton_options():
+    assert municipality.SWISS_CANTON_OPTIONS is cantons.SWISS_CANTON_OPTIONS
+    assert municipality.SWISS_CANTONS is cantons.SWISS_CANTONS
+    assert rangliste.SWISS_CANTON_OPTIONS is cantons.SWISS_CANTON_OPTIONS
+
+
+def test_no_module_imports_canton_options_from_municipality():
+    offenders = []
+    for path in _python_files():
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.ImportFrom) or node.module != "municipality":
+                continue
+            if any(alias.name == "SWISS_CANTON_OPTIONS" for alias in node.names):
+                offenders.append(str(path.relative_to(PROJECT_ROOT)))
+
+    assert offenders == []

--- a/tests/test_e2e_integration.py
+++ b/tests/test_e2e_integration.py
@@ -58,11 +58,18 @@ class TestDatabaseSchema:
             content = f.read()
         assert "lea_reports" in content
 
+    def test_database_has_ops_snapshots_table(self):
+        with open(os.path.join(PROJECT_ROOT, "database.py")) as f:
+            content = f.read()
+        assert "ops_snapshots" in content
+
     def test_database_has_lea_report_functions(self):
         with open(os.path.join(PROJECT_ROOT, "database.py")) as f:
             content = f.read()
         assert "def save_lea_report" in content
         assert "def get_lea_reports" in content
+        assert "def save_ops_snapshot" in content
+        assert "def get_ops_snapshots" in content
 
 
 class TestAdminPipelineHTML:

--- a/tests/test_private_content_absent.py
+++ b/tests/test_private_content_absent.py
@@ -104,8 +104,10 @@ def test_public_package_excludes_private_workspace_material(tmp_path):
         "openclaw/mcp-openleg-server/package.json",
         "openclaw/mcp-openleg-server/server.mjs",
         "sales_pipeline.py",
+        "templates/admin/ops.html",
         "templates/admin/pipeline.html",
         "templates/admin/strategy.html",
+        "tests/test_admin_ops.py",
         "templates/emails/municipality_outreach.html",
         "tests/test_admin_pipeline.py",
         "tests/test_admin_strategy.py",
@@ -164,12 +166,16 @@ def test_public_package_has_no_private_operator_surfaces(tmp_path):
 
     forbidden_app_fragments = (
         "/admin/pipeline",
+        "/admin/ops",
         "/admin/strategy",
+        "/api/internal/agentmail",
         "/api/internal/lea-report",
+        "/api/internal/ops-snapshot",
         "/admin/lea-reports",
     )
     assert all(fragment not in app_content for fragment in forbidden_app_fragments)
     assert "municipality_outreach" not in email_content
     assert "lea_reports" not in database_content
+    assert "ops_snapshots" not in database_content
     assert "vnb_research" not in database_content
     assert "openclaw:" not in compose_content

--- a/tests/test_pv_badge.py
+++ b/tests/test_pv_badge.py
@@ -2,11 +2,13 @@
 """Tests für SVG-Badges und Social-Cards."""
 
 import os
+from unittest.mock import MagicMock
 
 from flask import Flask
 
 import pv_badge
 import rangliste as rangliste_module
+from ranking import Ranking
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -34,14 +36,29 @@ def test_og_card_svg_dimensions_and_content():
     assert "42%" in svg
 
 
-def _make_client(monkeypatch, profile):
+def _make_client(monkeypatch, profile, ranking_profiles=None):
     monkeypatch.setattr(
         rangliste_module.db, "get_municipality_profile", lambda _bfs: profile
     )
     monkeypatch.setattr(
         rangliste_module.db,
         "get_pv_profiles",
-        lambda kanton=None: [profile] if profile else [],
+        lambda kanton=None: (
+            [profile] if profile and profile.get("pv_score_pct") is not None else []
+        ),
+    )
+
+    def _ranking_instance():
+        if ranking_profiles is not None:
+            return Ranking(ranking_profiles)
+        if profile and profile.get("pv_score_pct") is not None:
+            return Ranking([profile])
+        return Ranking([])
+
+    monkeypatch.setattr(
+        rangliste_module.Ranking,
+        "load",
+        classmethod(lambda cls, kanton=None: _ranking_instance()),
     )
     app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
     app.config["TESTING"] = True
@@ -74,6 +91,82 @@ def test_og_route_returns_svg(monkeypatch):
     assert b"Baden" in resp.data
 
 
+NO_PV_PROFILE = {
+    "bfs_number": 4021,
+    "name": "Baden",
+    "kanton": "AG",
+    "pv_score_pct": None,
+    "pv_untapped_kw": None,
+}
+
+
 def test_badge_route_404_when_missing(monkeypatch):
     client = _make_client(monkeypatch, None)
     assert client.get("/rangliste/badge/9999.svg").status_code == 404
+
+
+def test_og_route_404_when_missing(monkeypatch):
+    client = _make_client(monkeypatch, None)
+    assert client.get("/rangliste/og/9999.svg").status_code == 404
+
+
+def test_badge_route_no_pv_score_returns_na_openleg(monkeypatch):
+    client = _make_client(monkeypatch, NO_PV_PROFILE, ranking_profiles=[])
+    resp = client.get("/rangliste/badge/4021.svg")
+    assert resp.status_code == 200
+    data = resp.data.decode("utf-8", errors="ignore")
+    assert "n/a" in data
+    assert "OpenLEG" in data
+
+
+def test_og_route_no_pv_score_returns_na_openleg(monkeypatch):
+    client = _make_client(monkeypatch, NO_PV_PROFILE, ranking_profiles=[])
+    resp = client.get("/rangliste/og/4021.svg")
+    assert resp.status_code == 200
+    data = resp.data.decode("utf-8", errors="ignore")
+    assert "n/a" in data
+    assert "Offene Daten von BFE und BFS" in data
+
+
+def _badge_app_with_mocked_ranking(monkeypatch):
+    monkeypatch.setattr(
+        rangliste_module.db, "get_municipality_profile", lambda _bfs: PROFILE
+    )
+    mock_ranking = MagicMock()
+    mock_ranking.return_value.badge_svg.return_value = "<svg>ranking-badge</svg>"
+    monkeypatch.setattr(rangliste_module.Ranking, "load", mock_ranking)
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(rangliste_module.rangliste_bp)
+    return app.test_client(), mock_ranking
+
+
+def test_badge_route_delegates_to_ranking_facade(monkeypatch):
+    client, mock_ranking = _badge_app_with_mocked_ranking(monkeypatch)
+    resp = client.get("/rangliste/badge/4021.svg")
+    assert resp.status_code == 200
+    assert resp.data == b"<svg>ranking-badge</svg>"
+    mock_ranking.assert_called_once_with()
+    mock_ranking.return_value.badge_svg.assert_called_once_with(4021, profile=PROFILE)
+
+
+def _og_app_with_mocked_ranking(monkeypatch):
+    monkeypatch.setattr(
+        rangliste_module.db, "get_municipality_profile", lambda _bfs: PROFILE
+    )
+    mock_ranking = MagicMock()
+    mock_ranking.return_value.og_card_svg.return_value = "<svg>ranking-og</svg>"
+    monkeypatch.setattr(rangliste_module.Ranking, "load", mock_ranking)
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(rangliste_module.rangliste_bp)
+    return app.test_client(), mock_ranking
+
+
+def test_og_route_delegates_to_ranking_facade(monkeypatch):
+    client, mock_ranking = _og_app_with_mocked_ranking(monkeypatch)
+    resp = client.get("/rangliste/og/4021.svg")
+    assert resp.status_code == 200
+    assert resp.data == b"<svg>ranking-og</svg>"
+    mock_ranking.assert_called_once_with()
+    mock_ranking.return_value.og_card_svg.assert_called_once_with(4021, profile=PROFILE)

--- a/tests/test_rangliste.py
+++ b/tests/test_rangliste.py
@@ -2,10 +2,12 @@
 """Tests für den Ranglisten-Hub."""
 
 import os
+from unittest.mock import MagicMock
 
 from flask import Flask
 
 import rangliste as rangliste_module
+from ranking import Ranking
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -53,18 +55,18 @@ SAMPLE = [
 ]
 
 
-def _make_client(monkeypatch, rows=SAMPLE):
-    monkeypatch.setattr(
-        rangliste_module.db, "get_pv_profiles", lambda kanton=None: rows
-    )
+def _make_hub_client(monkeypatch, rows=SAMPLE):
+    monkeypatch.setattr(rangliste_module, "Ranking", Ranking, raising=False)
+    mock_load = MagicMock(return_value=Ranking(rows))
+    monkeypatch.setattr(rangliste_module.Ranking, "load", mock_load)
     app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
     app.config["TESTING"] = True
     app.register_blueprint(rangliste_module.rangliste_bp)
-    return app.test_client()
+    return app.test_client(), mock_load
 
 
 def test_hub_renders_ranked_table(monkeypatch):
-    client = _make_client(monkeypatch)
+    client, _ = _make_hub_client(monkeypatch)
     resp = client.get("/rangliste")
     assert resp.status_code == 200
     html = resp.data.decode("utf-8", errors="ignore")
@@ -79,24 +81,31 @@ def test_hub_renders_ranked_table(monkeypatch):
 
 
 def test_hub_caps_score_over_100(monkeypatch):
-    client = _make_client(monkeypatch)
+    client, _ = _make_hub_client(monkeypatch)
     html = client.get("/rangliste").data.decode("utf-8", errors="ignore")
     assert "100.0%" in html
     assert "104" not in html
 
 
 def test_hub_filters_by_canton(monkeypatch):
-    client = _make_client(monkeypatch)
+    client, _ = _make_hub_client(monkeypatch)
     html = client.get("/rangliste?kanton=AG").data.decode("utf-8", errors="ignore")
     assert "Sonnendorf" in html
     assert "Zürichberg" not in html
 
 
 def test_hub_filters_by_size(monkeypatch):
-    client = _make_client(monkeypatch)
+    client, _ = _make_hub_client(monkeypatch)
     html = client.get("/rangliste?size=large").data.decode("utf-8", errors="ignore")
     assert "Mittelstadt" in html
     assert "Sonnendorf" not in html
+
+
+def test_hub_calls_ranking_load_once(monkeypatch):
+    client, mock_load = _make_hub_client(monkeypatch)
+    resp = client.get("/rangliste")
+    assert resp.status_code == 200
+    mock_load.assert_called_once_with()
 
 
 MOVERS = [

--- a/tests/test_rangliste.py
+++ b/tests/test_rangliste.py
@@ -135,17 +135,22 @@ MOVERS = [
 
 
 def _make_movers_client(monkeypatch, rows=MOVERS):
-    monkeypatch.setattr(rangliste_module.db, "get_pv_movers", lambda: rows)
+    mock_ranking = MagicMock()
+    instance = mock_ranking.return_value
+    instance.movers.return_value = rows
+    monkeypatch.setattr(rangliste_module, "Ranking", mock_ranking)
     app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
     app.config["TESTING"] = True
     app.register_blueprint(rangliste_module.rangliste_bp)
-    return app.test_client()
+    return app.test_client(), mock_ranking, instance
 
 
 def test_movers_tab_renders_delta(monkeypatch):
-    client = _make_movers_client(monkeypatch)
+    client, mock_ranking, instance = _make_movers_client(monkeypatch)
     resp = client.get("/rangliste/fortschritte")
     assert resp.status_code == 200
+    mock_ranking.assert_called_once_with([])
+    instance.movers.assert_called_once_with()
     html = resp.data.decode("utf-8", errors="ignore")
     assert "Grösste Fortschritte" in html
     assert "+8.50 Pkt" in html
@@ -155,7 +160,7 @@ def test_movers_tab_renders_delta(monkeypatch):
 
 
 def test_movers_tab_filters_by_canton(monkeypatch):
-    client = _make_movers_client(monkeypatch)
+    client, _, _ = _make_movers_client(monkeypatch)
     html = client.get("/rangliste/fortschritte?kanton=ZH").data.decode(
         "utf-8", errors="ignore"
     )
@@ -164,28 +169,27 @@ def test_movers_tab_filters_by_canton(monkeypatch):
 
 
 def _make_compare_client(monkeypatch, rows=SAMPLE):
-    monkeypatch.setattr(
-        rangliste_module.db, "get_pv_profiles", lambda kanton=None: rows
-    )
     by_bfs = {r["bfs_number"]: r for r in rows}
     monkeypatch.setattr(
         rangliste_module.db, "get_municipality_profile", lambda bfs: by_bfs.get(bfs)
     )
+    mock_load = MagicMock(return_value=Ranking(rows))
+    monkeypatch.setattr(rangliste_module.Ranking, "load", mock_load)
     app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
     app.config["TESTING"] = True
     app.register_blueprint(rangliste_module.rangliste_bp)
-    return app.test_client()
+    return app.test_client(), mock_load
 
 
 def test_vergleich_picker_without_selection(monkeypatch):
-    client = _make_compare_client(monkeypatch)
+    client, _ = _make_compare_client(monkeypatch)
     html = client.get("/rangliste/vergleich").data.decode("utf-8", errors="ignore")
     assert "Gemeinden vergleichen" in html
     assert "Sonnendorf" in html  # im Dropdown
 
 
 def test_vergleich_shows_two_municipalities(monkeypatch):
-    client = _make_compare_client(monkeypatch)
+    client, _ = _make_compare_client(monkeypatch)
     html = client.get("/rangliste/vergleich?a=1&b=3").data.decode(
         "utf-8", errors="ignore"
     )
@@ -193,6 +197,13 @@ def test_vergleich_shows_two_municipalities(monkeypatch):
     assert "Zürichberg" in html
     assert "Nationaler Rang" in html
     assert "Ungenutztes Potenzial" in html
+
+
+def test_vergleich_calls_ranking_load_once(monkeypatch):
+    client, mock_load = _make_compare_client(monkeypatch)
+    resp = client.get("/rangliste/vergleich?a=1&b=3")
+    assert resp.status_code == 200
+    mock_load.assert_called_once_with()
 
 
 def test_methodik_page_renders_caveats_and_register(monkeypatch):

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -1,0 +1,76 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Unit tests for the ranking facade.
+
+Pure unit tests: no Flask app, no real database.
+"""
+
+from unittest.mock import patch
+
+import pv_ranking
+import ranking
+from store import ranking as store_ranking
+
+
+class TestRanking:
+    def test_init_uses_injected_profiles(self):
+        profiles = [{"bfs_number": 1, "name": "A"}]
+        r = ranking.Ranking(profiles)
+        assert r._profiles is profiles
+
+    def test_load_calls_get_pv_profiles_once(self):
+        with patch.object(store_ranking, "get_pv_profiles") as mock_get:
+            mock_get.return_value = [{"bfs_number": 1, "name": "A"}]
+            r = ranking.Ranking.load()
+            mock_get.assert_called_once_with()
+            assert r._profiles == [{"bfs_number": 1, "name": "A"}]
+
+    def test_load_passes_kanton(self):
+        with patch.object(store_ranking, "get_pv_profiles") as mock_get:
+            mock_get.return_value = []
+            _r = ranking.Ranking.load(kanton="ZH")
+            mock_get.assert_called_once_with("ZH")
+
+    def test_national_enriches_and_assigns_ranks(self):
+        profiles = [
+            {"bfs_number": 1, "name": "A", "pv_score_pct": 120},
+            {"bfs_number": 2, "name": "B", "pv_score_pct": 50},
+        ]
+        r = ranking.Ranking(profiles)
+        result = r.national()
+
+        assert len(result) == 2
+        assert result[0]["rank"] == 1
+        assert result[0]["display_score"] == 100.0
+        assert result[0]["score_over_100"] is True
+        assert result[1]["rank"] == 2
+        assert result[1]["display_score"] == 50.0
+        assert result[1]["score_over_100"] is False
+
+    def test_national_empty(self):
+        r = ranking.Ranking([])
+        assert r.national() == []
+
+    def test_league_chips_delegates(self):
+        all_profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 90,
+                "population": 3000,
+                "density_per_km2": 100,
+                "kanton": "ZH",
+            },
+            {
+                "bfs_number": 2,
+                "name": "B",
+                "pv_score_pct": 80,
+                "population": 3000,
+                "density_per_km2": 100,
+                "kanton": "ZH",
+            },
+        ]
+        profile = all_profiles[0]
+        r = ranking.Ranking(all_profiles)
+        chips = r.league_chips(profile)
+        expected = pv_ranking.league_standings(all_profiles, profile)
+        assert chips == expected

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -269,3 +269,49 @@ class TestRankingBadgeSvg:
     def test_badge_svg_not_found_returns_empty(self):
         r = ranking.Ranking([])
         assert r.badge_svg(1) == ""
+
+    def test_badge_svg_uses_fallback_profile(self):
+        profiles = [{"bfs_number": 2, "name": "B", "pv_score_pct": 80, "kanton": "ZH"}]
+        fallback = {"bfs_number": 1, "name": "A", "kanton": "AG"}
+        r = ranking.Ranking(profiles)
+        with patch("ranking.pv_badge.badge_svg") as mock_badge:
+            mock_badge.return_value = "<svg>badge</svg>"
+            result = r.badge_svg(1, profile=fallback)
+
+            mock_badge.assert_called_once_with("A", None, None)
+            assert result == "<svg>badge</svg>"
+
+
+class TestRankingOgCardSvg:
+    def test_og_card_svg_delegates_to_pv_badge(self):
+        profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 120,
+                "kanton": "ZH",
+                "pv_untapped_kw": 1000,
+            }
+        ]
+        r = ranking.Ranking(profiles)
+        with patch("ranking.pv_badge.og_card_svg") as mock_og:
+            mock_og.return_value = "<svg>og</svg>"
+            result = r.og_card_svg(1)
+
+            mock_og.assert_called_once_with("A", "ZH", 100.0, 1, 1000)
+            assert result == "<svg>og</svg>"
+
+    def test_og_card_svg_not_found_returns_empty(self):
+        r = ranking.Ranking([])
+        assert r.og_card_svg(1) == ""
+
+    def test_og_card_svg_uses_fallback_profile(self):
+        profiles = [{"bfs_number": 2, "name": "B", "pv_score_pct": 80, "kanton": "ZH"}]
+        fallback = {"bfs_number": 1, "name": "A", "kanton": "AG"}
+        r = ranking.Ranking(profiles)
+        with patch("ranking.pv_badge.og_card_svg") as mock_og:
+            mock_og.return_value = "<svg>og</svg>"
+            result = r.og_card_svg(1, profile=fallback)
+
+            mock_og.assert_called_once_with("A", "AG", None, None, None)
+            assert result == "<svg>og</svg>"

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -74,3 +74,198 @@ class TestRanking:
         chips = r.league_chips(profile)
         expected = pv_ranking.league_standings(all_profiles, profile)
         assert chips == expected
+
+
+class TestRankingStandings:
+    def test_standings_filter_by_kanton(self):
+        profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 120,
+                "kanton": "ZH",
+                "population": 3000,
+                "density_per_km2": 100,
+            },
+            {
+                "bfs_number": 2,
+                "name": "B",
+                "pv_score_pct": 50,
+                "kanton": "BE",
+                "population": 3000,
+                "density_per_km2": 100,
+            },
+        ]
+        r = ranking.Ranking(profiles)
+        result = r.standings(kanton="ZH")
+
+        assert len(result) == 1
+        assert result[0]["bfs_number"] == 1
+        assert result[0]["rank"] == 1
+        assert result[0]["display_score"] == 100.0
+        assert result[0]["score_over_100"] is True
+
+    def test_standings_filter_by_size_and_density(self):
+        profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 80,
+                "kanton": "ZH",
+                "population": 3000,
+                "density_per_km2": 100,
+            },
+            {
+                "bfs_number": 2,
+                "name": "B",
+                "pv_score_pct": 90,
+                "kanton": "ZH",
+                "population": 30000,
+                "density_per_km2": 100,
+            },
+            {
+                "bfs_number": 3,
+                "name": "C",
+                "pv_score_pct": 70,
+                "kanton": "ZH",
+                "population": 3000,
+                "density_per_km2": 500,
+            },
+        ]
+        r = ranking.Ranking(profiles)
+        result = r.standings(size="small", density="low")
+
+        assert len(result) == 1
+        assert result[0]["bfs_number"] == 1
+
+    def test_standings_empty(self):
+        r = ranking.Ranking([])
+        assert r.standings() == []
+
+
+class TestRankingImprovementTarget:
+    def test_improvement_target_with_size_band(self):
+        profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 50,
+                "kanton": "ZH",
+                "population": 3000,
+                "pv_estimated_potential_kw": 1000,
+                "pv_installed_kw": 400,
+            },
+            {
+                "bfs_number": 2,
+                "name": "B",
+                "pv_score_pct": 90,
+                "kanton": "ZH",
+                "population": 3500,
+                "pv_estimated_potential_kw": 1000,
+                "pv_installed_kw": 800,
+            },
+            {
+                "bfs_number": 3,
+                "name": "C",
+                "pv_score_pct": 95,
+                "kanton": "ZH",
+                "population": 3200,
+                "pv_estimated_potential_kw": 1000,
+                "pv_installed_kw": 900,
+            },
+            {
+                "bfs_number": 4,
+                "name": "D",
+                "pv_score_pct": 85,
+                "kanton": "ZH",
+                "population": 4000,
+                "pv_estimated_potential_kw": 1000,
+                "pv_installed_kw": 700,
+            },
+        ]
+        profile = profiles[0]
+        r = ranking.Ranking(profiles)
+        target = r.improvement_target(profile)
+
+        assert target == {
+            "target_score": 95,
+            "needed_kw": 550.0,
+            "roofs": 55,
+        }
+
+    def test_improvement_target_no_size_band(self):
+        profile = {"bfs_number": 1, "name": "A", "population": None}
+        r = ranking.Ranking([profile])
+        assert r.improvement_target(profile) is None
+
+
+class TestRankingLeaders:
+    def test_leaders_delegates_to_league_leaders(self):
+        profiles = [
+            {
+                "bfs_number": 1,
+                "name": "A",
+                "pv_score_pct": 90,
+                "kanton": "ZH",
+                "population": 3000,
+                "pv_annual_potential_gwh": 10,
+            },
+            {
+                "bfs_number": 2,
+                "name": "B",
+                "pv_score_pct": 80,
+                "kanton": "ZH",
+                "population": 3000,
+                "pv_annual_potential_gwh": 10,
+            },
+            {
+                "bfs_number": 3,
+                "name": "C",
+                "pv_score_pct": 70,
+                "kanton": "BE",
+                "population": 3000,
+                "pv_annual_potential_gwh": 10,
+            },
+        ]
+        r = ranking.Ranking(profiles)
+        with patch.object(pv_ranking, "league_leaders") as mock_leaders:
+            mock_leaders.return_value = [{"bfs_number": 2, "name": "B"}]
+            result = r.leaders("ZH", exclude_bfs=1)
+
+            assert result == [{"bfs_number": 2, "name": "B"}]
+            mock_leaders.assert_called_once()
+            args, kwargs = mock_leaders.call_args
+            assert all(row["kanton"] == "ZH" for row in args[0])
+            assert kwargs.get("exclude_bfs") == 1
+
+
+class TestRankingMovers:
+    def test_movers_calls_store_by_default(self):
+        with patch.object(store_ranking, "get_pv_movers") as mock_get:
+            mock_get.return_value = [{"bfs_number": 1, "delta": 5.0}]
+            r = ranking.Ranking([])
+            result = r.movers()
+
+            mock_get.assert_called_once_with()
+            assert result == [{"bfs_number": 1, "delta": 5.0}]
+
+    def test_movers_uses_injected_rows(self):
+        r = ranking.Ranking([])
+        injected = [{"bfs_number": 2, "delta": 3.0}]
+        assert r.movers(mover_rows=injected) is injected
+
+
+class TestRankingBadgeSvg:
+    def test_badge_svg_delegates_to_pv_badge(self):
+        profiles = [{"bfs_number": 1, "name": "A", "pv_score_pct": 120, "kanton": "ZH"}]
+        r = ranking.Ranking(profiles)
+        with patch("ranking.pv_badge.badge_svg") as mock_badge:
+            mock_badge.return_value = "<svg>badge</svg>"
+            result = r.badge_svg(1)
+
+            mock_badge.assert_called_once_with("A", 100.0, 1)
+            assert result == "<svg>badge</svg>"
+
+    def test_badge_svg_not_found_returns_empty(self):
+        r = ranking.Ranking([])
+        assert r.badge_svg(1) == ""

--- a/tests/test_store_ranking.py
+++ b/tests/test_store_ranking.py
@@ -7,6 +7,8 @@ so legacy callers and existing monkeypatches keep working unchanged.
 """
 
 from contextlib import contextmanager
+import subprocess
+import sys
 
 import database
 from store import ranking
@@ -53,6 +55,17 @@ def test_database_reexports_are_identical_objects():
     assert database.get_pv_profiles is ranking.get_pv_profiles
     assert database.get_pv_movers is ranking.get_pv_movers
     assert database.get_municipality_pv_panel is ranking.get_municipality_pv_panel
+
+
+def test_store_ranking_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.ranking; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
 
 
 def test_ranking_uses_database_connection_seam(monkeypatch):


### PR DESCRIPTION
Ships the pending local work: the ranking/cantons refactor commits plus the LEA AgentMail + ops-snapshot feature.

## Ranking / cantons refactor
- Shared canton constants extracted (`cantons.py`); `municipality.py` slimmed.
- New `ranking.py` facade + `store/ranking.py` extensions; `rangliste.py` wired through it (hub, compare movers, badge routes).
- Adds `tests/test_ranking.py`, `tests/test_cantons_refactor.py`, extends rangliste/pv_badge/store tests.

## Ops / AgentMail
- `/api/internal/agentmail`: svix-verified (falls back to `X-Internal-Token`) inbound mail webhook; payload sanitized; stored as `lea_inbox` snapshot.
- `/api/internal/ops-snapshot`: token-gated snapshot ingest.
- `/admin/ops`: latest-by-category dashboard (HTML + JSON), counts, recent LEA reports.
- `database.py`: ops snapshot + LEA report storage.
- `openclaw/`: AgentMail wiring (entrypoint, MCP server, Dockerfile, README).
- `.env.example`: `INTERNAL_TOKEN`, AgentMail/LEA vars (placeholders only).
- `scripts/package_public.sh` strips `admin/ops.html` + `test_admin_ops.py` from the public snapshot.

## Tests
Full suite: 406 passed, 7 skipped (CI-equivalent, no local `.env`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)