### PR TITLE
refactor(store): extract store/email_queue repository from database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -1533,138 +1533,6 @@ def migrate_from_json(json_data: Dict) -> Tuple[int, int]:
     return success, errors
 
 
-# === Email Queue Operations ===
-
-
-def schedule_email(
-    building_id: str, email: str, template_key: str, send_at_timestamp: float
-) -> bool:
-    """Schedule an email for future delivery."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                # Skip if same template already scheduled/sent for this building
-                cur.execute(
-                    """
-                    SELECT id FROM scheduled_emails
-                    WHERE building_id = %s AND template_key = %s AND status IN ('pending', 'sent')
-                """,
-                    (building_id, template_key),
-                )
-                if cur.fetchone():
-                    return False
-                cur.execute(
-                    """
-                    INSERT INTO scheduled_emails (building_id, email, template_key, send_at)
-                    VALUES (%s, %s, %s, to_timestamp(%s))
-                """,
-                    (building_id, email, template_key, send_at_timestamp),
-                )
-                return True
-    except Exception as e:
-        logger.error(f"[DB] Error scheduling email: {e}")
-        return False
-
-
-def get_pending_emails(limit: int = 50) -> List[Dict]:
-    """Get emails ready to send (send_at <= now, status = pending)."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT se.id, se.building_id, se.email, se.template_key, se.send_at,
-                           b.address, b.lat, b.lon, b.plz
-                    FROM scheduled_emails se
-                    JOIN buildings b ON se.building_id = b.building_id
-                    WHERE se.status = 'pending' AND se.send_at <= CURRENT_TIMESTAMP
-                    ORDER BY se.send_at ASC
-                    LIMIT %s
-                """,
-                    (limit,),
-                )
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting pending emails: {e}")
-        return []
-
-
-def mark_email_sent(email_id: int) -> bool:
-    """Mark a scheduled email as sent."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    UPDATE scheduled_emails
-                    SET status = 'sent', sent_at = CURRENT_TIMESTAMP
-                    WHERE id = %s
-                """,
-                    (email_id,),
-                )
-                return cur.rowcount > 0
-    except Exception as e:
-        logger.error(f"[DB] Error marking email sent: {e}")
-        return False
-
-
-def mark_email_failed(email_id: int, error: str) -> bool:
-    """Mark a scheduled email as failed."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    UPDATE scheduled_emails
-                    SET status = 'failed', error_message = %s
-                    WHERE id = %s
-                """,
-                    (error, email_id),
-                )
-                return cur.rowcount > 0
-    except Exception as e:
-        logger.error(f"[DB] Error marking email failed: {e}")
-        return False
-
-
-def cancel_emails_for_building(building_id: str) -> int:
-    """Cancel all pending emails for a building (e.g. on unsubscribe)."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    UPDATE scheduled_emails
-                    SET status = 'cancelled'
-                    WHERE building_id = %s AND status = 'pending'
-                """,
-                    (building_id,),
-                )
-                return cur.rowcount
-    except Exception as e:
-        logger.error(f"[DB] Error cancelling emails: {e}")
-        return 0
-
-
-def get_email_stats() -> Dict:
-    """Get email queue statistics."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("""
-                    SELECT status, COUNT(*) as count
-                    FROM scheduled_emails
-                    GROUP BY status
-                """)
-                stats = {}
-                for row in cur.fetchall():
-                    stats[row["status"]] = row["count"]
-                return stats
-    except Exception as e:
-        logger.error(f"[DB] Error getting email stats: {e}")
-        return {}
-
-
 def get_neighbor_count_near(
     lat: float, lon: float, radius_km: float = 0.5, city_id: Optional[str] = None
 ) -> int:
@@ -2822,4 +2690,13 @@ from store.billing import (  # noqa: E402, F401
     get_active_communities,
     get_community_for_building,
     get_billing_period,
+)
+
+from store.email_queue import (  # noqa: E402, F401
+    schedule_email,
+    get_pending_emails,
+    mark_email_sent,
+    mark_email_failed,
+    cancel_emails_for_building,
+    get_email_stats,
 )

--- a/store/email_queue.py
+++ b/store/email_queue.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Outbound email queue repository.
+
+Repository module for the outbound email queue domain: schedule emails for the
+``scheduled_emails`` table, transition dispatch state (pending/sent/failed/
+cancelled), and return queue statistics. The connection seam is resolved via
+``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working
+unchanged and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+# === Email Queue Operations ===
+
+
+def schedule_email(
+    building_id: str, email: str, template_key: str, send_at_timestamp: float
+) -> bool:
+    """Schedule an email for future delivery."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                # Skip if same template already scheduled/sent for this building
+                cur.execute(
+                    """
+                    SELECT id FROM scheduled_emails
+                    WHERE building_id = %s AND template_key = %s AND status IN ('pending', 'sent')
+                """,
+                    (building_id, template_key),
+                )
+                if cur.fetchone():
+                    return False
+                cur.execute(
+                    """
+                    INSERT INTO scheduled_emails (building_id, email, template_key, send_at)
+                    VALUES (%s, %s, %s, to_timestamp(%s))
+                """,
+                    (building_id, email, template_key, send_at_timestamp),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error scheduling email: {e}")
+        return False
+
+
+def get_pending_emails(limit: int = 50) -> List[Dict]:
+    """Get emails ready to send (send_at <= now, status = pending)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT se.id, se.building_id, se.email, se.template_key, se.send_at,
+                           b.address, b.lat, b.lon, b.plz
+                    FROM scheduled_emails se
+                    JOIN buildings b ON se.building_id = b.building_id
+                    WHERE se.status = 'pending' AND se.send_at <= CURRENT_TIMESTAMP
+                    ORDER BY se.send_at ASC
+                    LIMIT %s
+                """,
+                    (limit,),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting pending emails: {e}")
+        return []
+
+
+def mark_email_sent(email_id: int) -> bool:
+    """Mark a scheduled email as sent."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE scheduled_emails
+                    SET status = 'sent', sent_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (email_id,),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error marking email sent: {e}")
+        return False
+
+
+def mark_email_failed(email_id: int, error: str) -> bool:
+    """Mark a scheduled email as failed."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE scheduled_emails
+                    SET status = 'failed', error_message = %s
+                    WHERE id = %s
+                """,
+                    (error, email_id),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error marking email failed: {e}")
+        return False
+
+
+def cancel_emails_for_building(building_id: str) -> int:
+    """Cancel all pending emails for a building (e.g. on unsubscribe)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE scheduled_emails
+                    SET status = 'cancelled'
+                    WHERE building_id = %s AND status = 'pending'
+                """,
+                    (building_id,),
+                )
+                return cur.rowcount
+    except Exception as e:
+        logger.error(f"[DB] Error cancelling emails: {e}")
+        return 0
+
+
+def get_email_stats() -> Dict:
+    """Get email queue statistics."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT status, COUNT(*) as count
+                    FROM scheduled_emails
+                    GROUP BY status
+                """)
+                stats = {}
+                for row in cur.fetchall():
+                    stats[row["status"]] = row["count"]
+                return stats
+    except Exception as e:
+        logger.error(f"[DB] Error getting email stats: {e}")
+        return {}

--- a/tests/test_store_email_queue.py
+++ b/tests/test_store_email_queue.py
@@ -1,0 +1,100 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the outbound email queue repository (store.email_queue).
+
+Verifies the extracted module resolves the connection seam via
+`database.get_connection` and that `database` re-exports the identical objects,
+so legacy callers and existing monkeypatches keep working unchanged. Mirrors
+`test_store_ranking.py` / `test_store_profile.py`; the seam is the test surface.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import email_queue
+
+
+_REEXPORTED = (
+    "schedule_email",
+    "get_pending_emails",
+    "mark_email_sent",
+    "mark_email_failed",
+    "cancel_emails_for_building",
+    "get_email_stats",
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None, rowcount=0):
+        self.rows = rows or []
+        self.one = one
+        self.rowcount = rowcount
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    for name in _REEXPORTED:
+        assert getattr(database, name) is getattr(email_queue, name), name
+
+
+def test_store_email_queue_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.email_queue; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_email_queue_uses_database_connection_seam(monkeypatch):
+    # Monkeypatching database.get_connection must affect store.email_queue calls,
+    # proving the seam is shared (not a stale direct import binding).
+    cur = _FakeCursor(rows=[{"id": 1, "email": "a@b.ch"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = email_queue.get_pending_emails()
+    assert rows == [{"id": 1, "email": "a@b.ch"}]
+    assert "scheduled_emails" in cur.executed[0][0]
+    assert cur.executed[0][1] == (50,)
+
+
+def test_schedule_email_skips_duplicate(monkeypatch):
+    # An already pending/sent template for the building returns False without insert.
+    cur = _FakeCursor(one=(1,))
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert email_queue.schedule_email("b1", "a@b.ch", "welcome", 0.0) is False


### PR DESCRIPTION
Extracts the outbound email queue domain (6 functions over the scheduled_emails table) from database.py into store/email_queue.py, re-exported so db.<fn>() keeps working. Continues Candidate #4 (store/ranking, store/profile, store/billing).

New tests/test_store_email_queue.py locks the contract (re-export identity, no circular import, shared seam, duplicate-skip edge case). 446 passed, ruff clean, no behavior change.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)