### PR TITLE
[codex] docs: reconcile design.md with shipped violet brand system

### DIFF
--- a/design.md
+++ b/design.md
@@ -2,26 +2,26 @@
 name: OpenLEG
 description: >
   Visual identity for OpenLEG, free open-source infrastructure for Swiss local
-  electricity communities (Lokale Elektrizitätsgemeinschaften). Civic, technical,
-  trustworthy. Energy coded in amber, action coded in indigo, grounded in slate.
+  electricity communities (Lokale Elektrizitätsgemeinschaften). Civic,
+  technical, trustworthy. Action and identity coded in violet, grounded in
+  slate.
 colors:
-  ink: "#0f172a"          # primary text, dark surfaces, footer
+  ink: "#0f172a"          # primary text, dark surfaces, footer, favicon tile
   ink-soft: "#1e293b"
   ink-muted: "#475569"    # secondary text
-  paper: "#f6f4ef"        # warm light surface
+  paper: "#f6f4ef"        # warm light surface and inverse wordmark text
   white: "#ffffff"
   line: "#e2e8f0"         # hairline borders
-  brand: "#f59e0b"        # action + identity: links, primary buttons, logo highlight (amber/yellow)
-  brand-light: "#fbbf24"
-  brand-dark: "#d97706"   # button hover, darker amber
-  accent: "#f59e0b"       # alias of brand; energy highlight
-  accent-hi: "#ffc043"    # amber top stop for gradients
+  brand: "#4f46e5"        # action + identity: links, primary buttons, logo highlight
+  brand-light: "#6366f1"
+  brand-dark: "#4338ca"   # button hover
+  accent: "#4f46e5"       # alias of brand
 typography:
   wordmark:
     family: "JetBrains Mono"
     weight: 500
     tracking: "-0.04em"
-    note: "open in ink/paper at 500, LEG in accent at 700"
+    note: "open in ink/paper at 500, LEG in brand at 700, violet caret"
   mono:
     family: "JetBrains Mono"
     weight: 500
@@ -39,11 +39,11 @@ spacing:
   gutter: "1rem"
 components:
   logo:
-    structure: "prompt '>' (accent) + 'open' (ink) + 'LEG' (accent, 700) + blinking caret"
+    structure: "'open' lowercase ink/paper + 'LEG' uppercase brand, 700 + blinking caret"
     partial: "templates/partials/brand_wordmark.html"
   favicon:
     file: "static/favicon.svg"
-    art: "amber shell prompt '>_' on ink rounded tile"
+    art: "violet blinking caret block on ink rounded tile"
   button-primary:
     bg: "{colors.brand}"
     color: "{colors.white}"
@@ -55,31 +55,38 @@ components:
 
 OpenLEG is free, open-source infrastructure for Swiss local electricity
 communities. The identity has to carry three things at once: **open source**
-(developer credibility), **energy** (what the product moves), and **civic trust**
-(citizens and municipalities act on it).
+(developer credibility), **energy coordination** (what the product enables), and
+**civic trust** (citizens and municipalities act on it).
 
-The logo encodes all three: a shell prompt for open source, amber for energy,
-and a plain, honest grotesk word for trust. Keep the system quiet. Let the amber
-do the talking.
+The logo encodes the product through a precise technical wordmark: lowercase
+`open`, uppercase `LEG`, and a blinking violet caret. Keep the system quiet. Let
+violet carry action and identity.
 
-Aesthetic: technical, Swiss-precise, warm. Not playful, not corporate.
+Aesthetic: technical, Swiss-precise, trustworthy. Not playful, not corporate.
 
 ## Colors
 
-One loud colour, one ground:
+One action colour, one ground:
 
