### PR TITLE
[codex] fix(conversion): funnel survives suggestion outages and CDN failures

### DIFF
--- a/api_public.py
+++ b/api_public.py
@@ -447,8 +447,8 @@ def address_suggest():
         except (ValueError, IndexError):
             pass
 
-    suggestions = data_enricher.get_address_suggestions(
-        q, limit=10, plz_ranges=plz_ranges
+    suggestions = (
+        data_enricher.get_address_suggestions(q, limit=10, plz_ranges=plz_ranges) or []
     )
     return jsonify({"suggestions": suggestions})
 

--- a/app.py
+++ b/app.py
@@ -886,6 +886,8 @@ def api_suggest_addresses():
     suggestions_raw = data_enricher.get_address_suggestions(
         query, limit=limit, plz_ranges=plz_ranges
     )
+    if suggestions_raw is None:
+        return jsonify({"error": "Adressvorschläge sind derzeit nicht verfügbar."}), 503
     suggestions = []
     for s in suggestions_raw:
         if isinstance(s, dict) and s.get("label") and s.get("label").strip():

--- a/data_enricher.py
+++ b/data_enricher.py
@@ -44,7 +44,14 @@ def _plz_in_ranges(plz_int, plz_ranges=None):
 
 
 def get_address_suggestions(query_string, limit=10, plz_ranges=None):
-    """Fragt Swisstopo API ab, um Adressvorschläge zu erhalten (gefiltert nach PLZ-Bereichen)."""
+    """Fragt Swisstopo API ab, um Adressvorschläge zu erhalten (gefiltert nach PLZ-Bereichen).
+
+    Returns a list of suggestion dicts; an empty list means the query
+    genuinely matched nothing. Returns None when the upstream request
+    fails, so callers can distinguish an outage from no matches and must
+    not treat None as an empty result (see /api/suggest_addresses, which
+    turns None into a 503).
+    """
     if not query_string or len(query_string) < 2:
         return []
 

--- a/data_enricher.py
+++ b/data_enricher.py
@@ -100,7 +100,7 @@ def get_address_suggestions(query_string, limit=10, plz_ranges=None):
         return suggestions
     except Exception as e:
         print(f"  [GEO FEHLER bei Vorschlägen] {e}")
-        return []
+        return None
 
 
 def get_coordinates_from_address(address_string):

--- a/templates/index.html
+++ b/templates/index.html
@@ -378,11 +378,16 @@
   <script src="/static/js/landing_segments.js"></script>
 
   <script>
-  // Map
-  const map = L.map('map').setView([{{ map_center_lat }}, {{ map_center_lon }}], {{ map_zoom }});
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-      maxZoom: 18, attribution: '&copy; OpenStreetMap'
-  }).addTo(map);
+  // Map (Leaflet kommt von einem CDN; der Funnel muss auch ohne Karte funktionieren)
+  let map = null;
+  if (typeof L !== 'undefined') {
+      map = L.map('map').setView([{{ map_center_lat }}, {{ map_center_lon }}], {{ map_zoom }});
+      L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          maxZoom: 18, attribution: '&copy; OpenStreetMap'
+      }).addTo(map);
+  } else {
+      document.getElementById('map').classList.add('hidden');
+  }
 
   let selectedProfile = null;
   let addressTimeout = null;
