### PR TITLE
style(copy): tighten public site wording

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -59,10 +59,9 @@
         <!-- Neighbor Count -->
         {% if neighbor_count > 0 %}
         <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-6 flex items-center gap-3">
-            <span class="text-2xl">🏘</span>
             <div>
                 <p class="font-semibold text-green-800">{{ neighbor_count }} Haushalte in Ihrer Nähe registriert</p>
-                <p class="text-sm text-green-700">Je mehr Nachbarn mitmachen, desto schneller wird Ihre LEG Realität.</p>
+                <p class="text-sm text-green-700">Je mehr Nachbarn mitmachen, desto schneller kann die Gründung starten.</p>
             </div>
         </div>
         {% endif %}
@@ -102,7 +101,7 @@
         {% if referral_link %}
         <div class="bg-white rounded-lg shadow-sm p-6 mb-6">
             <h2 class="text-lg font-bold mb-2">Nachbarn einladen</h2>
-            <p class="text-sm text-gray-600 mb-3">Teilen Sie diesen Link, um Ihre LEG-Gemeinschaft schneller zu bilden:</p>
+            <p class="text-sm text-gray-600 mb-3">Teilen Sie diesen Link mit Nachbarn, die mitmachen könnten:</p>
             <div class="flex gap-2">
                 <input type="text" readonly value="{{ referral_link }}" id="ref-link" class="flex-grow p-3 border border-gray-300 rounded-md text-sm bg-gray-50" onclick="this.select()">
                 <button onclick="navigator.clipboard.writeText(document.getElementById('ref-link').value);this.textContent='Kopiert!';setTimeout(()=>this.textContent='Kopieren',2000)" class="px-4 py-3 bg-gray-800 text-white text-sm font-semibold rounded-md hover:bg-gray-900 whitespace-nowrap">Kopieren</button>

