### PR TITLE
[codex] fix(security): escape user input in PDF generation

### DIFF
--- a/document_generator.py
+++ b/document_generator.py
@@ -145,7 +145,7 @@ def generate_teilnehmervertrag(
 
     pv_section = ""
     if pv_kwp and pv_kwp > 0:
-        pv_section = f"<p><strong>PV-Anlage:</strong> {pv_kwp} kWp</p>"
+        pv_section = f"<p><strong>PV-Anlage:</strong> {_escape_html(pv_kwp)} kWp</p>"
 
     html = f"""<!DOCTYPE html>
 <html><head><meta charset="utf-8">
@@ -244,7 +244,7 @@ th {{ background: #f0f0f0; }}
 <h2>Gemeinschaft</h2>
 <p><strong>Name:</strong> {community_name}<br>
 <strong>Netzebene:</strong> {network_level}<br>
-<strong>Gesamte PV-Leistung:</strong> {total_pv_kwp} kWp</p>
+<strong>Gesamte PV-Leistung:</strong> {_escape_html(total_pv_kwp)} kWp</p>
 
 <h2>Teilnehmer und Messpunkte</h2>
 <table><tr><th>#</th><th>Name</th><th>Adresse</th><th>Messpunkt-ID</th></tr>{rows}</table>

--- a/document_generator.py
+++ b/document_generator.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """PDF document generator for LEG formation documents using WeasyPrint."""
 
+import html
 from datetime import date
 
 
@@ -9,6 +10,10 @@ DISTRIBUTION_LABELS = {
     "proportional": "Proportionale Verteilung nach Verbrauchsanteil",
     "individuell": "Individuelle Vereinbarung gemäss Anhang",
 }
+
+
+def _escape_html(value):
+    return html.escape(str(value), quote=True)
 
 
 def _render_pdf(html_str):
@@ -50,12 +55,20 @@ def generate_gemeinschaftsvereinbarung(
     if date_str is None:
         date_str = date.today().isoformat()
 
-    dist_label = DISTRIBUTION_LABELS.get(distribution_model, distribution_model)
+    community_name = _escape_html(community_name)
+    municipality = _escape_html(municipality)
+    date_str = _escape_html(date_str)
+    dist_label = _escape_html(
+        DISTRIBUTION_LABELS.get(distribution_model, distribution_model)
+    )
 
     rows = ""
     for i, p in enumerate(participants, 1):
         role_label = "Produzent" if p["role"] == "producer" else "Konsument"
-        rows += f"<tr><td>{i}</td><td>{p['name']}</td><td>{p['address']}</td><td>{role_label}</td></tr>"
+        rows += (
+            f"<tr><td>{i}</td><td>{_escape_html(p['name'])}</td>"
+            f"<td>{_escape_html(p['address'])}</td><td>{role_label}</td></tr>"
+        )
 
     html = f"""<!DOCTYPE html>
 <html><head><meta charset="utf-8">
@@ -98,7 +111,7 @@ der gemäss separater Vollmacht bestimmt wird.</p>
 
 <h2>7. Unterschriften</h2>
 <table><tr><th>Name</th><th>Datum</th><th>Unterschrift</th></tr>
-{"".join("<tr><td>" + p["name"] + "</td><td></td><td></td></tr>" for p in participants)}
+{"".join("<tr><td>" + _escape_html(p["name"]) + "</td><td></td><td></td></tr>" for p in participants)}
 </table>
 
 <div class="footer">Generiert durch OpenLEG Platform, openleg.ch</div>
@@ -124,6 +137,10 @@ def generate_teilnehmervertrag(
     if date_str is None:
         date_str = date.today().isoformat()
 
+    participant_name = _escape_html(participant_name)
+    participant_address = _escape_html(participant_address)
+    community_name = _escape_html(community_name)
+    date_str = _escape_html(date_str)
     role_label = "Produzent" if role == "producer" else "Konsument"
 
     pv_section = ""
@@ -197,9 +214,17 @@ def generate_dso_anmeldung(
     if date_str is None:
         date_str = date.today().isoformat()
 
+    community_name = _escape_html(community_name)
+    dso_name = _escape_html(dso_name)
+    network_level = _escape_html(network_level)
+    date_str = _escape_html(date_str)
     rows = ""
     for i, p in enumerate(participants, 1):
-        rows += f"<tr><td>{i}</td><td>{p['name']}</td><td>{p['address']}</td><td>{p['metering_point']}</td></tr>"
+        rows += (
+            f"<tr><td>{i}</td><td>{_escape_html(p['name'])}</td>"
+            f"<td>{_escape_html(p['address'])}</td>"
+            f"<td>{_escape_html(p['metering_point'])}</td></tr>"
+        )
 
     html = f"""<!DOCTYPE html>
 <html><head><meta charset="utf-8">

--- a/tests/test_document_generator.py
+++ b/tests/test_document_generator.py
@@ -193,6 +193,73 @@ class TestDsoAnmeldung:
             )
 
 
+class TestHtmlEscaping:
+    """User input must be HTML-escaped before reaching WeasyPrint.
+
+    Mitigates WeasyPrint CSS injection via presentational hints
+    (GHSA-jhhc-3hcp-qhm5) by removing the HTML/attribute breakout surface.
+    """
+
+    HOSTILE = '<script>x</script>"><td bgcolor="red">'
+    ESCAPED = "&lt;script&gt;"
+
+    def _rendered_html(self, mock_render_pdf):
+        assert mock_render_pdf.call_args is not None
+        return mock_render_pdf.call_args.args[0]
+
+    def test_gemeinschaftsvereinbarung_escapes_participant(self, mock_render_pdf):
+        from document_generator import generate_gemeinschaftsvereinbarung
+
+        generate_gemeinschaftsvereinbarung(
+            community_name=self.HOSTILE,
+            participants=[
+                {"name": self.HOSTILE, "address": self.HOSTILE, "role": "producer"},
+                {"name": "Anna", "address": "Weg 2", "role": "consumer"},
+            ],
+            municipality=self.HOSTILE,
+            distribution_model="proportional",
+        )
+        html = self._rendered_html(mock_render_pdf)
+        assert "<script>" not in html
+        assert '<td bgcolor="red">' not in html
+        assert self.ESCAPED in html
+
+    def test_teilnehmervertrag_escapes_input(self, mock_render_pdf):
+        from document_generator import generate_teilnehmervertrag
+
+        generate_teilnehmervertrag(
+            participant_name=self.HOSTILE,
+            participant_address=self.HOSTILE,
+            community_name=self.HOSTILE,
+            role="consumer",
+        )
+        html = self._rendered_html(mock_render_pdf)
+        assert "<script>" not in html
+        assert '<td bgcolor="red">' not in html
+        assert self.ESCAPED in html
+
+    def test_dso_anmeldung_escapes_input(self, mock_render_pdf):
+        from document_generator import generate_dso_anmeldung
+
+        generate_dso_anmeldung(
+            community_name=self.HOSTILE,
+            dso_name=self.HOSTILE,
+            participants=[
+                {
+                    "name": self.HOSTILE,
+                    "address": self.HOSTILE,
+                    "metering_point": "CH1",
+                },
+            ],
+            total_pv_kwp=10.0,
+            network_level=self.HOSTILE,
+        )
+        html = self._rendered_html(mock_render_pdf)
+        assert "<script>" not in html
+        assert '<td bgcolor="red">' not in html
+        assert self.ESCAPED in html
+
+
 class TestDocumentStore:
     """Tests for storing/listing generated documents."""
 

--- a/tests/test_document_generator.py
+++ b/tests/test_document_generator.py
@@ -259,6 +259,21 @@ class TestHtmlEscaping:
         assert '<td bgcolor="red">' not in html
         assert self.ESCAPED in html
 
+    def test_dso_anmeldung_escapes_total_pv(self, mock_render_pdf):
+        """total_pv_kwp reaches the HTML unguarded; a string must be escaped."""
+        from document_generator import generate_dso_anmeldung
+
+        generate_dso_anmeldung(
+            community_name="LEG",
+            dso_name="EKZ",
+            participants=[{"name": "A", "address": "Weg 1", "metering_point": "CH1"}],
+            total_pv_kwp=self.HOSTILE,
+            network_level="NE7",
+        )
+        html = self._rendered_html(mock_render_pdf)
+        assert "<script>" not in html
+        assert self.ESCAPED in html
+
 
 class TestDocumentStore:
     """Tests for storing/listing generated documents."""


### PR DESCRIPTION
## Problem
Dependabot alert #18: WeasyPrint <= 68.1 CSS injection via presentational hints (GHSA-jhhc-3hcp-qhm5). No upstream patched version exists.

`document_generator.py` interpolated user-supplied values (participant names/addresses, community name, municipality, DSO name, metering points, network level) raw into the PDF HTML via f-strings. That HTML/attribute breakout is the exact surface the advisory exploits, and it was also a plain stored-HTML-injection bug independent of WeasyPrint.

## Fix
HTML-escape every user-controlled string via stdlib `html.escape(..., quote=True)` before HTML assembly. Numeric values and internal role/label constants are untouched.

## Tests
New `TestHtmlEscaping` (red first) feeds hostile input to all three generators and asserts `<script>` / `<td bgcolor="red">` never reach the HTML while `&lt;script&gt;` does. Full suite: 548 passed, 7 skipped; ruff check + format clean.

Closes #126.

🤖 Generated with [Claude Code](https://claude.com/claude-code)