@@ -538,6 +543,7 @@
               data = {};
           }
           if (res.ok) {
+              document.getElementById('form-error').classList.add('hidden');
               document.getElementById('step-register').classList.add('hidden');
               document.getElementById('step-success').classList.remove('hidden');
               if (data.referral_link) {

--- a/tests/test_conversion_paths.py
+++ b/tests/test_conversion_paths.py
@@ -236,3 +236,18 @@ class TestSuggestAddressesOutage:
 
         monkeypatch.setattr(data_enricher.requests, "get", _boom)
         assert data_enricher.get_address_suggestions("Mellingerstrasse 12") is None
+
+
+class TestFunnelSurvivesCdnFailure:
+    """Leaflet comes from a third-party CDN; when it fails to load (corporate
+    proxies, adblockers, CDN outage), an unguarded L.map() throws and kills
+    every funnel listener on the homepage: no autocomplete, no address check,
+    no registration. Found by driving the page in a browser with the CDN
+    blocked."""
+
+    def test_map_init_guarded(self):
+        html = _read_template("index.html")
+        assert "typeof L" in html, (
+            "guard the Leaflet map init so a CDN failure cannot break "
+            "the registration funnel"
+        )

--- a/tests/test_conversion_paths.py
+++ b/tests/test_conversion_paths.py
@@ -196,3 +196,43 @@ class TestAutocompleteResilience:
             "build nodes with textContent and dataset"
         )
         assert "textContent" in self.suggest_section
+
+
+# === Server: address-suggestion upstream outage (browser-drive finding) ===
+
+
+class TestSuggestAddressesOutage:
+    """An upstream Swisstopo failure must not masquerade as 'no matches'.
+
+    The enricher used to swallow errors and return [], so the funnel showed
+    'Keine passende Adresse gefunden' and disabled the check button: a dead
+    end for a visitor who typed a perfectly good address.
+    """
+
+    def test_upstream_failure_returns_503_json(self, full_app_module):
+        client = full_app_module.app.test_client()
+        with patch.object(
+            full_app_module.data_enricher, "get_address_suggestions", return_value=None
+        ):
+            resp = client.get("/api/suggest_addresses?q=Mellingerstrasse")
+        assert resp.status_code == 503
+        assert resp.is_json
+        assert "verfügbar" in resp.get_json()["error"]
+
+    def test_genuinely_empty_result_stays_200(self, full_app_module):
+        client = full_app_module.app.test_client()
+        with patch.object(
+            full_app_module.data_enricher, "get_address_suggestions", return_value=[]
+        ):
+            resp = client.get("/api/suggest_addresses?q=Atlantisweg")
+        assert resp.status_code == 200
+        assert resp.get_json() == {"suggestions": []}
+
+    def test_enricher_returns_none_on_upstream_error(self, monkeypatch):
+        import data_enricher
+
+        def _boom(*_a, **_k):
+            raise RuntimeError("upstream down")
+
+        monkeypatch.setattr(data_enricher.requests, "get", _boom)
+        assert data_enricher.get_address_suggestions("Mellingerstrasse 12") is None


### PR DESCRIPTION
Follow-up to #109/#115, found by driving the funnel end-to-end in a real browser under worst-case network conditions (third-party hosts blocked).

## Two dead-ends fixed

**1. Address-suggestion upstream outage masqueraded as "no matches".**
When Swisstopo is unreachable, `data_enricher.get_address_suggestions` swallowed the error and returned `[]`, so `/api/suggest_addresses` answered `200` with an empty list — and the client showed "Keine passende Adresse gefunden" and **disabled the check button**, dead-ending a visitor who typed a perfectly good address.
Fix: the enricher returns `None` on upstream failure; the funnel endpoint answers `503` with a German error, which the client's existing recovery path turns into "Vorschläge nicht verfügbar. Sie können die Adresse trotzdem prüfen." with the button re-enabled. The public API keeps its empty-list contract (`or []`).

**2. A Leaflet CDN failure killed the whole funnel.**
`index.html` loads Leaflet from unpkg; when that fails (corporate proxy, adblocker, CDN outage), the unguarded `L.map()` throws and none of the funnel listeners bind — no autocomplete, no address check, no registration. Fix: guard the map init (`typeof L !== 'undefined'`), hide the map container on failure, funnel stays alive.

Plus a cosmetic fix spotted in the verification screenshot: the consent error is cleared once registration succeeds.

## Verification (browser, worst-case conditions: CDN blocked + Swisstopo unreachable)

All nine end-to-end checks pass in Chromium:
- suggestion outage re-enables "Adresse prüfen"
- address check reveals the registration step
- missing consents blocked with the German inline error
- registration reaches the success screen
- the POST carries `profile` and the `?ref=` referral code
- Kalkulator: search finds Baden, "Berechnen" renders CHF results, no error
- no raw browser alert anywhere

Red-first tests: outage → 503 JSON (German), genuine empty result stays 200, enricher returns `None` on upstream error, map init guarded.
`scripts/tdd_cycle.sh gate`: 514 passed, 7 skipped; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM)_