-- **`brand` amber/yellow `#f59e0b`** is **both action and identity**. It is the
-  primary action (links, buttons, focus) AND the logo highlight (`LEG`, prompt,
-  caret). Yellow is the whole brand; there is no second action colour.
-- Amber fills carry **ink text**, never white (white on amber fails contrast).
-  Primary button: `bg-brand text-ink hover:bg-brand-dark`.
+- **`brand` violet `#4f46e5`** is **both action and identity**. It is the
+  primary action (links, buttons, focus) AND the logo highlight (`LEG`, caret).
+  Violet is the whole action system; there is no second action colour.
+- `brand-light #6366f1` supports lighter identity accents. `brand-dark #4338ca`
+  is the primary hover colour.
+- `accent #4f46e5` is an alias of `brand`, not a separate colour.
+- Violet fills carry **white text**. Primary button:
+  `bg-brand text-white rounded-lg font-semibold hover:bg-brand-dark`.
+  This is the shipped contrast rule.
+- Tinted chips and icon badges use `bg-brand/10 text-brand`.
+- Focus indicators use a 2px solid `#4f46e5` outline.
 - **`ink` slate `#0f172a`** is the ground: all body text, **all h1/h2/h3 titles
-  stay ink (black), never amber**, plus dark surfaces (footer, favicon tile).
-  `ink-muted #475569` for secondary text.
-- **`paper #f6f4ef`** and `white` are light surfaces.
+  stay ink (black), never violet**, plus dark surfaces (footer, favicon tile).
+  `ink-soft #1e293b` supports dense dark text. `ink-muted #475569` is secondary
+  text.
+- **`paper #f6f4ef`** and `white #ffffff` are light surfaces. `line #e2e8f0` is
+  the hairline colour.
 
-Gradient: `accent-hi #ffc043` (top) to `accent #f59e0b` (bottom), used only inside
-marks (sun, spark), never behind text.
+No gradient is part of the core brand system. Use flat fills and clear contrast.
 
 ## Typography
 
@@ -88,7 +95,9 @@ marks (sun, spark), never behind text.
   tariff figures, data tables, `kbd`. Mono signals "this is real infrastructure."
 
 The wordmark sets the rule: lowercase `open` at weight 500, uppercase `LEG` at
-weight 700 in amber, tracking `-0.04em`.
+weight 700 in violet `#4f46e5`, tracking `-0.04em`. It has no shell prompt
+character. The caret is a violet block with a slow 1.1s blink, disabled under
+`prefers-reduced-motion`.
 
 German user-facing text: Schweizer Hochdeutsch, real umlauts, `ss` not `ß`,
 active voice, no em or en dashes.
@@ -108,47 +117,54 @@ shadows, no glow.
 ## Shapes
 
 Rounded, not pill (except tags/badges). Buttons/inputs `8px`, cards `12px`, the
-favicon tile and feature panels `16px`. The favicon mark itself is built from
-round-capped strokes.
+favicon tile and feature panels `16px`. The favicon mark itself is a rounded
+caret block on a rounded tile.
 
 ## Components
 
 ### Logo / wordmark
 
 ```
-> openLEG▮
+openLEG▮
 ```
 
-- `>` shell prompt, amber, weight 700, ~0.45em right margin.
 - `open` lowercase, ink (paper/`#f6f4ef` on dark via `.ol-logo--inverse`).
-- `LEG` uppercase, amber, weight 700, no gap after `open`.
-- Caret: amber block, slow blink (1.1s), `prefers-reduced-motion` disables it.
-- Source of truth: `templates/partials/brand_wordmark.html`.
-  Inverse variant for dark surfaces: `{% with brand_inverse=true %}`.
+- `LEG` uppercase, violet `#4f46e5`, weight 700, no gap after `open`.
+- Caret: violet `#4f46e5` block, slow blink (1.1s),
+  `prefers-reduced-motion` disables it.
+- Font: `JetBrains Mono`, weight 500, tracking `-0.04em`.
+- Source of truth: `templates/partials/brand_wordmark.html`, with CSS in
+  `templates/partials/brand_head.html`.
+- Inverse variant for dark surfaces: `{% with brand_inverse=true %}` makes
+  `open` paper `#f6f4ef`.
 - Standalone asset (docs, OG, README): `static/images/openleg-logo.svg`.
 
 Never re-typeset the wordmark by hand: always include the partial or the SVG.
