### PR TITLE
[codex] refactor(store): extract token repository from database.py

### DIFF
--- a/database.py
+++ b/database.py
@@ -1117,102 +1117,6 @@ def update_building_verified(building_id: str, verified: bool = True) -> bool:
         return False
 
 
-# === Token Operations ===
-
-
-def save_token(
-    token: str, building_id: str, token_type: str, ttl_seconds: int = 2592000
-) -> bool:
-    """Save a verification or unsubscribe token (default TTL: 30 days)."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    INSERT INTO tokens (token, building_id, token_type, expires_at)
-                    VALUES (%s, %s, %s, CURRENT_TIMESTAMP + INTERVAL '%s seconds')
-                    ON CONFLICT (token) DO UPDATE SET
-                        building_id = EXCLUDED.building_id,
-                        token_type = EXCLUDED.token_type,
-                        expires_at = EXCLUDED.expires_at
-                """,
-                    (token, building_id, token_type, ttl_seconds),
-                )
-                return True
-    except Exception as e:
-        logger.error(f"[DB] Error saving token: {e}")
-        return False
-
-
-def get_token(token: str) -> Optional[Dict]:
-    """Get token info if valid (not expired, not used)."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    SELECT * FROM tokens
-                    WHERE token = %s
-                    AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
-                    AND used_at IS NULL
-                """,
-                    (token,),
-                )
-                row = cur.fetchone()
-                if row:
-                    return dict(row)
-                return None
-    except Exception as e:
-        logger.error(f"[DB] Error getting token: {e}")
-        return None
-
-
-def use_token(token: str) -> bool:
-    """Mark a token as used."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute(
-                    """
-                    UPDATE tokens SET used_at = CURRENT_TIMESTAMP
-                    WHERE token = %s
-                """,
-                    (token,),
-                )
-                return cur.rowcount > 0
-    except Exception as e:
-        logger.error(f"[DB] Error using token: {e}")
-        return False
-
-
-def delete_tokens_for_building(
-    building_id: str, token_type: Optional[str] = None
-) -> int:
-    """Delete tokens for a building."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                if token_type:
-                    cur.execute(
-                        """
-                        DELETE FROM tokens
-                        WHERE building_id = %s AND token_type = %s
-                    """,
-                        (building_id, token_type),
-                    )
-                else:
-                    cur.execute(
-                        """
-                        DELETE FROM tokens WHERE building_id = %s
-                    """,
-                        (building_id,),
-                    )
-                return cur.rowcount
-    except Exception as e:
-        logger.error(f"[DB] Error deleting tokens: {e}")
-        return 0
-
-
 # === Cluster Operations ===
 
 
