### PR TITLE
docs: Codex execution integration (CLI operating model + setup script)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,18 @@ Execution standard:
 - Prefer `scripts/tdd_cycle.sh` for deterministic loop commands
 - Run full regression gates before merge
 
+## Codex Execution
+
+The `Execution` stage can be delegated to OpenAI Codex. See
+`docs/codex-execution.md` for the full handoff contract.
+
+- Codex environments use `scripts/codex_setup.sh` as setup script; tests are
+  fully mocked and need no network, database, or secrets.
+- Codex branches use the `codex/<slug>` prefix, PR titles the `[codex]` prefix.
+- Codex must run `scripts/tdd_cycle.sh gate` before finishing and always merge
+  via PR, never push to `main`.
+- `AGENTS.md` is the Codex agent contract and stays byte-identical to this file.
+
 ## CI and Branch Policy
 
 `main` is PR-only.  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,15 +99,19 @@ Execution standard:
 
 ## Codex Execution
 
-The `Execution` stage can be delegated to OpenAI Codex. See
-`docs/codex-execution.md` for the full handoff contract.
+The `Execution` stage runs as a two-agent loop: an orchestrating agent
+(Claude) writes failing tests, reviews, and verifies; OpenAI Codex
+implements via `codex exec --full-auto`. Full contract and environment
+requirements: `docs/codex-execution.md`.
 
-- Codex environments use `scripts/codex_setup.sh` as setup script; tests are
-  fully mocked and need no network, database, or secrets.
-- Codex branches use the `codex/<slug>` prefix, PR titles the `[codex]` prefix.
-- Codex must run `scripts/tdd_cycle.sh gate` before finishing and always merge
-  via PR, never push to `main`.
-- `AGENTS.md` is the Codex agent contract and stays byte-identical to this file.
+- One slice, one issue, one `codex/<slug>` branch, one `[codex]` PR.
+- Red tests first; Codex iterates until the full suite is green; the
+  orchestrator reviews every hunk and drives the real app before shipping.
+- `scripts/tdd_cycle.sh gate` must pass before every PR; merge only via PR,
+  never push to `main`. QA stays human.
+- Cloud-task alternative: Codex environments use `scripts/codex_setup.sh`
+  as setup script; tests are fully mocked and need no network or secrets.
+- `AGENTS.md` is the agent contract and stays byte-identical to this file.
 
 ## CI and Branch Policy
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,18 @@ Execution standard:
 - Prefer `scripts/tdd_cycle.sh` for deterministic loop commands
 - Run full regression gates before merge
 
+## Codex Execution
+
+The `Execution` stage can be delegated to OpenAI Codex. See
+`docs/codex-execution.md` for the full handoff contract.
+
+- Codex environments use `scripts/codex_setup.sh` as setup script; tests are
+  fully mocked and need no network, database, or secrets.
+- Codex branches use the `codex/<slug>` prefix, PR titles the `[codex]` prefix.
+- Codex must run `scripts/tdd_cycle.sh gate` before finishing and always merge
+  via PR, never push to `main`.
+- `AGENTS.md` is the Codex agent contract and stays byte-identical to this file.
+
 ## CI and Branch Policy
 
 `main` is PR-only.  

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,15 +99,19 @@ Execution standard:
 
 ## Codex Execution
 
-The `Execution` stage can be delegated to OpenAI Codex. See
-`docs/codex-execution.md` for the full handoff contract.
+The `Execution` stage runs as a two-agent loop: an orchestrating agent
+(Claude) writes failing tests, reviews, and verifies; OpenAI Codex
+implements via `codex exec --full-auto`. Full contract and environment
+requirements: `docs/codex-execution.md`.
 
-- Codex environments use `scripts/codex_setup.sh` as setup script; tests are
-  fully mocked and need no network, database, or secrets.
-- Codex branches use the `codex/<slug>` prefix, PR titles the `[codex]` prefix.
-- Codex must run `scripts/tdd_cycle.sh gate` before finishing and always merge
-  via PR, never push to `main`.
-- `AGENTS.md` is the Codex agent contract and stays byte-identical to this file.
+- One slice, one issue, one `codex/<slug>` branch, one `[codex]` PR.
+- Red tests first; Codex iterates until the full suite is green; the
+  orchestrator reviews every hunk and drives the real app before shipping.
+- `scripts/tdd_cycle.sh gate` must pass before every PR; merge only via PR,
+  never push to `main`. QA stays human.
+- Cloud-task alternative: Codex environments use `scripts/codex_setup.sh`
+  as setup script; tests are fully mocked and need no network or secrets.
+- `AGENTS.md` is the agent contract and stays byte-identical to this file.
 
 ## CI and Branch Policy
 

