### PR TITLE
refactor(store): extract store/meter from database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -1809,81 +1809,6 @@ def update_municipality_status(bfs_number, status, admin_email=None):
         return False
 
 
-# === Meter Reading Operations ===
-
-
-def save_meter_readings(building_id, readings, source="csv"):
-    """Bulk insert meter readings. readings = list of (timestamp, consumption, production, feed_in)."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                from psycopg2.extras import execute_values
-
-                values = [
-                    (building_id, r[0], r[1], r[2], r[3], source) for r in readings
-                ]
-                execute_values(
-                    cur,
-                    """
-                    INSERT INTO meter_readings (building_id, timestamp, consumption_kwh, production_kwh, feed_in_kwh, source)
-                    VALUES %s
-                    ON CONFLICT (building_id, timestamp) DO UPDATE SET
-                        consumption_kwh = EXCLUDED.consumption_kwh,
-                        production_kwh = EXCLUDED.production_kwh,
-                        feed_in_kwh = EXCLUDED.feed_in_kwh
-                """,
-                    values,
-                )
-                return len(values)
-    except Exception as e:
-        logger.error(f"[DB] Error saving meter readings: {e}")
-        return 0
-
-
-def get_meter_readings(building_id, start=None, end=None, limit=1000):
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                query = "SELECT * FROM meter_readings WHERE building_id = %s"
-                params = [building_id]
-                if start:
-                    query += " AND timestamp >= %s"
-                    params.append(start)
-                if end:
-                    query += " AND timestamp <= %s"
-                    params.append(end)
-                query += " ORDER BY timestamp DESC LIMIT %s"
-                params.append(limit)
-                cur.execute(query, params)
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting meter readings: {e}")
-        return []
-
-
-def get_meter_reading_stats(building_id):
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT COUNT(*) as total_readings,
-                           MIN(timestamp) as first_reading,
-                           MAX(timestamp) as last_reading,
-                           SUM(consumption_kwh) as total_consumption,
-                           SUM(production_kwh) as total_production,
-                           SUM(feed_in_kwh) as total_feed_in
-                    FROM meter_readings WHERE building_id = %s
-                """,
-                    (building_id,),
-                )
-                row = cur.fetchone()
-                return dict(row) if row else {}
-    except Exception as e:
-        logger.error(f"[DB] Error getting meter stats: {e}")
-        return {}
-
-
 # === Data Consent Operations ===
 
 
@@ -2490,4 +2415,10 @@ from store.utility import (  # noqa: E402, F401
     update_utility_client_api_key,
     get_all_utility_clients,
     get_utility_client_stats,
+)
+
+from store.meter import (  # noqa: E402, F401
+    save_meter_readings,
+    get_meter_readings,
+    get_meter_reading_stats,
 )