@@ -2291,6 +2195,13 @@ from store.email_queue import (  # noqa: E402, F401
     mark_email_failed,
     cancel_emails_for_building,
     get_email_stats,
+)
+
+from store.token import (  # noqa: E402, F401
+    save_token,
+    get_token,
+    use_token,
+    delete_tokens_for_building,
 )
 
 from store.utility import (  # noqa: E402, F401

--- a/store/token.py
+++ b/store/token.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Verification/unsubscribe token repository.
+
+Repository module for the verification/unsubscribe token domain: save, fetch,
+use, and delete entries in the ``tokens`` table. The connection seam is
+resolved via ``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working
+unchanged and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+# === Token Operations ===
+
+
+def save_token(
+    token: str, building_id: str, token_type: str, ttl_seconds: int = 2592000
+) -> bool:
+    """Save a verification or unsubscribe token (default TTL: 30 days)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO tokens (token, building_id, token_type, expires_at)
+                    VALUES (%s, %s, %s, CURRENT_TIMESTAMP + INTERVAL '%s seconds')
+                    ON CONFLICT (token) DO UPDATE SET
+                        building_id = EXCLUDED.building_id,
+                        token_type = EXCLUDED.token_type,
+                        expires_at = EXCLUDED.expires_at
+                """,
+                    (token, building_id, token_type, ttl_seconds),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error saving token: {e}")
+        return False
+
+
+def get_token(token: str) -> Optional[Dict]:
+    """Get token info if valid (not expired, not used)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM tokens
+                    WHERE token = %s
+                    AND (expires_at IS NULL OR expires_at > CURRENT_TIMESTAMP)
+                    AND used_at IS NULL
+                """,
+                    (token,),
+                )
+                row = cur.fetchone()
+                if row:
+                    return dict(row)
+                return None
+    except Exception as e:
+        logger.error(f"[DB] Error getting token: {e}")
+        return None
+
+
+def use_token(token: str) -> bool:
+    """Mark a token as used."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE tokens SET used_at = CURRENT_TIMESTAMP
+                    WHERE token = %s
+                """,
+                    (token,),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error using token: {e}")
+        return False
+
+
+def delete_tokens_for_building(
+    building_id: str, token_type: Optional[str] = None
+) -> int:
+    """Delete tokens for a building."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                if token_type:
+                    cur.execute(
+                        """
+                        DELETE FROM tokens
+                        WHERE building_id = %s AND token_type = %s
+                    """,
+                        (building_id, token_type),
+                    )
+                else:
+                    cur.execute(
+                        """
+                        DELETE FROM tokens WHERE building_id = %s
+                    """,
+                        (building_id,),
+                    )
+                return cur.rowcount
+    except Exception as e:
+        logger.error(f"[DB] Error deleting tokens: {e}")
+        return 0

--- a/tests/test_store_token.py
+++ b/tests/test_store_token.py
@@ -109,3 +109,13 @@ def test_delete_tokens_filters_by_type(monkeypatch):
     query, params = cur.executed[0]
     assert "token_type" in query
     assert params == ("b1", "unsubscribe")
+
+
+def test_save_token_wires_params(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert store_token.save_token("t1", "b1", "verification", ttl_seconds=3600) is True
+    query, params = cur.executed[0]
+    assert "INSERT INTO tokens" in query
+    assert params == ("t1", "b1", "verification", 3600)

--- a/tests/test_store_token.py
+++ b/tests/test_store_token.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the token repository (store.token).
+
+Verifies the extracted module resolves the connection seam via
+`database.get_connection` and that `database` re-exports the identical
+objects, so legacy callers and existing monkeypatches keep working
+unchanged. Mirrors `test_store_email_queue.py`; the seam is the test
+surface.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import token as store_token
+
+
+_REEXPORTED = (
+    "save_token",
+    "get_token",
+    "use_token",
+    "delete_tokens_for_building",
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None, rowcount=0):
+        self.rows = rows or []
+        self.one = one
+        self.rowcount = rowcount
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    for name in _REEXPORTED:
+        assert getattr(database, name) is getattr(store_token, name), name
+
+
+def test_store_token_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.token; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_get_token_uses_database_connection_seam(monkeypatch):
+    # Monkeypatching database.get_connection must affect store.token calls,
+    # proving the seam is shared (not a stale direct import binding).
+    cur = _FakeCursor(one={"token": "t1", "building_id": "b1"})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    info = store_token.get_token("t1")
+    assert info == {"token": "t1", "building_id": "b1"}
+    assert "FROM tokens" in cur.executed[0][0]
+    assert cur.executed[0][1] == ("t1",)
+
+
+def test_use_token_reports_rowcount(monkeypatch):
+    cur = _FakeCursor(rowcount=1)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    assert store_token.use_token("t1") is True
+
+    cur = _FakeCursor(rowcount=0)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    assert store_token.use_token("missing") is False
+
+
+def test_delete_tokens_filters_by_type(monkeypatch):
+    cur = _FakeCursor(rowcount=2)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert store_token.delete_tokens_for_building("b1", "unsubscribe") == 2
+    query, params = cur.executed[0]
+    assert "token_type" in query
+    assert params == ("b1", "unsubscribe")


### PR DESCRIPTION
Closes #119

## Slice

Wave-2 architecture deepening, first extraction in the ascending-risk order (token → referral → api_client). The verification/unsubscribe token domain (4 functions) moves out of the `database.py` monolith into a per-domain repository.

## Changes

- New `store/token.py` mirroring the shipped `store/email_queue.py` pattern: connection seam resolved via `database.get_connection` at call time (`_get_connection()` helper), so existing `monkeypatch.setattr(database, "get_connection", ...)` tests keep working.
- `save_token`, `get_token`, `use_token`, `delete_tokens_for_building` moved **byte-identical** (verified programmatically against `git show HEAD:database.py` — only the `get_connection` → `_get_connection` swap differs).
- `database.py` re-exports all 4 names next to the existing store re-export blocks; `app.py`'s `db.save_token(...)` callers are untouched.
- `tests/test_store_token.py`: interface tests mirroring `test_store_email_queue.py` — identical re-exported objects, module imports without database bootstrap, seam monkeypatching affects store calls, rowcount/filter behavior.

## Verification

- Red first: the interface tests fail on main (`store.token` does not exist).
- Extraction via `codex exec --full-auto`, reviewed hunk by hunk with a programmatic byte-identity check on the moved SQL.
- `scripts/tdd_cycle.sh gate`: 515 passed, 7 skipped; ruff clean. `database.py` shrinks by 96 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM

---
_Generated by [Claude Code](https://claude.ai/code/session_011ePe8iMjgK3wL7kXo8wbxM)_