### PR TITLE
refactor(store): extract store/tenant from database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -1605,117 +1605,6 @@ def get_building_for_dashboard(building_id: str) -> Optional[Dict]:
         return None
 
 
-# === Tenant Operations ===
-
-
-def get_tenant_by_territory(territory: str) -> Optional[Dict]:
-    """Get tenant config by territory slug."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT * FROM white_label_configs
-                    WHERE territory = %s AND active = TRUE
-                """,
-                    (territory,),
-                )
-                row = cur.fetchone()
-                return dict(row) if row else None
-    except Exception as e:
-        logger.error(f"[DB] Error getting tenant {territory}: {e}")
-        return None
-
-
-def get_all_active_tenants() -> List[Dict]:
-    """Get all active tenant configs."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("""
-                    SELECT territory, utility_name, primary_color, contact_email, active, config
-                    FROM white_label_configs
-                    WHERE active = TRUE
-                    ORDER BY territory
-                """)
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting active tenants: {e}")
-        return []
-
-
-def upsert_tenant(territory: str, config: Dict) -> bool:
-    """Insert or update a tenant config."""
-    try:
-        import json
-
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO white_label_configs (
-                        territory, utility_name, primary_color, secondary_color,
-                        contact_email, contact_phone, legal_entity, dso_contact,
-                        active, config
-                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
-                    ON CONFLICT (territory) DO UPDATE SET
-                        utility_name = EXCLUDED.utility_name,
-                        primary_color = EXCLUDED.primary_color,
-                        secondary_color = EXCLUDED.secondary_color,
-                        contact_email = EXCLUDED.contact_email,
-                        contact_phone = EXCLUDED.contact_phone,
-                        legal_entity = EXCLUDED.legal_entity,
-                        dso_contact = EXCLUDED.dso_contact,
-                        active = EXCLUDED.active,
-                        config = EXCLUDED.config,
-                        updated_at = CURRENT_TIMESTAMP
-                """,
-                    (
-                        territory,
-                        config.get("utility_name", ""),
-                        config.get("primary_color", "#c7021a"),
-                        config.get("secondary_color", "#f59e0b"),
-                        config.get("contact_email", ""),
-                        config.get("contact_phone", ""),
-                        config.get("legal_entity", ""),
-                        config.get("dso_contact", ""),
-                        config.get("active", True),
-                        json.dumps(
-                            {
-                                k: v
-                                for k, v in config.items()
-                                if k
-                                not in (
-                                    "utility_name",
-                                    "primary_color",
-                                    "secondary_color",
-                                    "contact_email",
-                                    "contact_phone",
-                                    "legal_entity",
-                                    "dso_contact",
-                                    "active",
-                                    "territory",
-                                )
-                            }
-                        ),
-                    ),
-                )
-                return True
-    except Exception as e:
-        logger.error(f"[DB] Error upserting tenant {territory}: {e}")
-        return False
-
-
-def seed_default_tenant() -> bool:
-    """Seed the default Zurich tenant if it doesn't exist."""
-    from tenant import DEFAULT_TENANT
-
-    existing = get_tenant_by_territory("zurich")
-    if existing:
-        return True
-    return upsert_tenant("zurich", DEFAULT_TENANT)
-
-
 # === Municipality Operations ===
 
 
@@ -2421,4 +2310,11 @@ from store.meter import (  # noqa: E402, F401
     save_meter_readings,
     get_meter_readings,
     get_meter_reading_stats,
+)
+
+from store.tenant import (  # noqa: E402, F401
+    get_tenant_by_territory,
+    get_all_active_tenants,
+    upsert_tenant,
+    seed_default_tenant,
 )

