### PR TITLE
refactor(store): extract store/billing repository from database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -2671,111 +2671,6 @@ def list_leg_documents(community_id: int) -> List[Dict]:
         return []
 
 
-def save_billing_period(
-    community_id: int, period_start, period_end, summary: dict
-) -> int:
-    """Save billing period and line items from billing engine output."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO billing_periods
-                    (community_id, period_start, period_end, total_production_kwh, total_allocated_kwh,
-                     total_surplus_kwh, total_network_discount_chf, status)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, 'final') RETURNING id
-                """,
-                    (
-                        community_id,
-                        period_start,
-                        period_end,
-                        summary["total_production_kwh"],
-                        summary["total_allocated_kwh"],
-                        summary.get("total_surplus_kwh", 0),
-                        summary["total_network_discount_chf"],
-                    ),
-                )
-                period_id = cur.fetchone()[0]
-
-                for p in summary.get("participants", []):
-                    cur.execute(
-                        """
-                        INSERT INTO billing_line_items
-                        (billing_period_id, participant_id, consumption_kwh, allocated_kwh,
-                         self_supply_ratio, internal_cost_chf, network_discount_chf)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    """,
-                        (
-                            period_id,
-                            p["id"],
-                            p["consumption_kwh"],
-                            p["allocated_kwh"],
-                            p["self_supply_ratio"],
-                            p["internal_cost_chf"],
-                            p["network_discount_chf"],
-                        ),
-                    )
-
-                return period_id
-    except Exception as e:
-        logger.error(f"[DB] Error saving billing period: {e}")
-        return 0
-
-
-def get_active_communities() -> List[Dict]:
-    """Get all communities with status='active'."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT * FROM communities WHERE status = 'active'")
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting active communities: {e}")
-        return []
-
-
-def get_community_for_building(building_id: str) -> Optional[Dict]:
-    """Get community for a building via community_members join."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT c.* FROM communities c
-                    JOIN community_members cm ON c.community_id = cm.community_id
-                    WHERE cm.building_id = %s AND c.status = 'active'
-                    LIMIT 1
-                """,
-                    (building_id,),
-                )
-                row = cur.fetchone()
-                return dict(row) if row else None
-    except Exception as e:
-        logger.error(f"[DB] Error getting community for building: {e}")
-        return None
-
-
-def get_billing_period(period_id: int) -> Optional[Dict]:
-    """Get billing period with line items."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("SELECT * FROM billing_periods WHERE id = %s", (period_id,))
-                period = cur.fetchone()
-                if not period:
-                    return None
-                result = dict(period)
-                cur.execute(
-                    "SELECT * FROM billing_line_items WHERE billing_period_id = %s",
-                    (period_id,),
-                )
-                result["line_items"] = [dict(row) for row in cur.fetchall()]
-                return result
-    except Exception as e:
-        logger.error(f"[DB] Error getting billing period: {e}")
-        return None
-
-
 # PUBLIC-SNAPSHOT-PRIVATE-START: operator-report-helpers
 def save_lea_report(job_name: str, summary_text: str, status: str = "ok") -> bool:
     """Save an autonomous LEA report from a cron job webhook."""
@@ -2920,4 +2815,11 @@ from store.profile import (  # noqa: E402, F401
     get_profile_bfs_missing_elcom_tariffs,
     save_sonnendach_municipal,
     get_sonnendach_municipal,
+)
+
+from store.billing import (  # noqa: E402, F401
+    save_billing_period,
+    get_active_communities,
+    get_community_for_building,
+    get_billing_period,
 )