--- a/templates/datenschutz.html
+++ b/templates/datenschutz.html
@@ -5,11 +5,11 @@
 
 {% block meta %}
 {{ page_meta(
-  title="Datenschutz - " ~ platform_name,
-  description="Datenschutzerklärung von " ~ platform_name ~ " - Erfahren Sie, wie Ihre Daten geschützt und für das Matching von Lokalen Elektrizitätsgemeinschaften genutzt werden.",
+  title="Datenschutz | " ~ platform_name,
+  description="Datenschutzerklärung von " ~ platform_name ~ ": welche Daten wir nutzen, warum wir sie brauchen und wie Sie Auskunft oder Löschung verlangen.",
   path="/datenschutz",
-  og_title="Datenschutz - " ~ platform_name,
-  og_description="Transparente Informationen zum Datenschutz des " ~ platform_name ~ "-Services.",
+  og_title="Datenschutz | " ~ platform_name,
+  og_description="Welche Daten " ~ platform_name ~ " nutzt und wie Sie die Kontrolle behalten.",
   og_type="article",
   robots="index, follow",
   site_url=site_url,
@@ -21,8 +21,8 @@
     <h1 class="text-2xl font-bold mb-4">Datenschutz</h1>
 
     <p class="mb-4">
-      Diese Datenschutzerklärung informiert Sie über Art, Umfang und Zweck der Verarbeitung
-      personenbezogener Daten bei der Nutzung von {{ platform_name }}.
+      Diese Datenschutzerklärung sagt, welche Personendaten {{ platform_name }} nutzt,
+      warum wir sie brauchen und wie Sie Auskunft, Korrektur oder Löschung verlangen.
     </p>
 
     <h2 class="text-xl font-semibold mt-6 mb-2">1. Verantwortliche Stelle</h2>
@@ -47,31 +47,31 @@
 
     <h2 class="text-xl font-semibold mt-6 mb-2">4. Rechtsgrundlagen</h2>
     <p class="mb-4">
-      Die Verarbeitung erfolgt zur Erfüllung des von Ihnen angefragten Dienstes und auf Basis Ihrer Einwilligung
+      Wir verarbeiten Ihre Daten, um den von Ihnen angefragten Dienst zu erbringen, und auf Basis Ihrer Einwilligung
       (z. B. Klick auf den Bestätigungslink).
     </p>
 
     <h2 class="text-xl font-semibold mt-6 mb-2">5. Weitergabe</h2>
     <p class="mb-4">
-      Personendaten werden nur dann an Dritte übermittelt, wenn dies für den Betrieb notwendig ist
+      Wir geben Personendaten nur dann an Dritte weiter, wenn dies für den Betrieb notwendig ist
       (z. B. Hosting-Provider) oder Sie explizit zugestimmt haben (Austausch von Kontaktdaten nach beidseitiger Bestätigung).
     </p>
 
     <h2 class="text-xl font-semibold mt-6 mb-2">6. Speicherdauer</h2>
     <p class="mb-4">
-      Registrierungs- und Match-Daten werden für die Dauer des Match-Prozesses gespeichert. Nicht bestätigte Matches
-      werden nach angemessener Frist gelöscht. Server-Logs werden turnusmässig gelöscht.
+      Wir speichern Registrierungs- und Match-Daten für die Dauer des Match-Prozesses. Nicht bestätigte Matches
+      löschen wir nach angemessener Frist. Server-Logs löschen wir regelmässig.
     </p>
 
     <h2 class="text-xl font-semibold mt-6 mb-2">7. Sicherheit</h2>
     <p class="mb-4">
-      Wir treffen angemessene technische und organisatorische Massnahmen, um Daten vor Verlust, Missbrauch und unbefugtem Zugriff zu schützen.
+      Wir schützen Daten mit technischen und organisatorischen Massnahmen vor Verlust, Missbrauch und unbefugtem Zugriff.
     </p>
 
     <h2 class="text-xl font-semibold mt-6 mb-2">8. Ihre Rechte</h2>
     <ul class="list-disc ml-6 mb-4">
       <li>Auskunft, Berichtigung, Löschung</li>
-      <li>Widerruf erteilter Einwilligungen mit Wirkung für die Zukunft</li>
+      <li>Widerruf erteilter Einwilligungen für künftige Verarbeitungen</li>
       <li>Beschwerderecht bei einer Aufsichtsbehörde</li>
     </ul>
 

--- a/templates/emails/day_0_welcome.html
+++ b/templates/emails/day_0_welcome.html
@@ -30,8 +30,8 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
     <h1>{{ platform_name }}</h1>
   </div>
   <div class="content">
-    <h2>Willkommen bei {{ platform_name }}!</h2>
-    <p>Schön, dass Sie dabei sind! Seit dem 1. Januar 2026 können Haushalte in {{ city_name }} eine lokale Stromgemeinschaft (LEG) gründen und gemeinsam Solarstrom teilen. OpenLEG ist kostenlos und Open Source, Ihre Daten bleiben bei Ihnen.</p>
+    <h2>Willkommen bei {{ platform_name }}</h2>
+    <p>Seit dem 1. Januar 2026 können Haushalte in {{ city_name }} eine lokale Stromgemeinschaft (LEG) gründen und gemeinsam Solarstrom teilen. OpenLEG ist kostenlos und Open Source. Ihre Daten bleiben bei Ihnen.</p>
 
     {% if neighbor_count > 0 %}
     <div class="highlight">
@@ -41,9 +41,9 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
 
     <p><strong>Was passiert als Nächstes?</strong></p>
     <ol class="steps">
-      <li>Wir schauen automatisch, ob genug Nachbarn in Ihrer Nähe interessiert sind.</li>
+      <li>Wir prüfen, ob genug Nachbarn in Ihrer Nähe interessiert sind.</li>
       <li>Sobald es genug Leute sind, stellen wir den Kontakt her.</li>
-      <li>Gemeinsam gründen Sie Ihre LEG und sparen rund CHF 500 bis 800 pro Jahr.</li>
+      <li>Gemeinsam gründen Sie Ihre LEG und sparen je nach Situation mehrere hundert Franken pro Jahr.</li>
     </ol>
 
     <p style="text-align:center;">
@@ -52,8 +52,8 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
 
     {% if referral_link %}
     <div class="referral-box">
-      <p><strong>Laden Sie Ihre Nachbarn ein!</strong></p>
-      <p style="font-size:14px;">Je mehr Nachbarn mitmachen, desto schneller wird Ihre LEG Realität:</p>
+      <p><strong>Laden Sie Ihre Nachbarn ein</strong></p>
+      <p style="font-size:14px;">Je mehr Nachbarn mitmachen, desto schneller kann die Gründung starten:</p>
       <div class="referral-link">{{ referral_link }}</div>
     </div>
     {% endif %}

--- a/templates/emails/day_14_formation.html
+++ b/templates/emails/day_14_formation.html
@@ -32,8 +32,8 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
     <h1>{{ platform_name }}</h1>
   </div>
   <div class="content">
-    <h2>Ihre Stromgemeinschaft kann starten!</h2>
-    <p>Zwei Wochen sind vergangen und wir haben genug Interessenten in Ihrer Nähe gefunden. Jetzt geht es an die Gründung.</p>
+    <h2>Ihre Stromgemeinschaft kann starten</h2>
+    <p>Wir haben genug Interessierte in Ihrer Nähe gefunden. Jetzt geht es an die Gründung.</p>
 
     <p><strong>So läuft die Gründung ab:</strong></p>
     <div class="timeline">
@@ -48,7 +48,7 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
         <div class="timeline-dot">2</div>
         <div class="timeline-text">
           <strong>Vertrag unterzeichnen</strong>
-          <span>Einfacher Gemeinschaftsvertrag, den alle Teilnehmer digital unterzeichnen.</span>
+          <span>Alle Teilnehmer unterzeichnen den Gemeinschaftsvertrag digital.</span>
         </div>
       </div>
       <div class="timeline-item">
@@ -62,7 +62,7 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
         <div class="timeline-dot">4</div>
         <div class="timeline-text">
           <strong>Strom teilen und sparen</strong>
-          <span>Nach Genehmigung starten Sie sofort mit dem lokalen Stromhandel.</span>
+          <span>Nach der Genehmigung teilen Sie den lokalen Strom innerhalb der LEG.</span>
         </div>
       </div>
     </div>

--- a/templates/emails/day_3_smartmeter.html
+++ b/templates/emails/day_3_smartmeter.html
@@ -26,19 +26,19 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
   </div>
   <div class="content">
     <h2>Haben Sie einen Smart Meter?</h2>
-    <p>Um bei einer lokalen Stromgemeinschaft (LEG) mitzumachen, brauchen Sie einen Smart Meter, also einen digitalen Stromzähler. Ihr Netzbetreiber ({{ utility_name }}) muss diesen innert 3 Monaten kostenlos einbauen, das ist Ihr Recht nach Art. 17e StromVG.</p>
+    <p>Für eine lokale Stromgemeinschaft (LEG) brauchen Sie einen Smart Meter, also einen digitalen Stromzähler. Ihr Netzbetreiber ({{ utility_name }}) muss ihn innert 3 Monaten einbauen, das ist Ihr Recht nach Art. 17e StromVG.</p>
 
     <div class="info-box">
       <p><strong>So prüfen Sie es:</strong> Schauen Sie auf Ihren Stromzähler im Keller oder Hausanschlussraum. Ein Smart Meter hat ein digitales Display (keine Drehscheibe).</p>
     </div>
 
-    <p>Wenn wir wissen, ob Sie schon einen Smart Meter haben, können wir die Gründung Ihrer Stromgemeinschaft schneller vorantreiben.</p>
+    <p>Wenn wir wissen, ob Sie schon einen Smart Meter haben, können wir den nächsten Schritt besser planen.</p>
 
     <p style="text-align:center;">
       <a href="{{ dashboard_url }}" class="cta">Status im Dashboard angeben</a>
     </p>
 
-    <p style="font-size:13px;color:#6b7280;">Noch keinen Smart Meter? Kein Problem. Sobald Ihre Stromgemeinschaft bereit ist, stellen wir die Anfrage an den Netzbetreiber. Dieser ist gesetzlich verpflichtet, den Smart Meter innert 3 Monaten zu installieren.</p>
+    <p style="font-size:13px;color:#6b7280;">Noch keinen Smart Meter? Kein Problem. Sobald Ihre Stromgemeinschaft bereit ist, stellen wir die Anfrage an den Netzbetreiber. Er muss den Smart Meter innert 3 Monaten installieren.</p>
   </div>
   <div class="footer">
     <p>{{ platform_name }} &middot; LEG für {{ city_name }}</p>

--- a/templates/emails/day_7_consumption.html
+++ b/templates/emails/day_7_consumption.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>LEG-Matching optimieren</title>
+<title>Verbrauch ergänzen</title>
 <style>
 body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; color: #1f2937; }
 .wrapper { max-width: 600px; margin: 0 auto; background: #ffffff; }
@@ -28,19 +28,19 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
     <h1>{{ platform_name }}</h1>
   </div>
   <div class="content">
-    <h2>So holen Sie das Meiste aus Ihrer Stromgemeinschaft</h2>
-    <p>Mit ein paar Angaben zu Ihrem Stromverbrauch finden wir die passenden Nachbarn und die beste Gruppengrösse für Sie.</p>
+    <h2>Ergänzen Sie Ihren Stromverbrauch</h2>
+    <p>Mit ein paar Angaben zu Ihrem Stromverbrauch kann OpenLEG besser einschätzen, welche Nachbarn gut zu Ihrer LEG passen.</p>
 
     <div class="savings-box">
       <div class="amount">CHF 500 bis 800</div>
-      <p>geschätzte jährliche Ersparnis pro Haushalt</p>
+      <p>mögliche jährliche Ersparnis pro Haushalt</p>
     </div>
 
     <p><strong>Was wir benötigen:</strong></p>
     <ul style="font-size:15px;line-height:1.8;">
       <li>Ihren ungefähren Jahresverbrauch in kWh (steht auf der Stromrechnung)</li>
       <li>Ob Sie eine Solaranlage haben (oder planen)</li>
-      <li>Ihre übliche Verbrauchszeit (tagsüber / abends)</li>
+      <li>Ihre übliche Verbrauchszeit, tagsüber oder abends</li>
     </ul>
 
     <p style="text-align:center;">
@@ -48,11 +48,11 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
     </p>
 
     <div class="tip">
-      <p><strong>Tipp:</strong> Ihre letzte Stromrechnung von {{ utility_name }} enthält alle nötigen Angaben. Halten Sie diese bereit.</p>
+      <p><strong>Tipp:</strong> Ihre letzte Stromrechnung von {{ utility_name }} enthält die nötigen Angaben.</p>
     </div>
 
     {% if neighbor_count > 0 %}
-    <p style="font-size:14px;color:#6b7280;">Aktuell haben sich {{ neighbor_count }} Haushalte in Ihrer Nähe registriert. Je mehr Angaben wir haben, desto schneller kann es losgehen.</p>
+    <p style="font-size:14px;color:#6b7280;">Aktuell haben sich {{ neighbor_count }} Haushalte in Ihrer Nähe registriert. Je vollständiger die Angaben sind, desto besser lässt sich die Gruppe planen.</p>
     {% endif %}
   </div>
   <div class="footer">

--- a/templates/emails/formation_nudge.html
+++ b/templates/emails/formation_nudge.html
@@ -34,7 +34,7 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
       <p>{{ next_step_description }}</p>
     </div>
 
-    <p>Wir helfen Ihnen gerne, den nächsten Schritt zu machen.</p>
+    <p>Wenn Sie festhängen, antworten Sie auf diese E-Mail. Wir schauen den nächsten Schritt mit Ihnen an.</p>
 
     <p style="text-align: center;">
       <a href="{{ dashboard_url }}" class="cta">Gründung fortsetzen</a>

--- a/templates/emails/municipality_outreach.html
+++ b/templates/emails/municipality_outreach.html
@@ -34,11 +34,11 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
   <div class="content">
     <h2>LEG-Potenzial in {{ municipality_name }}</h2>
     <p>Sehr geehrte Damen und Herren,</p>
-    <p>In <strong>{{ municipality_name }}</strong> zeigt sich ein wachsendes Interesse an lokalen Energiegemeinschaften (LEG). Wir möchten Ihnen eine Zusammenfassung der aktuellen Nachfragesituation vorlegen.</p>
+    <p>In <strong>{{ municipality_name }}</strong> melden sich erste Haushalte für lokale Energiegemeinschaften (LEG). Hier ist der aktuelle Stand.</p>
 
     {% if has_demand_data %}
     <div class="demand-box {{ demand_level }}">
-      <p><strong>Nachfrageübersicht — {{ municipality_name }}</strong></p>
+      <p><strong>Nachfrageübersicht: {{ municipality_name }}</strong></p>
       <p>Nachfrageniveau: <strong>{{ demand_level | upper }}</strong>{% if demand_score > 0 %} &nbsp;(Score: {{ demand_score }}/100){% endif %}</p>
       <div class="demand-stats">
         <span class="demand-stat"><strong>{{ verified_buildings }}</strong> Verifizierte Gebäude</span>
@@ -51,18 +51,18 @@ body { margin: 0; padding: 0; background: #f4f4f5; font-family: -apple-system, B
     </div>
     {% else %}
     <div class="demand-box none">
-      <p><strong>Nachfrageübersicht — {{ municipality_name }}</strong></p>
-      <p>Für diese Gemeinde liegen noch keine verifizierten Nachfragedaten vor. Wir freuen uns, gemeinsam mit Ihnen einen ersten Schritt einzuleiten.</p>
+      <p><strong>Nachfrageübersicht: {{ municipality_name }}</strong></p>
+      <p>Für diese Gemeinde liegen noch keine verifizierten Nachfragedaten vor. Eine Gemeinde-Seite kann den ersten Einstieg schaffen.</p>
     </div>
     {% endif %}
 
-    <p>Als Gemeinde können Sie den LEG-Prozess aktiv unterstützen, indem Sie Ihre Einwohnerinnen und Einwohner informieren und den Kontakt zur lokalen Netzgesellschaft erleichtern.</p>
+    <p>Als Gemeinde können Sie helfen, indem Sie Einwohnerinnen und Einwohner informieren und den Kontakt zur lokalen Netzgesellschaft erleichtern.</p>
 
     <p style="text-align: center;">
       <a href="{{ site_url }}/gemeinde/onboarding" class="cta">Gemeinde registrieren</a>
     </p>
 
-    <p>Bei Fragen stehen wir gerne zur Verfügung: <a href="mailto:{{ contact_email }}">{{ contact_email }}</a></p>
+    <p>Fragen beantworten wir unter <a href="mailto:{{ contact_email }}">{{ contact_email }}</a>.</p>
   </div>
   <div class="footer">
     <p>{{ platform_name }} &middot; Kostenlose LEG-Infrastruktur für Gemeinden</p>

--- a/templates/fuer_bewohner.html
+++ b/templates/fuer_bewohner.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Für Bewohner und Gründer | OpenLEG",
-  description="OpenLEG für Bewohner: Adresse prüfen, Nachbarn finden und Ihre lokale Stromgemeinschaft (LEG) gründen. Kostenlos, Open Source, Ihre Daten bleiben bei Ihnen.",
+  description="OpenLEG für Bewohner: Adresse prüfen, Nachbarn finden und eine lokale Stromgemeinschaft (LEG) gründen. Kostenlos, Open Source, ohne Datenverkauf.",
   path="/fuer-bewohner",
   og_title="OpenLEG für Bewohner und Gründer",
   og_description="In drei Schritten zur eigenen Stromgemeinschaft: Adresse prüfen, Nachbarn finden, LEG starten. Bis 40% weniger Netzgebühren.",
@@ -31,7 +31,7 @@
     <header class="max-w-2xl mb-10">
       <p class="text-sm font-semibold text-brand mb-2">Für Bewohner und Gründer</p>
       <h1 class="text-4xl font-bold tracking-tight mb-3">Ihr Strom. Ihre Nachbarn. Ihre Gemeinschaft.</h1>
-      <p class="text-lg text-ink-muted">Seit dem 1. Januar 2026 dürfen Nachbarn ihren lokal erzeugten Strom gemeinsam nutzen. Eine Lokale Elektrizitätsgemeinschaft (LEG) spart bis 40% Netzgebühren. OpenLEG bringt Sie in drei Schritten dorthin.</p>
+      <p class="text-lg text-ink-muted">Seit dem 1. Januar 2026 dürfen Nachbarn lokal erzeugten Strom gemeinsam nutzen. Eine Lokale Elektrizitätsgemeinschaft (LEG) kann bis 40% Netzgebühren sparen. OpenLEG zeigt, ob Ihr Haus passt, und hilft beim Start.</p>
       <div class="mt-6 flex flex-col sm:flex-row gap-3">
         <a href="/#registrieren" class="bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Adresse prüfen</a>
         <a href="/leg-kalkulator" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">Ersparnis berechnen</a>
@@ -44,7 +44,7 @@
         <li class="rounded-2xl border border-slate-200 bg-white p-5 border-t-4 border-t-brand">
           <div class="text-sm font-semibold text-brand">Schritt 1</div>
           <div class="font-semibold text-lg mt-1">Adresse prüfen</div>
-          <p class="text-sm text-ink-muted mt-1">Wir zeigen anonymisiert, wer in Ihrer Nähe mitmachen will, und schätzen Ihr Solarpotenzial.</p>
+          <p class="text-sm text-ink-muted mt-1">Sie sehen anonymisiert, wer in Ihrer Nähe mitmachen will, und erhalten eine erste Schätzung zum Solarpotenzial.</p>
         </li>
         <li class="rounded-2xl border border-slate-200 bg-white p-5 border-t-4 border-t-brand">
           <div class="text-sm font-semibold text-brand">Schritt 2</div>
@@ -54,7 +54,7 @@
         <li class="rounded-2xl border border-slate-200 bg-white p-5 border-t-4 border-t-brand">
           <div class="text-sm font-semibold text-brand">Schritt 3</div>
           <div class="font-semibold text-lg mt-1">LEG starten</div>
-          <p class="text-sm text-ink-muted mt-1">OpenLEG erstellt Vereinbarung, Verträge und die Anmeldung beim Netzbetreiber.</p>
+          <p class="text-sm text-ink-muted mt-1">OpenLEG unterstützt bei Vereinbarung, Verträgen und Anmeldung beim Netzbetreiber.</p>
         </li>
       </ol>
     </section>
@@ -75,7 +75,7 @@
     <section class="bg-brand/5 border border-brand/20 rounded-2xl p-6">
       <h2 class="text-xl font-bold mb-3">Ihre Daten bleiben bei Ihnen</h2>
       <ul class="grid sm:grid-cols-2 gap-x-6 gap-y-2 text-sm text-ink-muted">
-        <li>&#10003; Kostenlos, für immer</li>
+        <li>&#10003; Kostenlos nutzbar</li>
         <li>&#10003; Open Source, gehostet in der Schweiz</li>
         <li>&#10003; Smart-Meter-Daten bleiben in Ihrer LEG</li>
         <li>&#10003; Kein Datenverkauf, jederzeit löschbar</li>

--- a/templates/fuer_gemeinden.html
+++ b/templates/fuer_gemeinden.html
@@ -4,10 +4,10 @@
 {% block meta %}
 {{ page_meta(
   title="Für Gemeinden | OpenLEG",
-  description="OpenLEG für Gemeinden: Solarnutzungs-Rangliste, eigene Gemeinde-Seite, LEG-Onboarding, Selbsthosting und optionaler Projektsupport.",
+  description="OpenLEG für Gemeinden: Solarnutzung vergleichen, eigene Gemeinde-Seite starten, Interessierte sammeln und lokale Stromgemeinschaften vorbereiten.",
   path="/fuer-gemeinden",
   og_title="OpenLEG für Gemeinden",
-  og_description="Vergleichen Sie die Solarnutzung Ihrer Gemeinde und starten Sie lokale Stromgemeinschaften mit freier Open Source Infrastruktur.",
+  og_description="Sehen Sie, wo Ihre Gemeinde bei der Solarnutzung steht, und schaffen Sie einen einfachen Einstieg für lokale Stromgemeinschaften.",
   site_url=site_url,
 ) }}
 {% endblock %}
@@ -22,19 +22,19 @@
   <main class="max-w-5xl mx-auto px-4 py-12">
     <header class="text-center mb-10">
       <h1 class="text-4xl font-bold mb-2">OpenLEG für Gemeinden</h1>
-      <p class="text-ink-muted max-w-2xl mx-auto">Zwei Wege, ein Ziel: funktionierende Lokale Elektrizitätsgemeinschaften. Plattform-Kern kostenlos und Open Source.</p>
+      <p class="text-ink-muted max-w-2xl mx-auto">OpenLEG zeigt, wo Ihre Gemeinde bei der Solarnutzung steht. Danach können Sie eine eigene Seite starten, auf der sich interessierte Haushalte melden.</p>
     </header>
 
     <section class="bg-brand/5 border border-brand/20 rounded-xl p-6 mb-10 text-center">
       <h2 class="text-xl font-bold mb-2">Wo steht Ihre Gemeinde bei der Solarnutzung?</h2>
-      <p class="text-ink-muted max-w-2xl mx-auto mb-4">Die Rangliste vergleicht Sie mit vergleichbaren Gemeinden und nennt das nächste konkrete Ziel. Aus offenen Daten von BFE und BFS, ohne Anmeldung.</p>
+      <p class="text-ink-muted max-w-2xl mx-auto mb-4">Die Rangliste vergleicht Ihre Gemeinde mit ähnlichen Gemeinden und zeigt, wie viele Dächer bis zum oberen Viertel fehlen. Aus offenen Daten von BFE und BFS, ohne Anmeldung.</p>
       <a href="/rangliste" class="inline-block bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Rangliste ansehen</a>
     </section>
 
     <div class="grid md:grid-cols-2 gap-6">
       <section class="bg-white rounded-xl shadow-md p-6 border-t-4 border-ink/20 flex flex-col">
         <h2 class="text-xl font-bold mb-1">Selbst betreiben</h2>
-        <p class="text-sm text-ink-muted mb-4">Für IT-Teams mit eigener Infrastruktur.</p>
+        <p class="text-sm text-ink-muted mb-4">Für Gemeinden mit eigenem IT-Team oder bestehendem Hostingpartner.</p>
         <ul class="text-sm space-y-2 mb-6 text-ink-muted flex-1">
           <li>&#10003; Open Source (AGPL-3.0)</li>
           <li>&#10003; Volle Datenhoheit</li>
@@ -51,7 +51,7 @@ docker compose up -d</code></pre>
 
       <section class="bg-white rounded-xl shadow-md p-6 border-t-4 border-brand flex flex-col">
         <h2 class="text-xl font-bold mb-1">Gehostet mit optionalem Projektsupport</h2>
-        <p class="text-sm text-ink-muted mb-4">Plattform-Kern kostenlos. Support nach Aufwand, projektbasiert.</p>
+        <p class="text-sm text-ink-muted mb-4">Für Gemeinden, die schnell starten wollen. Die Plattform bleibt kostenlos, Projektsupport läuft nach Aufwand.</p>
         <ul class="text-sm space-y-2 mb-6 text-ink-muted flex-1">
           <li>&#10003; Setup und Betrieb durch uns (SLA optional)</li>
           <li>&#10003; Schulungen, Onboarding, SDAT-CH Integration (optional)</li>

--- a/templates/gemeinde/methodik.html
+++ b/templates/gemeinde/methodik.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Methodik der Solarnutzungs-Rangliste | OpenLEG",
-  description="Wie OpenLEG die Solarnutzung berechnet: Kennzahl, Datenquellen, Ligen, Fortschritt und die ehrlichen Grenzen der Daten.",
+  description="Wie OpenLEG die Solarnutzung berechnet: Kennzahl, Datenquellen, Ligen, Fortschritt und Grenzen der Daten.",
   path=canonical_path,
   og_type="website",
   site_url=site_url,
@@ -16,7 +16,7 @@
     <header class="mb-8">
       <h1 class="text-3xl font-bold">Methodik</h1>
       <p class="text-ink-muted mt-2">
-        Wir legen offen, wie die Solarnutzung entsteht, woher die Daten kommen und wo ihre Grenzen liegen.
+        Wir zeigen, wie die Solarnutzung entsteht, welche Daten wir nutzen und wo die Zahlen unsicher bleiben.
       </p>
       <p class="text-sm text-ink-muted mt-2"><a href="/rangliste" class="text-brand hover:underline">Zurück zur Rangliste</a></p>
     </header>
@@ -25,7 +25,7 @@
       <h2 class="text-xl font-semibold mb-2">Kennzahl</h2>
       <p class="text-gray-700">
         Solarnutzung = installierte PV-Leistung geteilt durch geschätztes Dachpotenzial, mal 100.
-        Sie zeigt, welchen Anteil ihres Dachpotenzials eine Gemeinde schon nutzt.
+        Die Kennzahl zeigt, welchen Anteil des Dachpotenzials eine Gemeinde schon nutzt.
       </p>
       <ul class="mt-3 space-y-1 text-sm text-gray-700 list-disc list-inside">
         <li><strong>Aktueller Snapshot:</strong> nutzt die installierte Leistung der heute registrierten Anlagen.</li>

--- a/templates/gemeinde/onboarding.html
+++ b/templates/gemeinde/onboarding.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Gemeinde anmelden | OpenLEG",
-  description="Melden Sie Ihre Gemeinde an und ermöglichen Sie Bewohnern, lokale Stromgemeinschaften zu gründen. Kostenlos, kein IT Aufwand.",
+  description="Melden Sie Ihre Gemeinde an und schaffen Sie einen einfachen Einstieg für lokale Stromgemeinschaften. Kostenlos, ohne eigenes IT-Projekt.",
   path=canonical_path,
   og_type="website",
   site_url=site_url,
@@ -20,7 +20,7 @@
     </div>
     <p class="text-sm font-semibold text-brand mb-2">Gemeinde-Anmeldung</p>
     <h1 class="text-3xl font-bold mb-2">Gemeinde anmelden</h1>
-    <p class="text-gray-600 mb-8">Melden Sie Ihre Gemeinde an und ermöglichen Sie Bewohnern, lokale Stromgemeinschaften zu gründen. Kostenlos, kein IT Aufwand.</p>
+    <p class="text-gray-600 mb-8">Melden Sie Ihre Gemeinde an und schaffen Sie einen einfachen Einstieg für lokale Stromgemeinschaften. Kostenlos, ohne eigenes IT-Projekt.</p>
 
     <form id="onboarding-form" class="bg-white rounded-lg shadow-md p-6 space-y-4">
         <div>
@@ -40,13 +40,13 @@
             <input type="text" id="contact-name" placeholder="Vor- und Nachname" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-gray-400 focus:outline-none">
         </div>
         <div class="bg-gray-50 p-4 rounded-lg text-sm">
-            <h4 class="font-medium mb-1">Was Sie erhalten (kostenlos):</h4>
+            <h4 class="font-medium mb-1">Was Ihre Gemeinde kostenlos erhält:</h4>
             <ul class="text-gray-700 space-y-1">
                 <li>&#10003; Eigene Instanz unter <span id="subdomain-preview" class="font-mono text-gray-900">gemeinde.openleg.ch</span></li>
-                <li>&#10003; Bewohner-Registrierung und automatisches Matching</li>
+                <li>&#10003; Registrierung und Matching für Bewohner</li>
                 <li>&#10003; Übersicht über Anmeldungen und Formationsfortschritt</li>
                 <li>&#10003; Alle Dokumente inklusive (Vereinbarung, Verträge, DSO-Anmeldung)</li>
-                <li>&#10003; Keine versteckten Kosten, kein Abo, kein Vendor Lock-in</li>
+                <li>&#10003; Keine versteckten Kosten, kein Abo, keine Anbieterbindung</li>
             </ul>
         </div>
         <button type="submit" class="w-full bg-gray-900 text-white py-3 rounded-lg font-semibold hover:bg-gray-800">Gemeinde anmelden</button>

--- a/templates/gemeinde/profil.html
+++ b/templates/gemeinde/profil.html
@@ -3,7 +3,7 @@
 
 {% block meta %}
     {{ page_meta(
-        title=profile.name ~ " – Energieprofil | OpenLEG",
+        title=profile.name ~ " | Energieprofil | OpenLEG",
         description="Energieprofil und LEG-Potenzial für " ~ profile.name ~ ": Stromtarife, Solarnutzung, Energiewende-Score.",
         path="/gemeinde/profil/" ~ profile.bfs_number,
         og_title=("Solarnutzung " ~ profile.name ~ " | OpenLEG") if profile.get('pv_score_pct') is not none and share_base else None,
@@ -124,7 +124,7 @@
             </p>
             {% else %}
             <p class="text-gray-700">
-                Jede zusätzliche Dachanlage hebt die Solarnutzung von {{ profile.name }}. Legen Sie mit den eigenen Liegenschaften los.
+                Jede zusätzliche Dachanlage hebt die Solarnutzung von {{ profile.name }}. Starten Sie mit den eigenen Liegenschaften.
             </p>
             {% endif %}
 
@@ -218,7 +218,7 @@
         {% if value_gap %}
         <div class="mt-8 bg-gradient-to-r from-brand/10 to-accent/10 rounded-xl p-6 border border-brand/20">
             <h2 class="text-lg font-semibold mb-2">LEG-Potenzial für {{ profile.name }}</h2>
-            <p class="text-gray-600 mb-4">Mit einer Lokalen Elektrizitätsgemeinschaft (LEG) können Haushalte in {{ profile.name }} Netzgebühren einsparen.</p>
+            <p class="text-gray-600 mb-4">Mit einer Lokalen Elektrizitätsgemeinschaft (LEG) können Haushalte in {{ profile.name }} Netzgebühren sparen.</p>
             <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
                 <div>
                     <p class="text-sm text-gray-500">Netzgebühr aktuell</p>
@@ -245,7 +245,7 @@
         <div class="mt-8 bg-brand rounded-xl p-6 text-white md:flex md:items-center md:justify-between gap-6">
             <div>
                 <h2 class="text-xl font-semibold mb-1">Wohnen Sie in {{ profile.name }}?</h2>
-                <p class="text-sm text-white/80 max-w-xl">Gründen Sie mit Ihren Nachbarn eine lokale Stromgemeinschaft und sparen Sie bis 40% auf Netzgebühren. Kostenlos, Ihre Daten bleiben bei Ihnen.</p>
+                <p class="text-sm text-white/80 max-w-xl">Prüfen Sie, ob in Ihrer Nähe schon Interesse besteht. Mit genug Nachbarn können Sie eine lokale Stromgemeinschaft starten und Netzgebühren sparen.</p>
             </div>
             <div class="mt-4 md:mt-0 flex flex-col sm:flex-row gap-2 shrink-0">
                 <a href="/fuer-bewohner" class="inline-block text-center bg-white text-brand px-5 py-2 rounded-lg text-sm font-semibold hover:bg-slate-100">Stromgemeinschaft gründen</a>
@@ -257,13 +257,13 @@
         <div class="mt-6 grid md:grid-cols-2 gap-6">
             <div class="bg-white rounded-xl p-6 shadow-sm border">
                 <h3 class="font-semibold mb-2">API-Zugang</h3>
-                <p class="text-sm text-ink-muted mb-3">Alle Daten auf dieser Seite sind über unsere offene API verfügbar.</p>
+                <p class="text-sm text-ink-muted mb-3">Alle Daten auf dieser Seite gibt es auch über die offene API.</p>
                 <code class="block bg-slate-100 rounded p-3 text-xs mb-3">GET /api/v1/municipalities/{{ profile.bfs_number }}</code>
                 <a href="/api/v1/docs" class="text-brand text-sm font-medium hover:underline">API-Dokumentation &rarr;</a>
             </div>
             <div class="bg-white rounded-xl p-6 shadow-sm border">
                 <h3 class="font-semibold mb-2">Sind Sie die Gemeinde {{ profile.name }}?</h3>
-                <p class="text-sm text-ink-muted mb-3">Starten Sie Ihre eigene Gemeinde-Seite und unterstützen Sie LEGs vor Ort. Kostenlos, kein IT-Projekt.</p>
+                <p class="text-sm text-ink-muted mb-3">Starten Sie eine Gemeinde-Seite, auf der sich interessierte Haushalte melden können. Kostenlos, ohne eigenes IT-Projekt.</p>
                 <a href="/fuer-gemeinden" class="text-brand text-sm font-medium hover:underline">Für Gemeinden &rarr;</a>
             </div>
         </div>

--- a/templates/gemeinde/rangliste.html
+++ b/templates/gemeinde/rangliste.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Solarnutzungs-Rangliste der Schweizer Gemeinden | OpenLEG",
-  description="Wie gut nutzt Ihre Gemeinde ihr Solardach-Potenzial? Vergleichen Sie sich mit fairen Peers nach Kanton, Grösse und Dichte. Offene Daten von BFE und BFS.",
+  description="Wie viel Solardach-Potenzial nutzt Ihre Gemeinde schon? Vergleichen Sie Gemeinden nach Kanton, Grösse und Dichte. Offene Daten von BFE und BFS.",
   path=canonical_path,
   og_type="website",
   site_url=site_url,
@@ -16,9 +16,8 @@
     <header class="mb-6">
       <h1 class="text-3xl font-bold">Solarnutzungs-Rangliste</h1>
       <p class="text-ink-muted mt-2 max-w-2xl">
-        Solarnutzung zeigt, welchen Anteil ihres Dachpotenzials eine Gemeinde schon nutzt.
-        Vergleichen Sie sich mit fairen Peers und holen Sie auf. Die Spitze macht vor,
-        wie es geht, der Rest hat die grösste Chance.
+        Solarnutzung zeigt, welchen Anteil des Dachpotenzials eine Gemeinde schon nutzt.
+        Vergleichen Sie ähnliche Gemeinden und sehen Sie, wo noch Dächer fehlen.
       </p>
       <p class="text-sm text-ink-muted mt-2">
         <a href="/rangliste/vergleich" class="text-brand hover:underline">Zwei Gemeinden vergleichen</a>
@@ -93,7 +92,7 @@
               {{ "%.1f"|format(r.display_score|float) }}%{% if r.score_over_100 %}<span class="text-[10px] text-ink-muted ml-1">+</span>{% endif %}
             </td>
             <td class="px-4 py-3 text-right text-ink-muted">
-              {% if r.pv_untapped_kw is not none %}{{ "{:,}".format(r.pv_untapped_kw|int).replace(",", "'") }} kW{% else %}–{% endif %}
+              {% if r.pv_untapped_kw is not none %}{{ "{:,}".format(r.pv_untapped_kw|int).replace(",", "'") }} kW{% else %}k. A.{% endif %}
             </td>
             <td class="px-4 py-3">
               {% if r.recommendation == 'vorbild' %}

--- a/templates/gemeinde/rangliste_fortschritte.html
+++ b/templates/gemeinde/rangliste_fortschritte.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Grösste Fortschritte bei der Solarnutzung | OpenLEG",
-  description="Welche Schweizer Gemeinden haben im letzten Jahr am meisten Solarnutzung aufgeholt? Fortschritt aus dem 10-Jahres-Panel von BFE und BFS.",
+  description="Welche Schweizer Gemeinden haben im letzten Jahr bei der Solarnutzung aufgeholt? Fortschritt aus dem 10-Jahres-Panel von BFE und BFS.",
   path=canonical_path,
   og_type="website",
   site_url=site_url,
@@ -16,9 +16,9 @@
     <header class="mb-6">
       <h1 class="text-3xl font-bold">Grösste Fortschritte</h1>
       <p class="text-ink-muted mt-2 max-w-2xl">
-        Wer hat im letzten vollen Jahr{% if latest_year %} ({{ latest_year }}){% endif %} am meisten Solarnutzung aufgeholt?
-        Dieser Wert misst die Veränderung in Prozentpunkten, berechnet aus dem 10-Jahres-Panel.
-        Aufholen zählt, egal von welchem Stand aus.
+        Welche Gemeinden haben im letzten vollen Jahr{% if latest_year %} ({{ latest_year }}){% endif %} bei der Solarnutzung aufgeholt?
+        Der Wert misst die Veränderung in Prozentpunkten, berechnet aus dem 10-Jahres-Panel.
+        Auch kleine Gemeinden mit tiefem Startwert können hier sichtbar werden.
       </p>
       <p class="text-sm text-ink-muted mt-2">
         <a href="/rangliste/methodik" class="text-brand hover:underline">Methodik und Datenquellen</a>

--- a/templates/gemeinde/vergleich.html
+++ b/templates/gemeinde/vergleich.html
@@ -59,16 +59,16 @@
           <div>
             <p class="text-xs text-ink-muted uppercase tracking-wide">Solarnutzung</p>
             <p class="text-3xl font-bold {{ 'text-brand' if leads else 'text-ink' }}">
-              {% if g.display_score is not none %}{{ "%.1f"|format(g.display_score|float) }}%{% if g.score_over_100 %}<span class="text-xs ml-1">+</span>{% endif %}{% else %}–{% endif %}
+              {% if g.display_score is not none %}{{ "%.1f"|format(g.display_score|float) }}%{% if g.score_over_100 %}<span class="text-xs ml-1">+</span>{% endif %}{% else %}k. A.{% endif %}
             </p>
           </div>
           <div>
             <p class="text-xs text-ink-muted uppercase tracking-wide">Nationaler Rang</p>
-            <p class="text-lg font-semibold">{% if g.pv_rank %}{{ g.pv_rank }}{% else %}–{% endif %}</p>
+            <p class="text-lg font-semibold">{% if g.pv_rank %}{{ g.pv_rank }}{% else %}k. A.{% endif %}</p>
           </div>
           <div>
             <p class="text-xs text-ink-muted uppercase tracking-wide">Ungenutztes Potenzial</p>
-            <p class="text-lg font-semibold">{% if g.pv_untapped_kw is not none %}{{ "{:,}".format(g.pv_untapped_kw|int).replace(",", "'") }} kW{% else %}–{% endif %}</p>
+            <p class="text-lg font-semibold">{% if g.pv_untapped_kw is not none %}{{ "{:,}".format(g.pv_untapped_kw|int).replace(",", "'") }} kW{% else %}k. A.{% endif %}</p>
           </div>
         </div>
       </div>

--- a/templates/gemeinde/verzeichnis.html
+++ b/templates/gemeinde/verzeichnis.html
@@ -3,8 +3,8 @@
 
 {% block meta %}
 {{ page_meta(
-  title="Gemeindeverzeichnis – Energieprofile Schweizer Gemeinden | OpenLEG",
-  description="Schweizer Gemeinden im Energiewende-Vergleich: Stromtarife, Solarpotenzial, LEG-Ersparnis. Offene Daten von ElCom, Sonnendach, Energie Reporter.",
+  title="Gemeindeverzeichnis | Energieprofile Schweizer Gemeinden | OpenLEG",
+  description="Energieprofile Schweizer Gemeinden: Stromtarife, Solarpotenzial und mögliche LEG-Ersparnis. Offene Daten von ElCom, Sonnendach und Energie Reporter.",
   path=canonical_path,
   og_type="website",
   site_url=site_url,
@@ -16,7 +16,7 @@
 {% block content %}
     <main class="max-w-6xl mx-auto px-4 py-8">
         <h1 class="text-3xl font-bold mb-2">Gemeindeverzeichnis</h1>
-        <p class="text-gray-600 mb-6">Energieprofile Schweizer Gemeinden: Stromtarife, LEG-Potenzial, Energiewende-Score.</p>
+        <p class="text-gray-600 mb-6">Stromtarife, Solarpotenzial und mögliche LEG-Ersparnis für Schweizer Gemeinden.</p>
 
         <!-- Search + Filter -->
         <div class="flex flex-col md:flex-row gap-4 mb-6">
@@ -109,7 +109,7 @@
         <div class="mt-8 bg-gray-100 rounded-xl p-6 border">
             <div class="flex flex-col md:flex-row justify-between items-center gap-4">
                 <div>
-                    <h3 class="font-semibold">Diese Daten programmatisch nutzen</h3>
+                    <h3 class="font-semibold">Diese Daten per API nutzen</h3>
                     <p class="text-sm text-gray-600">Alle Gemeindedaten sind frei über unsere REST API verfügbar. Kein API-Key nötig.</p>
                 </div>
                 <a href="/api/v1/docs" class="bg-brand text-ink px-6 py-2 rounded-lg text-sm font-medium hover:bg-brand-dark whitespace-nowrap">API-Dokumentation</a>

--- a/templates/how-it-works.html
+++ b/templates/how-it-works.html
@@ -7,7 +7,7 @@
   description="So funktioniert eine Lokale Elektrizitätsgemeinschaft in der Schweiz: Adresse prüfen, Nachbarn finden, gründen, Netzbetreiber melden und Strom teilen.",
   path="/how-it-works",
   og_title="So funktioniert eine Stromgemeinschaft | OpenLEG",
-  og_description="Der einfache Ablauf von der Adresse bis zur aktiven Lokalen Elektrizitätsgemeinschaft.",
+  og_description="Der Ablauf von der Adresse bis zur aktiven Lokalen Elektrizitätsgemeinschaft.",
   og_type="article",
   og_image="/static/images/og-image.png",
   site_url=site_url,
@@ -36,14 +36,14 @@
 
   <div class="max-w-4xl mx-auto px-4 py-12">
     <h1 class="text-4xl font-bold mb-4">So funktioniert eine Stromgemeinschaft</h1>
-    <p class="text-ink-muted mb-8">Von der Idee zur aktiven LEG: was Bewohner und Gemeinden wissen müssen.</p>
+    <p class="text-ink-muted mb-8">Was zuerst passiert, wer was entscheidet und wann der Netzbetreiber ins Spiel kommt.</p>
 
     <div class="space-y-10">
       <section class="grid md:grid-cols-[3rem_1fr] gap-4">
         <div class="w-12 h-12 rounded-full bg-brand text-ink flex items-center justify-center font-bold text-lg">1</div>
         <div>
           <h2 class="text-2xl font-semibold mb-2">Adresse prüfen</h2>
-          <p class="text-ink-muted">Geben Sie Ihre Adresse auf openleg.ch ein. Das System prüft Ihr Solarpotenzial (via BFE Sonnendach) und zeigt, ob Nachbarn in Ihrer Nähe ebenfalls Interesse haben. Alles anonymisiert.</p>
+          <p class="text-ink-muted">Geben Sie Ihre Adresse ein. OpenLEG prüft das Solarpotenzial mit BFE Sonnendach und zeigt, ob in Ihrer Nähe schon Nachbarn Interesse angemeldet haben. Die Karte bleibt anonymisiert.</p>
         </div>
       </section>
 
@@ -51,7 +51,7 @@
         <div class="w-12 h-12 rounded-full bg-brand text-ink flex items-center justify-center font-bold text-lg">2</div>
         <div>
           <h2 class="text-2xl font-semibold mb-2">Nachbarn finden</h2>
-          <p class="text-ink-muted">Registrieren Sie sich mit E-Mail. Das System findet automatisch Haushalte in Ihrem Umkreis (max. 150m), die ebenfalls mitmachen wollen. Sobald genug Nachbarn zusammen kommen, kann die Gründung starten.</p>
+          <p class="text-ink-muted">Registrieren Sie sich mit Ihrer E-Mail. OpenLEG sucht Haushalte im Umkreis von höchstens 150 m. Sobald genug Interesse da ist, lohnt sich der nächste Schritt.</p>
         </div>
       </section>
 
@@ -59,7 +59,7 @@
         <div class="w-12 h-12 rounded-full bg-brand text-ink flex items-center justify-center font-bold text-lg">3</div>
         <div>
           <h2 class="text-2xl font-semibold mb-2">Stromgemeinschaft gründen</h2>
-          <p class="text-ink-muted">Wählen Sie ein Verteilmodell (gleichmässig, proportional, individuell). OpenLEG generiert automatisch alle nötigen Dokumente: Gemeinschaftsvereinbarung, Teilnehmerverträge, Anmeldung beim Netzbetreiber.</p>
+          <p class="text-ink-muted">Wählen Sie ein Verteilmodell: gleichmässig, proportional oder individuell. OpenLEG erstellt die Gemeinschaftsvereinbarung, Teilnehmerverträge und die Anmeldung beim Netzbetreiber.</p>
         </div>
       </section>
 
@@ -67,7 +67,7 @@
         <div class="w-12 h-12 rounded-full bg-brand text-ink flex items-center justify-center font-bold text-lg">4</div>
         <div>
           <h2 class="text-2xl font-semibold mb-2">Netzbetreiber melden</h2>
-          <p class="text-ink-muted">Die Anmeldung geht direkt an Ihren Netzbetreiber. Dieser muss innert 3 Monaten einen Smart Meter installieren (Art. 17e StromVG). OpenLEG überwacht den Status und erinnert bei Verzögerungen.</p>
+          <p class="text-ink-muted">Die Anmeldung geht an Ihren Netzbetreiber. Er muss innert 3 Monaten einen Smart Meter installieren (Art. 17e StromVG). OpenLEG zeigt den Status und erinnert, wenn etwas liegen bleibt.</p>
         </div>
       </section>
 
@@ -75,7 +75,7 @@
         <div class="w-12 h-12 rounded-full bg-brand text-ink flex items-center justify-center font-bold text-lg">5</div>
         <div>
           <h2 class="text-2xl font-semibold mb-2">Strom teilen, Geld sparen</h2>
-          <p class="text-ink-muted">Ihre LEG ist aktiv. Solarstrom wird lokal geteilt, alle 15 Minuten abgerechnet. Sie sparen bis 40% auf Netzgebühren (gleiche Netzebene) oder 20% (mit Ebenenwechsel). Auf einem typischen Haushalt (4'500 kWh/Jahr) sind das CHF 90 bis 270 pro Jahr.</p>
+          <p class="text-ink-muted">Ihre LEG ist aktiv. Die Mitglieder teilen Solarstrom lokal und rechnen alle 15 Minuten ab. Je nach Netzebene sparen Haushalte bis 40% auf Netzgebühren. Bei 4'500 kWh pro Jahr sind das grob CHF 90 bis 270.</p>
         </div>
       </section>
     </div>
@@ -91,11 +91,11 @@
 
     <div class="mt-6 bg-amber-50 border border-amber-200 rounded-xl p-6">
       <h2 class="text-2xl font-bold mb-3">Für Gemeinden</h2>
-      <p class="text-ink-muted mb-3">Jede Gemeinde kann kostenlos eine eigene OpenLEG-Instanz erhalten. Bewohner registrieren sich auf gemeinde.openleg.ch, das System findet passende Nachbarn und begleitet die Gründung.</p>
+      <p class="text-ink-muted mb-3">Jede Gemeinde kann kostenlos mit einer eigenen OpenLEG-Seite starten. Bewohner melden dort Interesse an, OpenLEG findet passende Nachbarn und führt durch die Gründung.</p>
       <ul class="list-disc list-inside text-ink-muted space-y-1 mb-4">
         <li>Eigene Webseite mit Gemeinde-Branding</li>
-        <li>Automatisches Nachbarschafts-Matching</li>
-        <li>Dokumentengenerierung und Netzbetreiber-Anmeldung</li>
+        <li>Nachbarschafts-Matching</li>
+        <li>Dokumente und Netzbetreiber-Anmeldung</li>
         <li>Übersicht über alle Anmeldungen und Fortschritt</li>
       </ul>
       <a href="/gemeinde/onboarding" class="inline-block bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Gemeinde anmelden</a>
@@ -105,8 +105,8 @@
       <h2 class="text-2xl font-bold mb-3">Ihre Daten, Ihre Kontrolle</h2>
       <div class="text-ink-muted space-y-2">
         <p>OpenLEG verkauft keine Daten. Nicht an Energieversorger, nicht an Dritte, nicht in aggregierter Form. Ihre Smart-Meter-Daten bleiben in Ihrer Stromgemeinschaft.</p>
-        <p>Die Plattform ist Open Source (AGPL-3.0). Der gesamte Code ist auf GitHub einsehbar. Sie können jederzeit alle Ihre Daten exportieren oder löschen lassen.</p>
-        <p>Gehostet auf Schweizer Infrastruktur, konform mit dem neuen Datenschutzgesetz (nDSG).</p>
+        <p>Die Plattform ist Open Source (AGPL-3.0). Der gesamte Code liegt auf GitHub. Sie können Ihre Daten jederzeit exportieren oder löschen lassen.</p>
+        <p>OpenLEG läuft auf Schweizer Infrastruktur und richtet sich nach dem neuen Datenschutzgesetz (nDSG).</p>
       </div>
     </div>
 

--- a/templates/impressum.html
+++ b/templates/impressum.html
@@ -5,11 +5,11 @@
 
 {% block meta %}
 {{ page_meta(
-  title="Impressum - " ~ platform_name,
-  description="Impressum von " ~ platform_name ~ " - Kontakt und rechtliche Hinweise zum kostenlosen Service für Lokale Elektrizitätsgemeinschaften in " ~ city_name ~ ".",
+  title="Impressum | " ~ platform_name,
+  description="Impressum von " ~ platform_name ~ ": Kontakt und rechtliche Hinweise zum kostenlosen Service für Lokale Elektrizitätsgemeinschaften in " ~ city_name ~ ".",
   path="/impressum",
-  og_title="Impressum - " ~ platform_name,
-  og_description="Kontakt und rechtliche Hinweise zum kostenlosen " ~ platform_name ~ "-Service.",
+  og_title="Impressum | " ~ platform_name,
+  og_description="Kontakt und rechtliche Hinweise zu " ~ platform_name ~ ".",
   og_type="article",
   robots="index, follow",
   site_url=site_url,
@@ -38,21 +38,21 @@
 
     <p class="mb-2"><strong>Haftungsausschluss</strong></p>
     <p class="mb-4">
-      Alle Inhalte wurden mit grösster Sorgfalt erstellt. Für die Richtigkeit, Vollständigkeit und
-      Aktualität der Inhalte wird keine Gewähr übernommen. Verlinkte externe Inhalte liegen in
+      Wir erstellen die Inhalte sorgfältig. Für Richtigkeit, Vollständigkeit und
+      Aktualität übernehmen wir keine Gewähr. Verlinkte externe Inhalte liegen in
       der Verantwortung der jeweiligen Anbieter.
     </p>
 
     <p class="mb-2"><strong>Urheberrecht</strong></p>
     <p class="mb-4">
-      Die auf dieser Website veröffentlichten Inhalte unterliegen dem Urheberrecht. Jede Verwertung
+      Die Inhalte auf dieser Website unterliegen dem Urheberrecht. Jede Verwertung
       bedarf der vorherigen Zustimmung der Rechteinhaber, soweit nicht gesetzlich zulässig.
     </p>
 
     <p class="mb-2"><strong>Nutzungshinweis</strong></p>
     <p class="mb-4">
-      Dies ist ein kostenloser Service. Ihre Daten werden ausschliesslich für das Matching innerhalb von {{ platform_name }} verwendet
-      und nicht an Dritte weitergegeben.
+      Dies ist ein kostenloser Service. Wir verwenden Ihre Daten ausschliesslich für das Matching innerhalb von {{ platform_name }}
+      und geben sie nicht an Dritte weiter.
     </p>
 
     <a href="/" class="inline-block mt-6 text-sm underline">Zurück zur Startseite</a>

--- a/templates/index.html
+++ b/templates/index.html
@@ -4,10 +4,10 @@
 {% block meta %}
 {{ page_meta(
   title="OpenLEG: Freie Infrastruktur für Schweizer Stromgemeinschaften",
-  description="OpenLEG ist die kostenlose Open Source Plattform für Lokale Elektrizitätsgemeinschaften (LEG) in der Schweiz. Nachbarn finden, Stromgemeinschaft gründen, Netzgebühren sparen.",
+  description="OpenLEG hilft Nachbarn und Gemeinden, lokale Stromgemeinschaften in der Schweiz zu starten. Adresse prüfen, Nachbarn finden, Netzgebühren sparen.",
   path="/",
   og_title="OpenLEG: Freie Infrastruktur für Schweizer Stromgemeinschaften",
-  og_description="Kostenlos, Open Source, gehostet in der Schweiz. Gründen Sie Ihre lokale Stromgemeinschaft und sparen Sie bis 40% auf Netzgebühren.",
+  og_description="Prüfen Sie Ihre Adresse, finden Sie Nachbarn und starten Sie eine lokale Stromgemeinschaft. Kostenlos, Open Source, Schweizer Hosting.",
   og_image="/static/images/og-image.png",
   site_url=site_url
 ) }}
@@ -42,7 +42,7 @@
         <div class="mt-6" aria-live="polite">
           <div data-seg-panel="bewohner">
             <h1 class="text-4xl md:text-5xl font-bold tracking-tight">Ihr Strom. Ihre Nachbarn. Ihre Gemeinschaft.</h1>
-            <p class="mt-4 text-lg text-ink-muted max-w-xl">Gründen Sie eine lokale Stromgemeinschaft (LEG) und sparen Sie bis 40% auf Netzgebühren. Kostenlos, Open Source, Ihre Daten bleiben bei Ihnen.</p>
+            <p class="mt-4 text-lg text-ink-muted max-w-xl">Prüfen Sie Ihre Adresse, finden Sie Nachbarn und starten Sie eine lokale Stromgemeinschaft. OpenLEG zeigt den nächsten Schritt und verkauft keine Daten.</p>
             <div class="mt-6 flex flex-col sm:flex-row gap-3">
               <a href="#registrieren" class="bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Adresse prüfen</a>
               <a href="/how-it-works" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">So funktioniert's</a>
@@ -57,7 +57,7 @@
 
           <div data-seg-panel="gemeinde" class="hidden">
             <h1 class="text-4xl md:text-5xl font-bold tracking-tight">Sehen Sie, wo Ihre Gemeinde bei der Solarnutzung steht.</h1>
-            <p class="mt-4 text-lg text-ink-muted max-w-xl">Vergleichen Sie sich mit vergleichbaren Gemeinden, holen Sie auf und gründen Sie lokale Stromgemeinschaften. Kostenlos, kein IT Projekt.</p>
+            <p class="mt-4 text-lg text-ink-muted max-w-xl">Vergleichen Sie Ihre Solarnutzung mit ähnlichen Gemeinden. OpenLEG zeigt, welche Dächer fehlen und wie Ihre Gemeinde eine LEG startet.</p>
             <div class="mt-6 flex flex-col sm:flex-row gap-3">
               <a href="/rangliste" class="bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Rangliste ansehen</a>
               <a href="/gemeinde/onboarding" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">Gemeinde anmelden</a>
@@ -94,8 +94,8 @@
     <div class="max-w-6xl mx-auto px-4">
       <div class="max-w-2xl mb-8">
         <p class="text-sm font-semibold text-brand mb-2">Für wen ist OpenLEG?</p>
-        <h2 class="text-3xl font-bold tracking-tight">Vier Wege, ein Ziel: funktionierende Stromgemeinschaften.</h2>
-        <p class="text-ink-muted mt-3">Wählen Sie Ihren Einstieg. Jeder Weg führt zu einem konkreten nächsten Schritt, kostenlos und ohne Anmeldung zum Lesen.</p>
+        <h2 class="text-3xl font-bold tracking-tight">Starten Sie dort, wo Sie heute stehen.</h2>
+        <p class="text-ink-muted mt-3">Bewohner prüfen ihre Adresse. Gemeinden sehen ihr Solarpotenzial. Betreiber finden den Gründungsweg. Entwickler bekommen Code und Daten.</p>
       </div>
 
       <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
@@ -104,7 +104,7 @@
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 11.5 12 4l9 7.5"/><path d="M5 10v10h14V10"/><path d="M9 20v-6h6v6"/></svg>
           </span>
           <h3 class="font-semibold text-lg">Bewohner und Gründer</h3>
-          <p class="text-sm text-ink-muted mt-1 flex-1">Adresse prüfen, Nachbarn finden und Ihre lokale Stromgemeinschaft starten.</p>
+          <p class="text-sm text-ink-muted mt-1 flex-1">Prüfen Sie Ihre Adresse und sehen Sie, ob in Ihrer Nähe schon Interesse besteht.</p>
           <span class="mt-4 text-sm font-semibold text-brand inline-flex items-center gap-1">Einstieg für Bewohner <span aria-hidden="true" class="transition group-hover:translate-x-0.5">&rarr;</span></span>
         </a>
 
@@ -113,7 +113,7 @@
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 4 14h7l-1 8 9-12h-7l1-8Z"/></svg>
           </span>
           <h3 class="font-semibold text-lg">LEG-Betreiber</h3>
-          <p class="text-sm text-ink-muted mt-1 flex-1">Gemeinschaft gründen, Mitglieder verwalten, Eigenverbrauch abrechnen.</p>
+          <p class="text-sm text-ink-muted mt-1 flex-1">Klären Sie Mitglieder, Verträge, Netzbetreiber und Abrechnung.</p>
           <span class="mt-4 text-sm font-semibold text-brand inline-flex items-center gap-1">LEG gründen <span aria-hidden="true" class="transition group-hover:translate-x-0.5">&rarr;</span></span>
         </a>
 
@@ -122,7 +122,7 @@
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M3 21h18"/><path d="M5 21V7l7-4 7 4v14"/><path d="M9 9h.01M12 9h.01M15 9h.01M9 13h.01M12 13h.01M15 13h.01"/></svg>
           </span>
           <h3 class="font-semibold text-lg">Gemeinde</h3>
-          <p class="text-sm text-ink-muted mt-1 flex-1">Solarnutzung vergleichen, aufholen und eine eigene Gemeinde-Seite starten.</p>
+          <p class="text-sm text-ink-muted mt-1 flex-1">Vergleichen Sie Ihre Gemeinde und starten Sie eine Seite für Interessierte.</p>
           <span class="mt-4 text-sm font-semibold text-brand inline-flex items-center gap-1">Für Gemeinden <span aria-hidden="true" class="transition group-hover:translate-x-0.5">&rarr;</span></span>
         </a>
 
@@ -131,7 +131,7 @@
             <svg class="h-5 w-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m8 6-6 6 6 6"/><path d="m16 6 6 6-6 6"/></svg>
           </span>
           <h3 class="font-semibold text-lg">Entwickler und Self-Hosting</h3>
-          <p class="text-sm text-ink-muted mt-1 flex-1">Code lesen, freie API nutzen oder OpenLEG auf eigener Infrastruktur betreiben.</p>
+          <p class="text-sm text-ink-muted mt-1 flex-1">Lesen Sie den Code, nutzen Sie die API oder betreiben Sie OpenLEG selbst.</p>
           <span class="mt-4 text-sm font-semibold text-brand inline-flex items-center gap-1">Codebase und Install <span aria-hidden="true" class="transition group-hover:translate-x-0.5">&rarr;</span></span>
         </a>
       </div>
@@ -168,8 +168,8 @@
     <div class="max-w-6xl mx-auto px-4">
       <div class="grid md:grid-cols-2 gap-10 items-center">
         <div>
-          <h2 class="text-3xl font-bold">Für Gemeinden: vergleichen, aufholen, gründen.</h2>
-          <p class="text-ink-muted mt-3">Die Solarnutzungs-Rangliste zeigt, wie viel Dachpotenzial Ihre Gemeinde schon nutzt und wer in Ihrer Liga vorangeht. Daraus wird ein konkreter nächster Schritt.</p>
+          <h2 class="text-3xl font-bold">Für Gemeinden: Potenzial sehen, Einstieg schaffen.</h2>
+          <p class="text-ink-muted mt-3">Die Rangliste zeigt, wie viel Dachpotenzial Ihre Gemeinde nutzt, welche vergleichbaren Gemeinden weiter sind und wie viele Dächer bis zum oberen Viertel fehlen.</p>
           <ol class="mt-5 grid md:grid-cols-3 gap-3 text-sm">
             <li class="rounded-lg border border-slate-200 bg-white p-3">
               <div class="font-semibold">1. Rang prüfen</div>
@@ -177,7 +177,7 @@
             </li>
             <li class="rounded-lg border border-slate-200 bg-white p-3">
               <div class="font-semibold">2. Ziel sehen</div>
-              <p class="text-ink-muted mt-1">Dächer bis zum oberen Viertel erkennen.</p>
+              <p class="text-ink-muted mt-1">Sehen, wie viele Dächer bis zum oberen Viertel fehlen.</p>
             </li>
             <li class="rounded-lg border border-slate-200 bg-white p-3">
               <div class="font-semibold">3. Gemeinde anmelden</div>
@@ -198,7 +198,7 @@
         <div class="rounded-2xl border border-slate-200 bg-amber-50 p-6">
           <div class="text-sm text-ink-muted">Kurz gesagt</div>
           <div class="mt-2 text-2xl font-semibold">In Tagen live, nicht in Monaten.</div>
-          <div class="mt-3 text-ink-muted">Kostenlos. Kein IT Projekt. Kein Aufwand für Ihre Verwaltung. Wir übernehmen Technik und Betrieb.</div>
+          <div class="mt-3 text-ink-muted">Kostenlos starten. Ohne eigenes IT-Projekt. OpenLEG übernimmt Technik und Betrieb, wenn Ihre Gemeinde das möchte.</div>
         </div>
       </div>
     </div>
@@ -266,8 +266,8 @@
   <section id="bewohner" class="py-16 bg-[#f6f4ef]">
     <div class="max-w-6xl mx-auto px-4">
       <div class="mb-6">
-        <h2 class="text-3xl font-bold">Nachbarn finden, Stromgemeinschaft gründen</h2>
-        <p class="text-ink-muted mt-2">Geben Sie Ihre Adresse ein und sehen Sie, wer in Ihrer Nähe ebenfalls mitmachen will. Alles anonymisiert, Ihre Daten bleiben bei Ihnen.</p>
+        <h2 class="text-3xl font-bold">Erst Adresse prüfen, dann Nachbarn finden</h2>
+        <p class="text-ink-muted mt-2">Geben Sie Ihre Adresse ein. OpenLEG prüft die Umgebung, zeigt anonymisierte Interessierte und sagt, ob sich der Start einer LEG lohnt.</p>
         {% if user_count > 0 %}
         <p class="text-ink-muted mt-2">Bereits <strong class="text-ink">{{ user_count }}</strong> Haushalte registriert</p>
         {% endif %}
@@ -304,7 +304,7 @@
               <div data-address-state="not-found" class="hidden rounded-lg border border-amber-200 bg-amber-50 p-3 text-amber-800">Noch keine Nachbarn gefunden. Sie können den Startpunkt setzen und andere einladen.</div>
             </div>
             <div id="profile-summary" class="text-sm text-ink-muted mt-2 hidden"></div>
-            <p id="address-privacy" class="text-xs text-ink-muted mt-3">Ihre Adresse wird nur zur Prüfung verwendet. Kartenpunkte werden um 120m versetzt, Smart-Meter-Daten bleiben in Ihrer LEG und werden nicht verkauft.</p>
+            <p id="address-privacy" class="text-xs text-ink-muted mt-3">Wir nutzen Ihre Adresse nur für die Prüfung. Kartenpunkte werden um 120 m versetzt. Smart-Meter-Daten bleiben in Ihrer LEG und werden nicht verkauft.</p>
             <button id="btn-check" class="w-full bg-brand text-ink py-2 rounded-lg mt-3 font-medium hover:bg-brand-dark disabled:opacity-50" disabled>Adresse prüfen</button>
           </div>
           <div id="step-register" class="hidden">
@@ -346,7 +346,7 @@
           <ul class="mt-4 space-y-2 text-ink-muted list-disc list-inside">
             <li>Gesamter Code auf GitHub, AGPL-3.0 Lizenz</li>
             <li>Freie API für Schweizer Energiedaten (ElCom Tarife, Sonnendach, Energie Reporter)</li>
-            <li>Kein Vendor Lock-in: jederzeit selbst hosten oder migrieren</li>
+            <li>Keine Anbieterbindung: jederzeit selbst hosten oder migrieren</li>
             <li>Community-Beiträge willkommen</li>
           </ul>
           <div class="mt-6 flex flex-col sm:flex-row gap-3">

--- a/templates/leg_gruenden.html
+++ b/templates/leg_gruenden.html
@@ -3,8 +3,8 @@
 
 {% block meta %}
 {{ page_meta(
-  title="LEG gründen: Der komplette Leitfaden für die Schweiz | OpenLEG",
-  description="Schritt-für-Schritt-Anleitung zur Gründung einer Lokalen Elektrizitätsgemeinschaft (LEG) in der Schweiz. Rechtliche Anforderungen, Zeitplan, Dokumente und Kosten.",
+  title="LEG gründen: Anleitung für die Schweiz | OpenLEG",
+  description="Anleitung zur Gründung einer Lokalen Elektrizitätsgemeinschaft (LEG) in der Schweiz. Voraussetzungen, Mitglieder, Rechtsform, Dokumente und Kosten.",
   path="/leg-gruenden",
   og_title="LEG gründen: Leitfaden für die Schweiz | OpenLEG",
   og_description="Schritt für Schritt zur Lokalen Elektrizitätsgemeinschaft: Voraussetzungen, Mitglieder, Rechtsform, Dokumente und Netzbetreiber.",
@@ -30,10 +30,10 @@
 {% block content %}
   <main class="max-w-4xl mx-auto px-4 py-12">
     <header class="text-center mb-12">
-      <h1 class="text-5xl font-bold mb-4">LEG gründen: Der komplette Leitfaden</h1>
+      <h1 class="text-5xl font-bold mb-4">LEG gründen: der Weg von der Idee zum Betrieb</h1>
       <p class="text-xl text-ink-muted max-w-3xl mx-auto">
         Seit dem Mantelerlass (Januar 2026) können Sie eine Lokale Elektrizitätsgemeinschaft (LEG) gründen. 
-        Diese Anleitung zeigt Ihnen genau, wie es geht.
+        Diese Anleitung zeigt die Entscheidungen, Dokumente und Fristen, die Sie dafür klären müssen.
       </p>
     </header>
 
@@ -285,7 +285,7 @@
           <div class="flex-1">
             <h3 class="text-2xl font-bold mb-3">Betrieb und Abrechnung</h3>
             <p class="text-ink-muted mb-4">
-              Nach der Inbetriebnahme läuft Ihre LEG automatisch:
+              Nach der Inbetriebnahme braucht Ihre LEG vor allem saubere Daten:
             </p>
             <ul class="space-y-2 text-ink-muted mb-4">
               <li class="flex items-start gap-2">
@@ -307,8 +307,8 @@
             </ul>
             <div class="p-4 bg-green-50 rounded-lg border border-green-200">
               <p class="text-sm text-green-900">
-                <strong>OpenLEG-Software:</strong> Unsere Plattform automatisiert die Abrechnung komplett. 
-                Sie laden einfach die CSV-Datei vom VNB hoch.
+                <strong>OpenLEG-Software:</strong> OpenLEG übernimmt die Abrechnung.
+                Sie laden die CSV-Datei vom VNB hoch.
               </p>
             </div>
           </div>
@@ -416,8 +416,8 @@
     <section class="bg-brand text-ink rounded-xl shadow-md p-10 mt-12 text-center">
       <h2 class="text-3xl font-bold mb-4">Bereit für Ihre LEG?</h2>
       <p class="text-white/90 mb-6 max-w-2xl mx-auto">
-        Mit OpenLEG wird die Gründung und Verwaltung Ihrer LEG kinderleicht. 
-        Unsere Software automatisiert die Abrechnung, dokumentiert alles rechtssicher und ist komplett kostenlos.
+        OpenLEG nimmt Ihnen nicht die Gründung ab, aber es räumt viel Kleinarbeit weg:
+        Abrechnung, Dokumente, Vorlagen und ein sauberer Einstieg für neue Mitglieder.
       </p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="/leg-kalkulator" class="inline-block bg-white text-brand px-8 py-3 rounded-lg font-bold hover:bg-slate-100">
@@ -435,11 +435,11 @@
       <div class="space-y-4">
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Kann ich eine LEG gründen, wenn ich keine Solaranlage habe?</summary>
-          <p class="mt-3 text-ink-muted">Nein, mindestens ein Teilnehmer muss Strom produzieren. Aber Sie müssen nicht selbst der Produzent sein – Sie können einer LEG beitreten, bei der ein Nachbar die Solaranlage hat.</p>
+          <p class="mt-3 text-ink-muted">Nein, mindestens ein Teilnehmer muss Strom produzieren. Sie müssen aber nicht selbst der Produzent sein. Sie können einer LEG beitreten, bei der ein Nachbar die Solaranlage hat.</p>
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Wie viel Geld spare ich mit einer LEG?</summary>
-          <p class="mt-3 text-ink-muted">Das hängt von Ihrem Verbrauch und der lokalen Produktion ab. Typischerweise sparen LEG-Mitglieder 10-30% auf den Netznutzungsentgelt. Nutzen Sie unseren <a href="/leg-kalkulator" class="text-brand underline">LEG-Kalkulator</a> für eine genaue Berechnung.</p>
+          <p class="mt-3 text-ink-muted">Das hängt von Ihrem Verbrauch und der lokalen Produktion ab. Typischerweise sparen LEG-Mitglieder 10 bis 30% bei den Netznutzungsentgelten. Nutzen Sie unseren <a href="/leg-kalkulator" class="text-brand underline">LEG-Kalkulator</a> für eine genauere Schätzung.</p>
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Muss ich einen Smart Meter haben?</summary>
@@ -451,7 +451,7 @@
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Was passiert, wenn meine Gemeinde keine LEG-Plattform hat?</summary>
-          <p class="mt-3 text-ink-muted">Sie können trotzdem eine LEG gründen – es ist nur etwas mehr Aufwand. Oder Sie schlagen Ihrer Gemeinde vor, bei OpenLEG mitzumachen (für Gemeinden kostenlos).</p>
+          <p class="mt-3 text-ink-muted">Sie können trotzdem eine LEG gründen. Es braucht dann mehr Eigenarbeit. Oder Sie schlagen Ihrer Gemeinde vor, bei OpenLEG mitzumachen. Für Gemeinden ist der Plattformstart kostenlos.</p>
         </details>
       </div>
     </section>

--- a/templates/leg_kalkulator.html
+++ b/templates/leg_kalkulator.html
@@ -4,10 +4,10 @@
 {% block meta %}
 {{ page_meta(
   title="LEG-Kalkulator: Sparpotenzial berechnen | OpenLEG",
-  description="Berechnen Sie, wie viel Sie mit einer Lokalen Elektrizitätsgemeinschaft (LEG) sparen. Interaktiver Rechner mit aktuellen Tarifdaten für alle Schweizer Gemeinden.",
+  description="Schätzen Sie, wie viel Sie mit einer Lokalen Elektrizitätsgemeinschaft (LEG) sparen. Rechner mit Schweizer Tarifdaten.",
   path="/leg-kalkulator",
   og_title="LEG-Kalkulator: Sparpotenzial berechnen | OpenLEG",
-  og_description="Berechnen Sie Ihr Sparpotenzial mit einer Lokalen Elektrizitätsgemeinschaft anhand von Schweizer Tarifdaten.",
+  og_description="Schätzen Sie Ihr Sparpotenzial mit einer Lokalen Elektrizitätsgemeinschaft anhand von Schweizer Tarifdaten.",
   og_type="website",
   keywords="LEG Rechner, Stromgemeinschaft Kalkulator, LEG Sparpotenzial, Netzkosten Rechner, Stromkosten Schweiz",
   site_url=site_url
@@ -59,7 +59,7 @@
     <header class="text-center mb-12">
       <h1 class="text-5xl font-bold mb-4">LEG-Kalkulator</h1>
       <p class="text-xl text-ink-muted max-w-3xl mx-auto">
-        Berechnen Sie in 2 Minuten, wie viel Sie mit einer Lokalen Elektrizitätsgemeinschaft (LEG) sparen können.
+        Schätzen Sie in 2 Minuten, wie viel eine Lokale Elektrizitätsgemeinschaft (LEG) bei Ihren Netzkosten bringen kann.
       </p>
     </header>
 
@@ -116,7 +116,7 @@
             <span>15'000 kWh</span>
           </div>
           <p class="text-sm text-ink-muted mt-2">
-            💡 Durchschnitt Schweiz: 1-Person: 1'500 kWh | 2-Personen: 2'500 kWh | 4-Personen: 4'500 kWh
+            Richtwerte Schweiz: 1 Person ca. 1'500 kWh, 2 Personen ca. 2'500 kWh, 4 Personen ca. 4'500 kWh.
           </p>
         </div>
       </section>
@@ -143,7 +143,7 @@
             <span>100%</span>
           </div>
           <p class="text-sm text-ink-muted mt-2">
-            Dies hängt davon ab, wann die Solaranlage produziert und wann Sie verbrauchen. Typisch: 40-80%.
+            Das hängt davon ab, wann die Solaranlage produziert und wann Sie Strom brauchen. Typisch sind 40 bis 80%.
           </p>
         </div>
       </section>
@@ -230,7 +230,7 @@
           <!-- CTA -->
           <div class="text-center">
             <a href="/leg-gruenden" class="inline-block bg-brand text-ink px-8 py-3 rounded-lg font-bold hover:bg-brand-dark">
-              LEG gründen →
+              LEG gründen &rarr;
             </a>
           </div>
         </div>
@@ -243,15 +243,15 @@
       <h2 class="text-3xl font-bold mb-6">So funktioniert der Rechner</h2>
       <div class="space-y-4 text-ink-muted">
         <p>
-          Dieser Kalkulator berechnet Ihre potenzielle Einsparung durch eine Lokale Elektrizitätsgemeinschaft (LEG).
+          Dieser Rechner schätzt Ihre mögliche Einsparung durch eine Lokale Elektrizitätsgemeinschaft (LEG).
         </p>
         <p>
-          <strong>Grundlage:</strong> Wir verwenden offizielle Tarifdaten von ElCom (Eidgenössische Elektrizitätskommission) 
+          <strong>Grundlage:</strong> Wir nutzen offizielle Tarifdaten von ElCom (Eidgenössische Elektrizitätskommission)
           für Ihre Gemeinde. Die Berechnung berücksichtigt Energiekosten, Netznutzungsgebühren und Abgaben.
         </p>
         <p>
           <strong>LEG-Rabatt:</strong> Bei lokal verbrauchtem Strom entfallen die Netznutzungsgebühren für die übergeordneten Netzebenen. 
-          Typische Reduktion: 20-40% auf den Netznutzungsentgelt.
+          Typische Reduktion: 20 bis 40% auf den Netznutzungsentgelten.
         </p>
         <p>
           <strong>Annahmen:</strong> Der Rechner geht davon aus, dass der lokale Solarstrom zum gleichen Preis wie EVU-Strom verrechnet wird. 
@@ -272,28 +272,27 @@
           <summary class="font-bold text-ink cursor-pointer">Warum spare ich mit einer LEG Geld?</summary>
           <p class="mt-3 text-ink-muted">
             Bei lokal verbrauchtem Strom entfallen die Netznutzungsgebühren für die übergeordneten Netzebenen (Swissgrid, regionale Netze). 
-            Sie zahlen nur für das lokale Verteilnetz. Das spart typischerweise 20-40% auf die Netzkosten.
+            Sie zahlen nur für das lokale Verteilnetz. Das spart typischerweise 20 bis 40% auf die Netzkosten.
           </p>
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Ist die Berechnung genau?</summary>
           <p class="mt-3 text-ink-muted">
-            Der Rechner nutzt offizielle ElCom-Tarifdaten und realistische Annahmen. Die tatsächliche Einsparung kann abweichen, 
+            Der Rechner nutzt offizielle ElCom-Tarifdaten und nachvollziehbare Annahmen. Die tatsächliche Einsparung kann abweichen,
             da sie von Ihrem individuellen Verbrauchsprofil und der LEG-Struktur abhängt. Betrachten Sie das Ergebnis als Richtwert.
           </p>
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Was bedeutet "lokal verbrauchbar"?</summary>
           <p class="mt-3 text-ink-muted">
-            Das ist der Anteil der Solarproduktion, der direkt in Ihrer LEG verbraucht wird (statt ins Netz eingespeist). 
-            Wenn die Sonne mittags scheint, aber alle arbeiten sind, ist der Anteil tief. Mit Batteriespeichern oder vielen Teilnehmern steigt er.
+            Das ist der Anteil der Solarproduktion, den Ihre LEG direkt verbraucht, statt ihn ins Netz einzuspeisen.
+            Wenn die Sonne mittags scheint, aber fast niemand zuhause ist, bleibt der Anteil tief. Mit Batterien oder mehr Teilnehmern steigt er.
           </p>
         </details>
         <details class="bg-white rounded-lg shadow-md p-6">
           <summary class="font-bold text-ink cursor-pointer">Berücksichtigt der Rechner Investitionskosten?</summary>
           <p class="mt-3 text-ink-muted">
-            Nein, der Rechner zeigt nur die laufenden Einsparungen. Die Gründungskosten (CHF 500-2'000) und die Kosten für 
-            Smart Meter sind nicht eingerechnet. Diese amortisieren sich aber meist innerhalb von 1-2 Jahren.
+            Nein, der Rechner zeigt nur die laufenden Einsparungen. Gründungskosten von etwa CHF 500 bis 2'000 und Smart-Meter-Kosten sind nicht eingerechnet. Je nach LEG amortisieren sie sich nach 1 bis 2 Jahren.
           </p>
         </details>
       </div>

--- a/templates/meter_upload.html
+++ b/templates/meter_upload.html
@@ -4,7 +4,7 @@
 {% block meta %}
 {{ page_meta(
   title="Smart-Meter-Daten hochladen | OpenLEG",
-  description="Laden Sie Ihren EKZ-CSV-Export hoch. Die Daten werden verschlüsselt gespeichert und nur gemäss Ihrer Einwilligung verwendet.",
+  description="Laden Sie Ihren EKZ-CSV-Export hoch. OpenLEG speichert die Daten verschlüsselt und nutzt sie nur gemäss Ihrer Einwilligung.",
   path="/meter-upload",
   og_type="website",
   site_url=site_url,
@@ -16,7 +16,7 @@
 {% block content %}
 <main class="max-w-xl mx-auto px-4 py-12">
     <h1 class="text-3xl font-bold mb-2">Smart-Meter-Daten hochladen</h1>
-    <p class="text-gray-600 mb-6">Laden Sie Ihren EKZ-CSV-Export hoch. Die Daten werden verschlüsselt gespeichert und nur gemäss Ihrer Einwilligung verwendet.</p>
+    <p class="text-gray-600 mb-6">Laden Sie Ihren EKZ-CSV-Export hoch. OpenLEG speichert die Daten verschlüsselt und nutzt sie nur gemäss Ihrer Einwilligung.</p>
 
     <div class="bg-white rounded-lg shadow-md p-6">
         <div class="mb-4">
@@ -34,11 +34,11 @@
         </div>
 
         <div class="bg-amber-50 p-4 rounded-lg text-sm mb-4">
-            <h4 class="font-medium mb-1">Datenschutz-Stufen:</h4>
+            <h4 class="font-medium mb-1">Datenschutzstufen:</h4>
             <div class="space-y-2">
                 <label class="flex items-start gap-2"><input type="radio" name="tier" value="1" checked class="mt-1"> <div><strong>Stufe 1:</strong> Nur LEG-Teilnahme, Daten mit Nachbarn und Gemeinde teilen</div></label>
                 <label class="flex items-start gap-2"><input type="radio" name="tier" value="2" class="mt-1"> <div><strong>Stufe 2:</strong> Anonymisiert für Forschung freigeben</div></label>
-                <label class="flex items-start gap-2"><input type="radio" name="tier" value="3" class="mt-1"> <div><strong>Stufe 3:</strong> Aggregierte Insights für Energieversorger freigeben</div></label>
+                <label class="flex items-start gap-2"><input type="radio" name="tier" value="3" class="mt-1"> <div><strong>Stufe 3:</strong> Aggregierte Auswertung für Energieversorger freigeben</div></label>
             </div>
         </div>
 

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -3,11 +3,11 @@
 
 {% block meta %}
 {{ page_meta(
-  title="Open Source und Codebase | OpenLEG",
-  description="Wie OpenLEG als offene Infrastruktur funktioniert: Public App Repo, Private Ops Repo, Flask, PostgreSQL, Redis, Caddy und offene Energiedaten.",
+  title="Open Source und Code | OpenLEG",
+  description="Wie OpenLEG als offene Infrastruktur funktioniert: öffentliches App-Repo, privates Ops-Repo, Flask, PostgreSQL, Redis, Caddy und offene Energiedaten.",
   path="/open-source",
-  og_title="Open Source und Codebase | OpenLEG",
-  og_description="Architektur, Datenpipeline, Repo-Grenzen und Selbsthosting der freien OpenLEG Infrastruktur.",
+  og_title="Open Source und Code | OpenLEG",
+  og_description="Architektur, Datenpipeline, Repo-Grenzen und Selbsthosting der freien OpenLEG-Infrastruktur.",
   site_url=site_url,
 ) }}
 {% endblock %}
@@ -34,7 +34,7 @@
     <header class="max-w-3xl mb-10">
       <p class="text-sm font-semibold text-brand mb-2">Open Source</p>
       <h1 class="text-4xl font-bold mb-4">Freie Energieinfrastruktur, die man prüfen und selbst betreiben kann.</h1>
-      <p class="text-lg text-ink-muted">OpenLEG ist das Public App Repo für Schweizer Lokale Elektrizitätsgemeinschaften. Der Code ist offen, die Datenquellen sind nachvollziehbar, und produktive Geheimnisse bleiben ausserhalb des öffentlichen Repos.</p>
+      <p class="text-lg text-ink-muted">OpenLEG ist das öffentliche App-Repo für Schweizer Lokale Elektrizitätsgemeinschaften. Der Code ist offen, die Datenquellen sind nachvollziehbar, und produktive Secrets bleiben ausserhalb des öffentlichen Repos.</p>
       <div class="mt-6 flex flex-col sm:flex-row gap-3">
         <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">GitHub öffnen</a>
         <a href="/api/v1/docs" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">API ansehen</a>
@@ -43,22 +43,22 @@
 
     <section class="grid md:grid-cols-2 gap-6 mb-10">
       <div class="bg-white border border-slate-200 rounded-xl p-6">
-        <h2 class="text-xl font-bold mb-3">Public App Repo</h2>
-        <p class="text-ink-muted mb-4">Hier liegen Produktcode, Tests, Templates, öffentliche Datenmodelle, API und CI. Dieses Repo ist dafür gedacht, gelesen, geprüft und geforkt zu werden.</p>
+        <h2 class="text-xl font-bold mb-3">Öffentliches App-Repo</h2>
+        <p class="text-ink-muted mb-4">Hier liegen Produktcode, Tests, Templates, öffentliche Datenmodelle, API und CI. Das Repo soll lesbar, prüfbar und einfach zu forken sein.</p>
         <ul class="space-y-2 text-sm text-ink-muted list-disc list-inside">
-          <li>Flask App und öffentliche API</li>
-          <li>PostgreSQL Schema und idempotente Migrationen</li>
+          <li>Flask-App und öffentliche API</li>
+          <li>PostgreSQL-Schema und idempotente Migrationen</li>
           <li>Templates, statische Assets und Tests</li>
           <li>AGPL-3.0-or-later Lizenz</li>
         </ul>
       </div>
       <div class="bg-white border border-slate-200 rounded-xl p-6">
-        <h2 class="text-xl font-bold mb-3">Private Ops Repo</h2>
+        <h2 class="text-xl font-bold mb-3">Privates Ops-Repo</h2>
         <p class="text-ink-muted mb-4">Produktionsbetrieb, Host-Inventar, Secrets, Incident-Notizen und interne Strategie bleiben privat. So bleibt der App-Code offen, ohne produktive Infrastruktur offenzulegen.</p>
         <ul class="space-y-2 text-sm text-ink-muted list-disc list-inside">
           <li>Deployment-Runbooks und Hostnamen</li>
           <li>Secret-Handling und Rotation</li>
-          <li>Incident Response und interne Planung</li>
+          <li>Incident-Notizen und interne Planung</li>
           <li>Keine Bürgerdaten im öffentlichen Repo</li>
         </ul>
       </div>
@@ -69,11 +69,11 @@
       <div class="grid md:grid-cols-4 gap-4 text-sm">
         <div class="border border-slate-200 rounded-lg p-4">
           <h3 class="font-semibold mb-1">Flask</h3>
-          <p class="text-ink-muted">Routen, Formulare, Gemeindeprofile, Rangliste und JSON API.</p>
+          <p class="text-ink-muted">Routen, Formulare, Gemeindeprofile, Rangliste und JSON-API.</p>
         </div>
         <div class="border border-slate-200 rounded-lg p-4">
           <h3 class="font-semibold mb-1">PostgreSQL</h3>
-          <p class="text-ink-muted">Gemeindedaten, PV Panel, Tarife, Registrierungen und Audit-Daten.</p>
+          <p class="text-ink-muted">Gemeindedaten, PV-Anlagen, Tarife, Registrierungen und Audit-Daten.</p>
         </div>
         <div class="border border-slate-200 rounded-lg p-4">
           <h3 class="font-semibold mb-1">Redis</h3>
@@ -81,7 +81,7 @@
         </div>
         <div class="border border-slate-200 rounded-lg p-4">
           <h3 class="font-semibold mb-1">Caddy</h3>
-          <p class="text-ink-muted">TLS, Domains und Reverse Proxy vor der Flask App.</p>
+          <p class="text-ink-muted">TLS, Domains und Reverse Proxy vor der Flask-App.</p>
         </div>
       </div>
     </section>

--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -4,10 +4,10 @@
 {% block meta %}
 {{ page_meta(
   title="Kostenlos und Open Source | OpenLEG",
-  description="OpenLEG ist kostenlose Open Source Infrastruktur für Schweizer Stromgemeinschaften: Bewohner, Gemeinden und API ohne Lizenzkosten oder Datenverkauf.",
+  description="OpenLEG ist kostenlose Open Source Infrastruktur für Schweizer Stromgemeinschaften: für Bewohner, Gemeinden und Entwickler, ohne Lizenzkosten oder Datenverkauf.",
   path="/pricing",
   og_title="Kostenlos und Open Source | OpenLEG",
-  og_description="Keine Lizenzkosten, kein Vendor Lock-in, kein Datenverkauf. So finanziert sich OpenLEG.",
+  og_description="Keine Lizenzkosten, keine Anbieterbindung, kein Datenverkauf. So finanziert sich OpenLEG.",
   og_type="website",
   og_image="/static/images/og-image.png",
   site_url=site_url,
@@ -37,18 +37,18 @@
   <div class="max-w-5xl mx-auto px-4 py-12">
     <div class="text-center mb-10">
       <h1 class="text-4xl font-bold mb-2">Kostenlos. Open Source. Für immer.</h1>
-      <p class="text-ink-muted max-w-2xl mx-auto">OpenLEG ist freie Infrastruktur für Schweizer Stromgemeinschaften. Keine versteckten Kosten, kein Vendor Lock-in, keine Daten die verkauft werden.</p>
+      <p class="text-ink-muted max-w-2xl mx-auto">OpenLEG ist freie Infrastruktur für Schweizer Stromgemeinschaften. Keine versteckten Kosten, keine Abhängigkeit von einem Anbieter, kein Datenverkauf.</p>
     </div>
 
     <div class="grid md:grid-cols-3 gap-6">
       <div class="bg-white rounded-xl shadow-md p-6 border-t-4 border-brand">
         <h3 class="text-xl font-bold mb-1">Für Bewohner</h3>
         <div class="text-3xl font-bold mb-1">CHF 0</div>
-        <p class="text-sm text-ink-muted mb-4">Kostenlos, keine Registrierungsgebühr</p>
+        <p class="text-sm text-ink-muted mb-4">Adresse prüfen und Interesse anmelden.</p>
         <ul class="text-sm space-y-2 mb-6 text-ink-muted">
           <li>&#10003; Adresse prüfen, Nachbarn finden</li>
           <li>&#10003; Stromgemeinschaft gründen</li>
-          <li>&#10003; Alle Dokumente generieren</li>
+          <li>&#10003; Dokumente vorbereiten</li>
           <li>&#10003; Smart-Meter-Daten auswerten</li>
           <li>&#10003; Daten bleiben bei Ihnen</li>
         </ul>
@@ -58,11 +58,11 @@
       <div class="bg-white rounded-xl shadow-md p-6 border-t-4 border-brand">
         <h3 class="text-xl font-bold mb-1">Für Gemeinden</h3>
         <div class="text-3xl font-bold mb-1">CHF 0</div>
-        <p class="text-sm text-ink-muted mb-4">Eigene Instanz, keine Kosten</p>
+        <p class="text-sm text-ink-muted mb-4">Eigene Gemeinde-Seite, ohne Startkosten</p>
         <ul class="text-sm space-y-2 mb-6 text-ink-muted">
           <li>&#10003; Eigene Subdomain (gemeinde.openleg.ch)</li>
           <li>&#10003; Gemeinde-Branding</li>
-          <li>&#10003; Bewohner-Registrierung und Matching</li>
+          <li>&#10003; Registrierung und Matching für Bewohner</li>
           <li>&#10003; Fortschritt und Übersicht</li>
           <li>&#10003; Netzbetreiber-Anmeldung inklusive</li>
         </ul>
@@ -78,7 +78,7 @@
           <li>&#10003; Sonnendach Solarpotenzial</li>
           <li>&#10003; Energie Reporter Gemeinde-Daten</li>
           <li>&#10003; LEG Value-Gap Rechner</li>
-          <li>&#10003; Kein API-Key nötig, CORS offen</li>
+          <li>&#10003; Ohne API-Key nutzbar</li>
         </ul>
         <a href="/api/v1/docs" class="block text-center bg-amber-500 text-ink py-2 rounded-lg font-medium hover:bg-amber-400">API Dokumentation</a>
       </div>
@@ -100,7 +100,7 @@
           <h3 class="font-semibold text-ink mb-2">Optionale Einnahmen</h3>
           <ul class="space-y-2">
             <li>&#10003; Projektsupport für Gemeinden</li>
-            <li>&#10003; Self-Hosting Hilfe und Migration</li>
+            <li>&#10003; Hilfe bei Self-Hosting und Migration</li>
             <li>&#10003; Schulungen und Datenintegration</li>
             <li>&#10003; Keine Werbung, kein Datenverkauf</li>
           </ul>
@@ -109,7 +109,7 @@
     </div>
 
     <div class="mt-8 text-center">
-      <p class="text-ink-muted mb-4">Fragen zu Betrieb, Finanzierung oder Selbsthosting?</p>
+      <p class="text-ink-muted mb-4">Fragen zu Betrieb, Finanzierung oder Self-Hosting?</p>
       <div class="flex flex-col sm:flex-row gap-3 justify-center">
         <a href="/fuer-gemeinden" class="bg-brand text-ink px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Für Gemeinden</a>
         <a href="/open-source" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white">Code auf GitHub</a>

--- a/templates/unsubscribe.html
+++ b/templates/unsubscribe.html
@@ -3,10 +3,10 @@
 
 {% block meta %}
 {{ page_meta(
-  title="Abmeldung – " ~ platform_name,
+  title="Abmeldung | " ~ platform_name,
   description="Melden Sie sich bei " ~ platform_name ~ " vom Matching-Service für Lokale Elektrizitätsgemeinschaften ab. Eintrag mit einem Klick entfernen.",
   path="/unsubscribe",
-  og_title="Abmeldung – " ~ platform_name,
+  og_title="Abmeldung | " ~ platform_name,
   og_description="Hier können Sie sich vom " ~ platform_name ~ "-Service für Lokale Elektrizitätsgemeinschaften abmelden.",
   og_type="article",
   robots="index, follow",

--- a/templates/utility/dashboard.html
+++ b/templates/utility/dashboard.html
@@ -59,13 +59,13 @@
             <div class="bg-white rounded-lg shadow p-6">
                 <h2 class="text-lg font-bold mb-3">API-Zugang</h2>
                 {% if client.api_key_hash %}
-                <p class="text-sm text-green-600 mb-3">&#10003; API-Schluessel aktiv</p>
-                <p class="text-xs text-gray-500 mb-3">Nutzen Sie den Header <code class="bg-gray-100 px-1 rounded">X-API-Key</code> fuer B2B API Anfragen.</p>
+                <p class="text-sm text-green-600 mb-3">&#10003; API-Schlüssel aktiv</p>
+                <p class="text-xs text-gray-500 mb-3">Nutzen Sie den Header <code class="bg-gray-100 px-1 rounded">X-API-Key</code> für B2B-API-Anfragen.</p>
                 {% else %}
-                <p class="text-sm text-gray-500 mb-3">Noch kein API-Schluessel generiert.</p>
+                <p class="text-sm text-gray-500 mb-3">Noch kein API-Schlüssel vorhanden.</p>
                 {% endif %}
                 <button id="gen-key-btn" class="bg-amber-600 text-white px-4 py-2 rounded-lg text-sm hover:bg-amber-700">
-                    {% if client.api_key_hash %}Neuen Schluessel generieren{% else %}API-Schluessel generieren{% endif %}
+                    {% if client.api_key_hash %}Neuen Schlüssel erstellen{% else %}API-Schlüssel erstellen{% endif %}
                 </button>
                 <div id="api-key-result" class="mt-3 hidden">
                     <p class="text-sm text-amber-700 mb-1">Bitte sicher speichern, wird nur einmal angezeigt:</p>
@@ -85,7 +85,7 @@
                         <span class="w-6 h-6 rounded-full {{ 'bg-green-500 text-white' if client.api_key_hash else 'bg-gray-200 text-gray-500' }} flex items-center justify-center text-xs mr-3">
                             {% if client.api_key_hash %}&#10003;{% else %}2{% endif %}
                         </span>
-                        <span class="text-sm">API-Schluessel generieren</span>
+                        <span class="text-sm">API-Schlüssel erstellen</span>
                     </div>
                     <div class="flex items-center">
                         <span class="w-6 h-6 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs mr-3">3</span>
@@ -93,7 +93,7 @@
                     </div>
                     <div class="flex items-center">
                         <span class="w-6 h-6 rounded-full bg-gray-200 text-gray-500 flex items-center justify-center text-xs mr-3">4</span>
-                        <span class="text-sm">Erste LEG-Gruendung starten</span>
+                        <span class="text-sm">Erste LEG-Gründung starten</span>
                     </div>
                 </div>
             </div>
@@ -133,14 +133,14 @@
         <!-- API Documentation Link -->
         <div class="bg-amber-50 rounded-lg p-6 text-center">
             <h3 class="text-lg font-bold mb-2">API Dokumentation</h3>
-            <p class="text-gray-600 text-sm mb-4">Integrieren Sie LEG-Daten in Ihre bestehenden Systeme.</p>
-            <a href="/api/v1/docs" class="inline-block bg-amber-600 text-white px-6 py-2 rounded-lg hover:bg-amber-700">API Docs oeffnen</a>
+            <p class="text-gray-600 text-sm mb-4">Nutzen Sie LEG-Daten in Ihren bestehenden Systemen.</p>
+            <a href="/api/v1/docs" class="inline-block bg-amber-600 text-white px-6 py-2 rounded-lg hover:bg-amber-700">API-Dokumentation öffnen</a>
         </div>
     </div>
 
     <script>
     document.getElementById('gen-key-btn').addEventListener('click', async function() {
-        if (!confirm('Neuen API-Schluessel generieren? Der alte wird ungueltig.')) return;
+        if (!confirm('Neuen API-Schlüssel erstellen? Der alte wird ungültig.')) return;
         try {
             const res = await fetch('/utility/api-key', {
                 method: 'POST',
@@ -151,7 +151,7 @@
                 document.getElementById('api-key-value').textContent = data.api_key;
                 document.getElementById('api-key-result').classList.remove('hidden');
             } else {
-                alert(data.error || 'Fehler bei der Schluesselgenerierung.');
+                alert(data.error || 'Fehler beim Erstellen des Schlüssels.');
             }
         } catch(e) {
             alert('Netzwerkfehler.');

--- a/templates/utility/login.html
+++ b/templates/utility/login.html
@@ -22,7 +22,7 @@
 
             {% if registered %}
             <div class="bg-green-50 border border-green-200 rounded-lg p-3 mb-4 text-sm text-green-800">
-                Registrierung erfolgreich! Pruefen Sie Ihre E-Mail fuer den Login-Link.
+                Registrierung erfolgreich. Prüfen Sie Ihre E-Mail für den Login-Link.
             </div>
             {% endif %}
 
@@ -34,7 +34,7 @@
 
             <form id="login-form" class="space-y-4">
                 <div>
-                    <label class="block text-sm font-medium mb-1">Geschaeftliche E-Mail</label>
+                    <label class="block text-sm font-medium mb-1">Geschäftliche E-Mail</label>
                     <input type="email" id="email" placeholder="kontakt@evu.ch" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-amber-500 focus:outline-none" required autofocus>
                 </div>
                 <button type="submit" class="w-full bg-amber-600 text-white py-3 rounded-lg font-semibold hover:bg-amber-700">Login-Link senden</button>

--- a/templates/utility/register.html
+++ b/templates/utility/register.html
@@ -23,7 +23,7 @@
             <img src="/static/images/brand/flow-how-it-works.svg" alt="EVU Registrierung" class="w-full aspect-[3/1]" loading="lazy">
         </div>
         <h1 class="text-3xl font-bold mb-2">Netzbetreiber-Zugang</h1>
-        <p class="text-gray-600 mb-8">Registrieren Sie sich, um LEG-Anmeldungen aus Ihrem Versorgungsgebiet zu empfangen und den Formationsstatus zu verfolgen. Kostenlos.</p>
+        <p class="text-gray-600 mb-8">Registrieren Sie sich, damit OpenLEG LEG-Anmeldungen aus Ihrem Versorgungsgebiet an Sie weiterleiten kann. Kostenlos.</p>
 
         <form id="register-form" class="bg-white rounded-lg shadow-md p-6 space-y-4">
             <div>
@@ -38,8 +38,8 @@
                 <div>
                     <label class="block text-sm font-medium mb-1">Kanton</label>
                     <select id="kanton" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-gray-400 focus:outline-none">
-                        <option value="">Waehlen...</option>
-                        <option value="ZH">Zuerich</option>
+                        <option value="">Wählen...</option>
+                        <option value="ZH">Zürich</option>
                         <option value="BE">Bern</option>
                         <option value="AG">Aargau</option>
                         <option value="LU">Luzern</option>
@@ -48,7 +48,7 @@
                         <option value="BL">Basel-Landschaft</option>
                         <option value="SO">Solothurn</option>
                         <option value="TG">Thurgau</option>
-                        <option value="GR">Graubuenden</option>
+                        <option value="GR">Graubünden</option>
                         <option value="VS">Wallis</option>
                         <option value="VD">Waadt</option>
                         <option value="GE">Genf</option>
@@ -78,7 +78,7 @@
                 <input type="text" id="contact_name" placeholder="Vor- und Nachname" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-gray-400 focus:outline-none">
             </div>
             <div>
-                <label class="block text-sm font-medium mb-1">Geschaeftliche E-Mail *</label>
+                <label class="block text-sm font-medium mb-1">Geschäftliche E-Mail *</label>
                 <input type="email" id="contact_email" placeholder="kontakt@evu.ch" class="w-full border rounded-lg px-3 py-2 focus:ring-2 focus:ring-gray-400 focus:outline-none" required>
             </div>
             <div>
@@ -91,14 +91,14 @@
                 <ul class="text-gray-700 space-y-1">
                     <li>&#10003; LEG-Anmeldungen aus Ihrem Gebiet empfangen</li>
                     <li>&#10003; Formationsstatus verfolgen</li>
-                    <li>&#10003; Dokumentengenerierung (Gemeinschaftsvereinbarung, Teilnehmervertrag, DSO-Anmeldung)</li>
+                    <li>&#10003; Dokumente für Gemeinschaftsvereinbarung, Teilnehmervertrag und DSO-Anmeldung</li>
                     <li>&#10003; API-Zugang für Ihre bestehenden Systeme</li>
                 </ul>
             </div>
 
             <div class="bg-green-50 p-4 rounded-lg text-sm">
                 <h4 class="font-medium mb-1">Kostenlos</h4>
-                <p class="text-gray-600">OpenLEG ist Open Source und kostenlos. Keine Abonnements, keine versteckten Kosten.</p>
+                <p class="text-gray-600">OpenLEG ist Open Source und kostenlos. Kein Abo, keine versteckten Kosten.</p>
             </div>
 
             <button type="submit" class="w-full bg-gray-900 text-white py-3 rounded-lg font-semibold hover:bg-gray-800">Registrieren</button>

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -128,8 +128,8 @@ def test_open_source_page_explains_codebase(full_app_module):
     assert "Redis" in html
     assert "Caddy" in html
     assert "Datenpipeline" in html
-    assert "Public App Repo" in html
-    assert "Private Ops Repo" in html
+    assert "Öffentliches App-Repo" in html
+    assert "Privates Ops-Repo" in html
     assert "git clone https://github.com/Open-LEG-ch/openleg.git" in html
     assert "github.com/Open-LEG-ch/openleg" in html
     assert 'type="application/ld+json"' in html


### PR DESCRIPTION
## Summary
- Tighten OpenLEG public-site copy across homepage, stakeholder routes, municipality pages, calculator, pricing, legal pages, emails, and utility pages.
- Replace vague or over-absolute phrasing with concrete wording and next steps.
- Align visible template text with Swiss German rules: real umlauts, ss convention, no em/en dash placeholders.

## Tests
- pytest tests/test_stakeholder_pathways.py tests/test_fuer_gemeinden_page.py tests/test_app_organic_routes.py tests/test_municipality_organic.py tests/test_rangliste.py -q
- git diff --check
- rg -n "—|–|ß" templates

Closes #86