--- a/store/tenant.py
+++ b/store/tenant.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tenant repository.
+
+A Tenant maps a territory ``<territory>.openleg.ch`` to its white-label config.
+Resolves the connection seam via ``database.get_connection`` at call time.
+"""
+
+import logging
+from typing import Optional, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+def get_tenant_by_territory(territory: str) -> Optional[Dict]:
+    """Get tenant config by territory slug."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM white_label_configs
+                    WHERE territory = %s AND active = TRUE
+                """,
+                    (territory,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting tenant {territory}: {e}")
+        return None
+
+
+def get_all_active_tenants() -> List[Dict]:
+    """Get all active tenant configs."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("""
+                    SELECT territory, utility_name, primary_color, contact_email, active, config
+                    FROM white_label_configs
+                    WHERE active = TRUE
+                    ORDER BY territory
+                """)
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting active tenants: {e}")
+        return []
+
+
+def upsert_tenant(territory: str, config: Dict) -> bool:
+    """Insert or update a tenant config."""
+    try:
+        import json
+
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO white_label_configs (
+                        territory, utility_name, primary_color, secondary_color,
+                        contact_email, contact_phone, legal_entity, dso_contact,
+                        active, config
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (territory) DO UPDATE SET
+                        utility_name = EXCLUDED.utility_name,
+                        primary_color = EXCLUDED.primary_color,
+                        secondary_color = EXCLUDED.secondary_color,
+                        contact_email = EXCLUDED.contact_email,
+                        contact_phone = EXCLUDED.contact_phone,
+                        legal_entity = EXCLUDED.legal_entity,
+                        dso_contact = EXCLUDED.dso_contact,
+                        active = EXCLUDED.active,
+                        config = EXCLUDED.config,
+                        updated_at = CURRENT_TIMESTAMP
+                """,
+                    (
+                        territory,
+                        config.get("utility_name", ""),
+                        config.get("primary_color", "#c7021a"),
+                        config.get("secondary_color", "#f59e0b"),
+                        config.get("contact_email", ""),
+                        config.get("contact_phone", ""),
+                        config.get("legal_entity", ""),
+                        config.get("dso_contact", ""),
+                        config.get("active", True),
+                        json.dumps(
+                            {
+                                k: v
+                                for k, v in config.items()
+                                if k
+                                not in (
+                                    "utility_name",
+                                    "primary_color",
+                                    "secondary_color",
+                                    "contact_email",
+                                    "contact_phone",
+                                    "legal_entity",
+                                    "dso_contact",
+                                    "active",
+                                    "territory",
+                                )
+                            }
+                        ),
+                    ),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error upserting tenant {territory}: {e}")
+        return False
+
+
+def seed_default_tenant() -> bool:
+    """Seed the default Zurich tenant if it doesn't exist."""
+    from tenant import DEFAULT_TENANT
+
+    existing = get_tenant_by_territory("zurich")
+    if existing:
+        return True
+    return upsert_tenant("zurich", DEFAULT_TENANT)

--- a/tests/test_store_tenant.py
+++ b/tests/test_store_tenant.py
@@ -1,0 +1,108 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the tenant repository module (store.tenant).
+
+A Tenant maps a territory (`<territory>.openleg.ch`) to its white-label config.
+This module owns that persistence and resolves the connection seam via
+``database.get_connection`` at call time, so monkeypatches keep working and
+``database`` re-exports the identical objects for legacy callers.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import tenant
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None):
+        self.rows = rows or []
+        self.one = one
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    assert database.get_tenant_by_territory is tenant.get_tenant_by_territory
+    assert database.get_all_active_tenants is tenant.get_all_active_tenants
+    assert database.upsert_tenant is tenant.upsert_tenant
+    assert database.seed_default_tenant is tenant.seed_default_tenant
+
+
+def test_store_tenant_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.tenant; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_get_tenant_by_territory_uses_seam(monkeypatch):
+    cur = _FakeCursor(one={"territory": "zurich", "active": True})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    row = tenant.get_tenant_by_territory("zurich")
+    assert row == {"territory": "zurich", "active": True}
+    query, params = cur.executed[0]
+    assert "white_label_configs" in query
+    assert params == ("zurich",)
+
+
+def test_get_all_active_tenants_orders_by_territory(monkeypatch):
+    cur = _FakeCursor(rows=[{"territory": "aarau"}, {"territory": "zurich"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = tenant.get_all_active_tenants()
+    assert rows == [{"territory": "aarau"}, {"territory": "zurich"}]
+    assert "ORDER BY territory" in cur.executed[0][0]
+
+
+def test_seed_default_tenant_is_idempotent_when_present(monkeypatch):
+    # An existing zurich tenant short-circuits: no upsert, returns True.
+    cur = _FakeCursor(one={"territory": "zurich"})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    called = {"upsert": False}
+
+    def _fail_upsert(*_a, **_k):
+        called["upsert"] = True
+        return False
+
+    monkeypatch.setattr(tenant, "upsert_tenant", _fail_upsert)
+
+    assert tenant.seed_default_tenant() is True
+    assert called["upsert"] is False


### PR DESCRIPTION
Closes #97. Stacked on #96 (store/meter); base retargets to `main` once #96 merges.

## What

Peel the **Tenant** (white-label config) domain out of `database.py` into `store/tenant.py`, re-exported from `database.py`. Recipe identical to `store/meter`.

- `store/tenant.py`: `_get_connection()` shim + `get_tenant_by_territory`, `get_all_active_tenants`, `upsert_tenant`, `seed_default_tenant` moved verbatim. Lazy `tenant.DEFAULT_TENANT` import and intra-domain calls preserved.
- `database.py`: 4 defs + section comment removed, re-export block appended. **2424 → 2320 lines.**
- `tests/test_store_tenant.py`: re-export identity, no-bootstrap import, shared seam, ORDER BY, idempotent `seed_default_tenant`.

## Verification

- `pytest tests/test_store_tenant.py tests/test_tenant_cache.py` → **11 passed**
- All `tests/test_store_*.py` + tenant cache → **38 passed**
- `database.upsert_tenant.__module__ == "store.tenant"`; ruff green

No behaviour change; legacy `db.get_tenant_by_territory()` unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)