### PR TITLE
[codex] Document Postgres identity env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,9 @@
 # Copy this file to .env and fill in your values
 
 # === PostgreSQL ===
+POSTGRES_USER=openleg
 POSTGRES_PASSWORD=your-secure-postgres-password
+POSTGRES_DB=openleg
 
 # === Application Settings ===
 APP_BASE_URL=http://localhost:5000

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -70,6 +70,20 @@ class TestDockerCompose:
         assert len(db_urls) > 0
 
 
+class TestEnvExample:
+    """Validate documented env contract."""
+
+    @pytest.fixture(autouse=True)
+    def load_env_example(self):
+        path = os.path.join(PROJECT_ROOT, ".env.example")
+        with open(path) as f:
+            self.content = f.read()
+
+    def test_postgres_identity_is_explicit(self):
+        assert "POSTGRES_USER=" in self.content
+        assert "POSTGRES_DB=" in self.content
+
+
 class TestDeployScript:
     """Validate deploy.example.sh public deploy template."""
 


### PR DESCRIPTION
Closes #84.\n\n## What changed\n- Documents POSTGRES_USER and POSTGRES_DB in .env.example.\n- Adds a deployment artifact regression test so the env contract stays explicit.\n\n## Why\nopenleg.ch returned 502 on 2026-06-28 after Flask started with implicit compose defaults against a Postgres volume initialized with a different user/database.\n\n## Validation\n- pytest tests/test_deployment.py -q