+There is no shell prompt `>` character in the wordmark.
 
 ### Favicon
 
-`static/favicon.svg`: amber `>_` prompt on an ink `#0f172a` 16px-radius tile.
-Path-based, no font dependency, legible at 16px. Linked from
-`templates/partials/tailwind_brand.html` with `favicon.ico` as raster fallback.
+`static/favicon.svg`: violet `#4f46e5` blinking caret block on an ink `#0f172a`
+16px-radius tile with `rx 16`. It is path-based, animated by opacity, and has no
+font dependency. Linked from `templates/partials/tailwind_brand.html` with
+`favicon.ico` as raster fallback.
 
 ### Buttons
 
-- Primary (yellow action): `bg-brand text-ink rounded-lg font-semibold hover:bg-brand-dark`.
+- Primary action: `bg-brand text-white rounded-lg font-semibold hover:bg-brand-dark`.
 - Secondary: `border border-slate-200 text-ink bg-white`.
+- Chips and icon badges: `bg-brand/10 text-brand`.
 
 ## Do's and Don'ts
 
-- **Do** make every primary action yellow (`bg-brand`); yellow is the only action colour.
-- **Do** use **ink text on amber fills** (white on amber fails contrast).
-- **Do** keep all h1/h2/h3 titles **ink/black**, never amber.
-- **Do** use the wordmark partial; keep `LEG` uppercase and amber.
+- **Do** make every primary action violet (`bg-brand`); violet is the only action colour.
+- **Do** use **white text on violet fills** with `bg-brand text-white`.
+- **Do** keep all h1/h2/h3 titles **ink/black**, never violet.
+- **Do** use the wordmark partial; keep `LEG` uppercase and violet.
 - **Do** respect `prefers-reduced-motion` (caret stops).
-- **Don't** use indigo or any second action colour anywhere.
-- **Don't** put white text on an amber button, or amber on a heading.
-- **Don't** add a separate icon badge next to the wordmark; the prompt is the mark.
+- **Don't** introduce a second action colour.
+- **Don't** put violet on a heading.
+- **Don't** add a separate icon badge next to the wordmark; the caret is the mark.
+- **Don't** reintroduce a shell prompt `>` into the wordmark or favicon.
 - **Don't** introduce new fonts; sans for reading, mono for the technical voice.
 - **Don't** use em or en dashes in German copy.

--- a/tests/test_design_doc.py
+++ b/tests/test_design_doc.py
@@ -21,9 +21,21 @@ def _read(path):
 def _shipped_brand_hexes():
     """Extract the hex tokens from the colors block of tailwind.config.js."""
     config = _read(TAILWIND_CONFIG_PATH)
-    colors_block = re.search(r"colors:\s*\{.*?\n\s{6}\}", config, flags=re.DOTALL)
-    assert colors_block, "colors block not found in tailwind.config.js"
-    hexes = set(re.findall(r"#[0-9a-fA-F]{6}", colors_block.group(0)))
+    start = config.find("colors:")
+    assert start != -1, "colors block not found in tailwind.config.js"
+    brace_start = config.index("{", start)
+    depth = 0
+    end = None
+    for index in range(brace_start, len(config)):
+        if config[index] == "{":
+            depth += 1
+        elif config[index] == "}":
+            depth -= 1
+            if depth == 0:
+                end = index + 1
+                break
+    assert end, "unbalanced colors block in tailwind.config.js"
+    hexes = set(re.findall(r"#[0-9a-fA-F]{6}", config[brace_start:end]))
     assert hexes, "no hex tokens found in tailwind.config.js colors block"
     return hexes
 
@@ -48,7 +60,7 @@ class TestDesignDocBrandSync:
             )
 
     def test_no_amber_brand_language(self):