--- a/store/billing.py
+++ b/store/billing.py
@@ -1,0 +1,128 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""LEG community billing repository.
+
+Repository module for the LEG community billing domain: billing periods,
+billing line items, and communities. The connection seam is resolved via
+``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working
+unchanged and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Optional, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+# === Billing Operations ===
+
+
+def save_billing_period(
+    community_id: int, period_start, period_end, summary: dict
+) -> int:
+    """Save billing period and line items from billing engine output."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO billing_periods
+                    (community_id, period_start, period_end, total_production_kwh, total_allocated_kwh,
+                     total_surplus_kwh, total_network_discount_chf, status)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, 'final') RETURNING id
+                """,
+                    (
+                        community_id,
+                        period_start,
+                        period_end,
+                        summary["total_production_kwh"],
+                        summary["total_allocated_kwh"],
+                        summary.get("total_surplus_kwh", 0),
+                        summary["total_network_discount_chf"],
+                    ),
+                )
+                period_id = cur.fetchone()[0]
+
+                for p in summary.get("participants", []):
+                    cur.execute(
+                        """
+                        INSERT INTO billing_line_items
+                        (billing_period_id, participant_id, consumption_kwh, allocated_kwh,
+                         self_supply_ratio, internal_cost_chf, network_discount_chf)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    """,
+                        (
+                            period_id,
+                            p["id"],
+                            p["consumption_kwh"],
+                            p["allocated_kwh"],
+                            p["self_supply_ratio"],
+                            p["internal_cost_chf"],
+                            p["network_discount_chf"],
+                        ),
+                    )
+
+                return period_id
+    except Exception as e:
+        logger.error(f"[DB] Error saving billing period: {e}")
+        return 0
+
+
+def get_active_communities() -> List[Dict]:
+    """Get all communities with status='active'."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM communities WHERE status = 'active'")
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting active communities: {e}")
+        return []
+
+
+def get_community_for_building(building_id: str) -> Optional[Dict]:
+    """Get community for a building via community_members join."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT c.* FROM communities c
+                    JOIN community_members cm ON c.community_id = cm.community_id
+                    WHERE cm.building_id = %s AND c.status = 'active'
+                    LIMIT 1
+                """,
+                    (building_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting community for building: {e}")
+        return None
+
+
+def get_billing_period(period_id: int) -> Optional[Dict]:
+    """Get billing period with line items."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM billing_periods WHERE id = %s", (period_id,))
+                period = cur.fetchone()
+                if not period:
+                    return None
+                result = dict(period)
+                cur.execute(
+                    "SELECT * FROM billing_line_items WHERE billing_period_id = %s",
+                    (period_id,),
+                )
+                result["line_items"] = [dict(row) for row in cur.fetchall()]
+                return result
+    except Exception as e:
+        logger.error(f"[DB] Error getting billing period: {e}")
+        return None

--- a/tests/test_store_billing.py
+++ b/tests/test_store_billing.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the LEG community billing repository (store.billing).
+
+Verifies the extracted module resolves the connection seam via
+`database.get_connection` and that `database` re-exports the identical objects,
+so legacy callers and existing monkeypatches keep working unchanged. Mirrors
+`test_store_ranking.py` / `test_store_profile.py`; the seam is the test surface.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import billing
+
+
+_REEXPORTED = (
+    "save_billing_period",
+    "get_active_communities",
+    "get_community_for_building",
+    "get_billing_period",
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None):
+        self.rows = rows or []
+        self.one = one
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    for name in _REEXPORTED:
+        assert getattr(database, name) is getattr(billing, name), name
+
+
+def test_store_billing_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.billing; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_billing_uses_database_connection_seam(monkeypatch):
+    # Monkeypatching database.get_connection must affect store.billing calls,
+    # proving the seam is shared (not a stale direct import binding).
+    cur = _FakeCursor(rows=[{"community_id": 1, "status": "active"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = billing.get_active_communities()
+    assert rows == [{"community_id": 1, "status": "active"}]
+    assert "communities" in cur.executed[0][0]
+    assert "status = 'active'" in cur.executed[0][0]
+
+
+def test_get_billing_period_missing_returns_none(monkeypatch):
+    cur = _FakeCursor(one=None)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert billing.get_billing_period(999) is None


### PR DESCRIPTION
Extracts the LEG community billing domain (4 functions) from database.py into store/billing.py, re-exported so db.<fn>() keeps working. Continues the store/ranking + store/profile pattern (Candidate #4).

New tests/test_store_billing.py locks the contract (re-export identity, no circular import, shared seam, missing-period edge case). 442 passed, ruff clean, no behavior change.

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)