--- a/docs/codex-execution.md
+++ b/docs/codex-execution.md
@@ -1,0 +1,51 @@
+# Codex Execution Integration
+
+How to run the `Execution` stage of the pipeline
+(`Idea -> Research -> Prototype -> PRD -> Kanban -> Execution -> QA`)
+with OpenAI Codex against this repo.
+
+## One-time setup (Codex side)
+
+1. Connect the GitHub org `open-leg-ch` in Codex settings and grant access to
+   the `openleg` repository.
+2. Create a Codex environment for `open-leg-ch/openleg`:
+   - Base image: universal (Python 3.11 available)
+   - Setup script: `scripts/codex_setup.sh`
+   - Agent internet access: off is fine after setup; tests are fully mocked
+     and need no network, database, or Redis.
+3. No secrets are required. The test suite mocks the database
+   (`tests/conftest.py` sets `DATABASE_URL=""` plus test tokens). Never add
+   production credentials to a Codex environment for this repo.
+
+## What Codex reads
+
+- `AGENTS.md` at the repo root is the agent contract. It is byte-identical to
+  `CLAUDE.md` and enforced by `tests/test_docs_boundary_contract.py`. Change
+  both files together, never one alone.
+
+## Handing off a task
+
+Give Codex an execution packet, not a vague goal:
+
+- Link or paste the PRD slice (see `docs/matt-pocock-quality-slices.md` for the
+  format: repo, branch, status `ready for execution`, small slices).
+- State the target branch. Codex branches use the `codex/<slug>` prefix and PR
+  titles use the `[codex]` prefix (see PR #93 for a merged example).
+- Require the execution standard: TDD first (red -> green -> refactor) via
+  `scripts/tdd_cycle.sh`, then the full gate before finishing:
+
+```bash
+scripts/tdd_cycle.sh gate
+```
+
+## Merge path
+
+- `main` is PR-only; Codex must open a PR, never push to `main`.
+- Required checks are exactly `ci/lint`, `ci/test`, `ci/security`.
+- QA stays human: review the Codex PR before merge.
+
+## Boundary rules
+
+Codex works only in this public repo. Deployment runbooks, host inventory,
+secrets, and strategy material live in `openleg-ops` and are out of scope for
+Codex tasks here.

--- a/docs/codex-execution.md
+++ b/docs/codex-execution.md
@@ -2,50 +2,72 @@
 
 How to run the `Execution` stage of the pipeline
 (`Idea -> Research -> Prototype -> PRD -> Kanban -> Execution -> QA`)
-with OpenAI Codex against this repo.
+with OpenAI Codex as the executor. The proven operating model is a
+two-agent loop: an orchestrating agent (Claude) plans, writes the failing
+tests, reviews, and verifies; Codex implements.
 
-## One-time setup (Codex side)
+## Operating model (proven on issues #105 to #109)
 
-1. Connect the GitHub org `open-leg-ch` in Codex settings and grant access to
-   the `openleg` repository.
-2. Create a Codex environment for `open-leg-ch/openleg`:
-   - Base image: universal (Python 3.11 available)
-   - Setup script: `scripts/codex_setup.sh`
-   - Agent internet access: off is fine after setup; tests are fully mocked
-     and need no network, database, or Redis.
-3. No secrets are required. The test suite mocks the database
-   (`tests/conftest.py` sets `DATABASE_URL=""` plus test tokens). Never add
-   production credentials to a Codex environment for this repo.
+Per slice, one issue, one branch, one PR:
 
-## What Codex reads
-
-- `AGENTS.md` at the repo root is the agent contract. It is byte-identical to
-  `CLAUDE.md` and enforced by `tests/test_docs_boundary_contract.py`. Change
-  both files together, never one alone.
-
-## Handing off a task
-
-Give Codex an execution packet, not a vague goal:
-
-- Link or paste the PRD slice (see `docs/matt-pocock-quality-slices.md` for the
-  format: repo, branch, status `ready for execution`, small slices).
-- State the target branch. Codex branches use the `codex/<slug>` prefix and PR
-  titles use the `[codex]` prefix (see PR #93 for a merged example).
-- Require the execution standard: TDD first (red -> green -> refactor) via
-  `scripts/tdd_cycle.sh`, then the full gate before finishing:
+1. The orchestrator picks the slice and writes the failing tests first
+   (red), pinning the exact contract.
+2. Codex implements until green:
+   `codex exec --full-auto "<precise task: files, contract, DoD>"`.
+   The task prompt names the failing test file, the mapping rules, and the
+   constraints (no test edits, no built-asset edits, Schweizer Hochdeutsch
+   copy rules).
+3. The orchestrator reviews the diff hunk by hunk, fixes nits directly,
+   drives the real app (local Postgres 16 + Redis) to verify behavior, and
+   runs the full gate:
 
 ```bash
 scripts/tdd_cycle.sh gate
 ```
 
-## Merge path
+4. The orchestrator opens the PR against `main` and addresses review
+   feedback with the same red-test-first discipline.
 
-- `main` is PR-only; Codex must open a PR, never push to `main`.
-- Required checks are exactly `ci/lint`, `ci/test`, `ci/security`.
-- QA stays human: review the Codex PR before merge.
+Review Codex output critically: it is capable but will sometimes satisfy a
+gate the cheap way (for example excluding a file from formatting instead of
+formatting it). The orchestrator owns the gate.
+
+## Environment requirements (CLI executor)
+
+For a Claude Code cloud session driving Codex CLI:
+
+- Install: `npm i -g @openai/codex`, then authenticate headlessly:
+  `printenv OPENAI_API_KEY | codex login --with-api-key`.
+- `OPENAI_API_KEY` must be set as an environment secret. Never commit it.
+- The environment network policy must allow `api.openai.com`.
+- GitHub write access (push, issues, PRs) for the session.
+- Smoke test before first use: `codex exec --full-auto "list the files you
+  can see, change nothing"` must exit cleanly with a clean `git status`.
+
+## Conventions
+
+- Branches: `codex/<slug>`. PR titles: `[codex]` prefix.
+- `main` is PR-only; required checks are exactly `ci/lint`, `ci/test`,
+  `ci/security`. QA stays human: a maintainer reviews every PR before merge.
+- `AGENTS.md` at the repo root is the agent contract. It stays byte-identical
+  to `CLAUDE.md`, enforced by `tests/test_docs_boundary_contract.py`. Change
+  both together, never one alone.
+
+## Alternative: Codex cloud tasks
+
+For delegating whole tasks to Codex cloud instead of the in-session CLI:
+
+1. Connect the GitHub org `open-leg-ch` in Codex settings and grant access
+   to the `openleg` repository.
+2. Create a Codex environment with setup script `scripts/codex_setup.sh`
+   (Python 3.11 base). Tests are fully mocked and need no network, database,
+   or secrets after setup.
+3. Hand Codex an execution packet, not a vague goal: the PRD slice, the
+   target branch, and the execution standard (TDD via `scripts/tdd_cycle.sh`,
+   full gate before finishing).
 
 ## Boundary rules
 
 Codex works only in this public repo. Deployment runbooks, host inventory,
-secrets, and strategy material live in `openleg-ops` and are out of scope for
-Codex tasks here.
+secrets, and strategy material live in `openleg-ops` and are out of scope
+for Codex tasks here.

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: AGPL-3.0-or-later
+# Environment setup script for OpenAI Codex cloud environments.
+# Configure this as the environment "setup script" so dependencies are
+# installed while network access is still available. After setup, Codex
+# runs with restricted network, so everything the gates need must be
+# installed here.
+#
+# Gates after setup:
+#   scripts/tdd_cycle.sh gate   (pytest + ruff check + ruff format --check)
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+python -m pip install --upgrade pip
+python -m pip install -r requirements-dev.txt
+
+# Smoke check: the full regression gate must be runnable offline.
+python -c "import flask, pytest" >/dev/null
+ruff --version >/dev/null
+
+echo "codex setup complete"

--- a/scripts/codex_setup.sh
+++ b/scripts/codex_setup.sh
@@ -16,8 +16,9 @@ cd "$(dirname "$0")/.."
 python -m pip install --upgrade pip
 python -m pip install -r requirements-dev.txt
 
-# Smoke check: the full regression gate must be runnable offline.
-python -c "import flask, pytest" >/dev/null
-ruff --version >/dev/null
+# Prove the full regression gate runs before network access is restricted:
+# a green gate here guarantees the offline environment has everything the
+# tests and linters need, including native dependencies.
+bash scripts/tdd_cycle.sh gate
 
 echo "codex setup complete"


### PR DESCRIPTION
## What

Documents how the `Execution` pipeline stage runs with OpenAI Codex as executor, based on the operating model proven while shipping #105–#109 (PRs #111–#115):

- **`docs/codex-execution.md`**: the two-agent loop (orchestrator writes failing tests, reviews hunk by hunk, drives the real app, owns the gate; Codex implements via `codex exec --full-auto`), environment requirements (`OPENAI_API_KEY` secret, `api.openai.com` network allowlist, headless `codex login --with-api-key`, smoke test), conventions (`codex/<slug>` branches, `[codex]` PR titles, human QA before merge), and the Codex-cloud alternative.
- **`scripts/codex_setup.sh`**: setup script for Codex cloud environments (installs `requirements-dev.txt`, smoke-checks the offline gate).
- **`CLAUDE.md` / `AGENTS.md`**: matching "Codex Execution" section, kept byte-identical per `tests/test_docs_boundary_contract.py`.

Includes an honest caveat learned in practice: Codex sometimes satisfies gates the cheap way (e.g. excluding a file from formatting instead of formatting it) — the orchestrator owns the gate.

## Verification

- `scripts/tdd_cycle.sh gate`: 470 passed, 7 skipped on this branch's base; ruff clean.
- CLAUDE.md/AGENTS.md byte-equality and boundary contract tests pass.
- No secrets or private-ops details (public-repo boundary respected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM)_