-        assert "amber" not in self.design_lower, (
+        assert not re.search(r"\bamber\b", self.design_lower), (
             "design.md still describes the brand as amber"
         )
 

--- a/tests/test_design_doc.py
+++ b/tests/test_design_doc.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract tests keeping design.md in sync with the shipped brand tokens."""
+
+import os
+import re
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+DESIGN_PATH = os.path.join(PROJECT_ROOT, "design.md")
+TAILWIND_CONFIG_PATH = os.path.join(PROJECT_ROOT, "tailwind.config.js")
+
+LEGACY_AMBER_HEXES = ("#f59e0b", "#fbbf24", "#d97706", "#ffc043")
+
+
+def _read(path):
+    with open(path, encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _shipped_brand_hexes():
+    """Extract the hex tokens from the colors block of tailwind.config.js."""
+    config = _read(TAILWIND_CONFIG_PATH)
+    colors_block = re.search(r"colors:\s*\{.*?\n\s{6}\}", config, flags=re.DOTALL)
+    assert colors_block, "colors block not found in tailwind.config.js"
+    hexes = set(re.findall(r"#[0-9a-fA-F]{6}", colors_block.group(0)))
+    assert hexes, "no hex tokens found in tailwind.config.js colors block"
+    return hexes
+
+
+class TestDesignDocBrandSync:
+    @pytest.fixture(autouse=True)
+    def load_docs(self):
+        self.design = _read(DESIGN_PATH)
+        self.design_lower = self.design.lower()
+
+    def test_documents_every_shipped_brand_token(self):
+        for hex_token in sorted(_shipped_brand_hexes()):
+            assert hex_token.lower() in self.design_lower, (
+                f"design.md does not document shipped token {hex_token} "
+                "from tailwind.config.js"
+            )
+
+    def test_no_legacy_amber_hex(self):
+        for hex_token in LEGACY_AMBER_HEXES:
+            assert hex_token not in self.design_lower, (
+                f"design.md still contains legacy amber token {hex_token}"
+            )
+
+    def test_no_amber_brand_language(self):
+        assert "amber" not in self.design_lower, (
+            "design.md still describes the brand as amber"
+        )
+
+    def test_documents_white_text_on_brand_fills(self):
+        assert "bg-brand text-white" in self.design, (
+            "design.md must document the shipped primary button pattern "
+            "(violet fills carry white text)"
+        )
+
+    def test_no_stale_ink_on_brand_rule(self):
+        assert "bg-brand text-ink" not in self.design, (
+            "design.md still documents the old ink-text-on-brand button rule"
+        )


### PR DESCRIPTION
Closes #105

## Slice

`design.md` still documented the amber brand (`#f59e0b`, ink-text-on-amber buttons, shell prompt `>` wordmark, amber gradient). The shipped brand has been violet `#4f46e5` since PR #94: white text on brand fills, caret-only wordmark, violet favicon block. Any agent or contributor trusting the doc would re-yellow the site.

## Changes

- Rewrote `design.md` from the shipped tokens (`tailwind.config.js`, `brand_head.html`, `favicon.svg`, live button classes): violet token table, white-on-violet contrast rule (`bg-brand text-white`), `bg-brand/10 text-brand` tint pattern, focus outline, caret-only wordmark and favicon, re-derived do/don'ts.
- Added `tests/test_design_doc.py`: contract test that extracts the brand hexes from `tailwind.config.js` and asserts each is documented in `design.md`, bans the legacy amber hexes and amber brand language, and pins the white-text-on-brand-fills rule.

## Verification

- Red first: all 5 contract tests failed against the old doc.
- Green: rewrite executed via `codex exec --full-auto`, reviewed line by line against the shipped assets.
- `scripts/tdd_cycle.sh gate`: 475 passed, 7 skipped; `ruff check` and `ruff format --check` clean.
- No em/en dash characters in the doc (Swiss copy rule).

Remaining amber in templates is intentionally out of scope, tracked in #106.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM)_