--- a/store/meter.py
+++ b/store/meter.py
@@ -1,0 +1,88 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Smart-meter CSV persistence repository.
+
+Resolves the connection seam via ``database.get_connection`` at call time so
+monkeypatches keep working and ``database`` can re-export these functions.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+def save_meter_readings(building_id, readings, source="csv"):
+    """Bulk insert meter readings. readings = list of (timestamp, consumption, production, feed_in)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                from psycopg2.extras import execute_values
+
+                values = [
+                    (building_id, r[0], r[1], r[2], r[3], source) for r in readings
+                ]
+                execute_values(
+                    cur,
+                    """
+                    INSERT INTO meter_readings (building_id, timestamp, consumption_kwh, production_kwh, feed_in_kwh, source)
+                    VALUES %s
+                    ON CONFLICT (building_id, timestamp) DO UPDATE SET
+                        consumption_kwh = EXCLUDED.consumption_kwh,
+                        production_kwh = EXCLUDED.production_kwh,
+                        feed_in_kwh = EXCLUDED.feed_in_kwh
+                """,
+                    values,
+                )
+                return len(values)
+    except Exception as e:
+        logger.error(f"[DB] Error saving meter readings: {e}")
+        return 0
+
+
+def get_meter_readings(building_id, start=None, end=None, limit=1000):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                query = "SELECT * FROM meter_readings WHERE building_id = %s"
+                params = [building_id]
+                if start:
+                    query += " AND timestamp >= %s"
+                    params.append(start)
+                if end:
+                    query += " AND timestamp <= %s"
+                    params.append(end)
+                query += " ORDER BY timestamp DESC LIMIT %s"
+                params.append(limit)
+                cur.execute(query, params)
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting meter readings: {e}")
+        return []
+
+
+def get_meter_reading_stats(building_id):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT COUNT(*) as total_readings,
+                           MIN(timestamp) as first_reading,
+                           MAX(timestamp) as last_reading,
+                           SUM(consumption_kwh) as total_consumption,
+                           SUM(production_kwh) as total_production,
+                           SUM(feed_in_kwh) as total_feed_in
+                    FROM meter_readings WHERE building_id = %s
+                """,
+                    (building_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else {}
+    except Exception as e:
+        logger.error(f"[DB] Error getting meter stats: {e}")
+        return {}

--- a/tests/test_store_meter.py
+++ b/tests/test_store_meter.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the meter-data repository module (store.meter).
+
+Meter data is the LEG's smart-meter CSV state. This module owns its persistence
+and resolves the connection seam via ``database.get_connection`` at call time, so
+existing monkeypatches keep working and ``database`` re-exports the identical
+objects for legacy callers (``import database as db; db.get_meter_readings()``).
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import meter
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None):
+        self.rows = rows or []
+        self.one = one
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    # The re-export shim must expose the exact same function objects.
+    assert database.save_meter_readings is meter.save_meter_readings
+    assert database.get_meter_readings is meter.get_meter_readings
+    assert database.get_meter_reading_stats is meter.get_meter_reading_stats
+
+
+def test_store_meter_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.meter; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_get_meter_readings_uses_database_connection_seam(monkeypatch):
+    # Monkeypatching database.get_connection must affect store.meter calls,
+    # proving the seam is shared (not a stale direct import binding).
+    cur = _FakeCursor(rows=[{"building_id": "b1", "consumption_kwh": 4.2}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = meter.get_meter_readings("b1")
+    assert rows == [{"building_id": "b1", "consumption_kwh": 4.2}]
+    query, params = cur.executed[0]
+    assert "FROM meter_readings" in query
+    assert params[0] == "b1"
+    assert params[-1] == 1000  # default limit
+
+
+def test_get_meter_readings_applies_time_window(monkeypatch):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    meter.get_meter_readings("b1", start="2026-01-01", end="2026-02-01", limit=50)
+    query, params = cur.executed[0]
+    assert "timestamp >= %s" in query
+    assert "timestamp <= %s" in query
+    assert params == ["b1", "2026-01-01", "2026-02-01", 50]
+
+
+def test_get_meter_reading_stats_empty_returns_empty_dict(monkeypatch):
+    cur = _FakeCursor(one=None)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert meter.get_meter_reading_stats("b1") == {}


### PR DESCRIPTION
Closes #95. Continues the Candidate 4 data-layer deepening (`prd/architecture-deepening.md`).

## What

Peel the **Meter data** domain out of the 2493-line `database.py` into `store/meter.py`, re-exported from `database.py`. Same proven recipe as `store/ranking|profile|billing|email_queue|utility`.

- `store/meter.py`: `_get_connection()` seam shim + `save_meter_readings`, `get_meter_readings`, `get_meter_reading_stats` moved verbatim.
- `database.py`: 3 defs removed, one re-export block appended. **2493 → 2424 lines.**
- `tests/test_store_meter.py`: re-export identity, no-bootstrap import, shared-seam monkeypatch, time-window query, empty-stats edge.

## Why

**Locality:** the LEG's smart-meter persistence now lives in one file — meaningful given the data-sovereignty mission (meter data stays within each LEG). **Leverage:** `store/meter` is the unit test surface — no Flask, no live pool.

## Verification

- `pytest tests/test_store_meter.py tests/test_meter_formats.py -q` → **32 passed**
- All `tests/test_store_*.py` → **27 passed**
- `database.save_meter_readings.__module__ == "store.meter"` (re-export is the identical object)
- `ruff check` / `ruff format --check` green

No behaviour change; legacy `import database as db; db.get_meter_readings()` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)