### PR TITLE
[codex] fix(security): stop leaking exception text from cron endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -1558,8 +1558,9 @@ def api_cron_backfill_elcom():
             tariffs = public_data.fetch_elcom_tariffs(bfs, year=year)
             if tariffs:
                 result["saved"] += int(db.save_elcom_tariffs(tariffs) or 0)
-        except Exception as e:
-            result["errors"].append({"bfs": bfs, "error": str(e)})
+        except Exception:
+            logger.exception("ElCom backfill failed for BFS %s", bfs)
+            result["errors"].append({"bfs": bfs, "error": "fetch_failed"})
     return jsonify(result)
 
 

--- a/public_data.py
+++ b/public_data.py
@@ -424,7 +424,7 @@ def refresh_canton(kanton: str = "ZH", year: int = 2026) -> Dict:
             result["municipalities"] += 1
         except Exception as e:
             logger.error(f"[PUBLIC_DATA] Error refreshing BFS {bfs}: {e}")
-            result["errors"].append({"bfs": bfs, "error": str(e)})
+            result["errors"].append({"bfs": bfs, "error": "refresh_failed"})
 
     return result
 

--- a/tests/test_public_data_refresh_scope.py
+++ b/tests/test_public_data_refresh_scope.py
@@ -52,3 +52,32 @@ def test_refresh_canton_zh_keeps_seed_list(monkeypatch):
     result = public_data.refresh_canton("ZH", year=2026)
     assert result["kanton"] == "ZH"
     assert {p["bfs_number"] for p in saved_profiles} == {247, 261}
+
+
+def test_refresh_canton_does_not_leak_exception_detail(monkeypatch):
+    """Per-municipality failures must not expose exception text in the result.
+
+    Guards against py/stack-trace-exposure: refresh_canton is returned via
+    jsonify from a cron endpoint, so raw str(e) would flow to the response.
+    """
+    secret = "SECRET_DB_HOST=10.0.0.9 password=hunter2"
+
+    monkeypatch.setattr(public_data, "ZH_BFS_NUMBERS", [261])
+    monkeypatch.setattr(public_data, "fetch_energie_reporter", lambda: [])
+    monkeypatch.setattr(public_data, "fetch_sonnendach_municipal", lambda: [])
+
+    def _boom(_bfs, year=2026):
+        raise RuntimeError(secret)
+
+    monkeypatch.setattr(public_data, "fetch_elcom_tariffs", _boom)
+    monkeypatch.setattr(database, "save_sonnendach_municipal", lambda _entry: True)
+    monkeypatch.setattr(database, "save_elcom_tariffs", lambda _rows: 0)
+    monkeypatch.setattr(database, "save_municipality_profile", lambda profile: True)
+
+    result = public_data.refresh_canton("ZH", year=2026)
+
+    assert result["errors"], "expected the failing municipality to be recorded"
+    for entry in result["errors"]:
+        assert entry.get("bfs") == 261
+        assert secret not in str(entry)
+        assert "hunter2" not in str(entry)


### PR DESCRIPTION
## Problem
CodeQL `py/stack-trace-exposure` (medium, alerts #61 & #62). `refresh_canton` (public_data.py) and `api_cron_backfill_elcom` (app.py) appended raw `str(e)` into a dict returned via `jsonify`, so internal exception text flows to the HTTP response. Both endpoints are CRON_SECRET-protected, but this is still an info leak.

## Fix
Keep server-side logging (`logger.error` / `logger.exception`), return a generic label (`refresh_failed` / `fetch_failed`) instead of the exception string.

## Tests
New `test_refresh_canton_does_not_leak_exception_detail` (red first) makes a fetcher raise an exception carrying a secret marker and asserts it never reaches `result["errors"]`. Full suite: 550 passed, 7 skipped; ruff clean.

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)