### PR TITLE
fix(hardening): fail-closed cron auth, DeepSign webhook signatures, complete .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,7 +34,7 @@ CRON_SECRET=your-secure-cron-secret
 REDIS_URL=redis://redis:6379/1
 
 # === Database Pool (optional) ===
-DB_POOL_MIN=1
+DB_POOL_MIN=2
 DB_POOL_MAX=10
 
 # === DeepSign e-signatures (optional) ===

--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,27 @@ GA4_MEASUREMENT_ID=G-XXXXXXXXXX
 ADMIN_TOKEN=your-secure-admin-token
 INTERNAL_TOKEN=your-secure-internal-token
 
+# === Cron Authentication (required for /api/cron/* endpoints) ===
+CRON_SECRET=your-secure-cron-secret
+
+# === Cache / Rate Limiting ===
+REDIS_URL=redis://redis:6379/1
+
+# === Database Pool (optional) ===
+DB_POOL_MIN=1
+DB_POOL_MAX=10
+
+# === DeepSign e-signatures (optional) ===
+DEEPSIGN_API_URL=https://api.deepsign.ch/v1
+DEEPSIGN_API_KEY=
+DEEPSIGN_WEBHOOK_SECRET=
+
+# === Stripe billing (optional) ===
+STRIPE_SECRET_KEY=
+STRIPE_WEBHOOK_SECRET=
+STRIPE_PRICE_STARTER=
+STRIPE_PRICE_ENTERPRISE=
+
 # === OpenClaw (optional) ===
 MODEL_BASE_URL=https://api.example.com/v1
 MODEL_API_KEY=your-model-api-key

--- a/.gitignore
+++ b/.gitignore
@@ -29,10 +29,9 @@ env/
 # Node
 node_modules/
 
-# Environment Variables
-.env
-.env.local
-.env.production
+# Environment Variables (all variants except the tracked template)
+.env*
+!.env.example
 
 # IDEs
 .vscode/
@@ -102,6 +101,8 @@ infomaniak_*
 !/CONTRIBUTING.md
 !/SECURITY.md
 !/design.md
+!/CLAUDE.md
+!/AGENTS.md
 
 # Private planning, strategy, ops docs (explicit, defense in depth)
 archive/
@@ -127,11 +128,18 @@ SENDGRID_SETUP.md
 
 # Local-only deployment and generated artifacts
 deploy.sh
-output/imagegen/
+output/
 .claude/
 .orch/
 .github/scripts/
 handoff
+gitleaks.sarif
+
+# Database dumps and backups
+backups/
+*.sql
+*.sql.gz
+*.dump
 
 # Internal business admin: private-ops overlay only, never tracked publicly
 insights_engine.py

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: gunicorn app:app --bind 0.0.0.0:$PORT --workers 3 --timeout 120
-

--- a/app.py
+++ b/app.py
@@ -1467,20 +1467,24 @@ def api_formation_financial_model():
 
 
 # --- Cron ---
+def _require_cron_secret():
+    """Cron endpoints fail closed: no CRON_SECRET configured means no access."""
+    secret = request.headers.get("X-Cron-Secret") or request.args.get("secret") or ""
+    if not CRON_SECRET or secret != CRON_SECRET:
+        log_security_event("CRON_ACCESS_DENIED", "Invalid cron secret", "WARNING")
+        abort(403)
+
+
 @app.route("/api/cron/process-emails", methods=["POST"])
 def api_cron_process_emails():
-    secret = request.headers.get("X-Cron-Secret") or request.args.get("secret") or ""
-    if CRON_SECRET and secret != CRON_SECRET:
-        abort(403)
+    _require_cron_secret()
     result = email_automation.process_email_queue(app=app)
     return jsonify(result)
 
 
 @app.route("/api/cron/refresh-public-data", methods=["POST"])
 def api_cron_refresh_public_data():
-    secret = request.headers.get("X-Cron-Secret") or request.args.get("secret") or ""
-    if CRON_SECRET and secret != CRON_SECRET:
-        abort(403)
+    _require_cron_secret()
     import public_data
 
     result = public_data.refresh_canton("ZH")
@@ -1489,9 +1493,7 @@ def api_cron_refresh_public_data():
 
 @app.route("/api/cron/backfill-elcom", methods=["POST"])
 def api_cron_backfill_elcom():
-    secret = request.headers.get("X-Cron-Secret") or request.args.get("secret") or ""
-    if CRON_SECRET and secret != CRON_SECRET:
-        abort(403)
+    _require_cron_secret()
     import public_data
 
     year = request.args.get("year", 2026, type=int)
@@ -1533,6 +1535,10 @@ def webhook_deepsign():
     """Handle DeepSign e-signature webhook callbacks."""
     import deepsign_integration
 
+    signature = request.headers.get("X-DeepSign-Signature", "")
+    if not deepsign_integration.verify_webhook_signature(request.get_data(), signature):
+        log_security_event("DEEPSIGN_WEBHOOK_DENIED", "Invalid signature", "WARNING")
+        abort(403)
     payload = request.get_json(silent=True) or {}
     result = deepsign_integration.handle_webhook(payload)
     logger.info(
@@ -1544,9 +1550,7 @@ def webhook_deepsign():
 # --- Billing Cron ---
 @app.route("/api/cron/process-billing", methods=["POST"])
 def api_cron_process_billing():
-    secret = request.headers.get("X-Cron-Secret") or request.args.get("secret") or ""
-    if CRON_SECRET and secret != CRON_SECRET:
-        abort(403)
+    _require_cron_secret()
 
     communities = db.get_active_communities()
     processed = 0

--- a/deepsign_integration.py
+++ b/deepsign_integration.py
@@ -11,9 +11,9 @@ import os
 
 import requests
 
-API_URL = os.environ.get("DEEPSIGN_API_URL", "https://api.deepsign.ch/v1")
-API_KEY = os.environ.get("DEEPSIGN_API_KEY", "")
-WEBHOOK_SECRET = os.environ.get("DEEPSIGN_WEBHOOK_SECRET", "")
+API_URL = os.environ.get("DEEPSIGN_API_URL", "https://api.deepsign.ch/v1").strip()
+API_KEY = os.environ.get("DEEPSIGN_API_KEY", "").strip()
+WEBHOOK_SECRET = os.environ.get("DEEPSIGN_WEBHOOK_SECRET", "").strip()
 
 
 def sign_webhook_payload(body: bytes) -> str:

--- a/deepsign_integration.py
+++ b/deepsign_integration.py
@@ -5,12 +5,34 @@ Requires DEEPSIGN_API_KEY and DEEPSIGN_API_URL env vars.
 API docs: https://docs.deepsign.ch
 """
 
+import hashlib
+import hmac
 import os
+
 import requests
 
 API_URL = os.environ.get("DEEPSIGN_API_URL", "https://api.deepsign.ch/v1")
 API_KEY = os.environ.get("DEEPSIGN_API_KEY", "")
 WEBHOOK_SECRET = os.environ.get("DEEPSIGN_WEBHOOK_SECRET", "")
+
+
+def sign_webhook_payload(body: bytes) -> str:
+    """HMAC-SHA256 hex signature over the raw webhook body."""
+    return hmac.new(WEBHOOK_SECRET.encode(), body, hashlib.sha256).hexdigest()
+
+
+def verify_webhook_signature(body: bytes, signature: str) -> bool:
+    """Check a webhook signature.
+
+    Without a configured DEEPSIGN_WEBHOOK_SECRET the check is a no-op so
+    local development keeps working; with a secret set, unsigned or wrongly
+    signed requests are rejected.
+    """
+    if not WEBHOOK_SECRET:
+        return True
+    if not signature:
+        return False
+    return hmac.compare_digest(sign_webhook_payload(body), signature)
 
 
 def _headers():

--- a/passenger_wsgi.py
+++ b/passenger_wsgi.py
@@ -1,8 +1,0 @@
-# SPDX-License-Identifier: AGPL-3.0-or-later
-import os
-import sys
-
-# Ensure project path is in sys.path
-project_home = os.path.dirname(__file__)
-if project_home not in sys.path:
-    sys.path.insert(0, project_home)

--- a/railway.toml
+++ b/railway.toml
@@ -1,8 +1,0 @@
-[build]
-builder = "NIXPACKS"
-
-[deploy]
-startCommand = "gunicorn app:app --bind 0.0.0.0:$PORT --workers 3 --timeout 120"
-restartPolicyType = "ON_FAILURE"
-restartPolicyMaxRetries = 10
-

--- a/tests/test_public_hardening.py
+++ b/tests/test_public_hardening.py
@@ -93,6 +93,28 @@ def test_deepsign_webhook_rejects_unsigned_when_secret_set(app_with_deepsign_sec
     assert response.status_code == 403
 
 
+def test_deepsign_webhook_accepts_valid_signature(app_with_deepsign_secret):
+    import json as _json
+
+    import deepsign_integration
+
+    body = _json.dumps({"event": "document.signed", "document_id": "doc-1"}).encode()
+    signature = deepsign_integration.sign_webhook_payload(body)
+    with patch.object(
+        deepsign_integration,
+        "handle_webhook",
+        return_value={"action": "signature_completed", "document_id": "doc-1"},
+    ) as handler:
+        response = app_with_deepsign_secret.app.test_client().post(
+            "/webhook/deepsign",
+            data=body,
+            content_type="application/json",
+            headers={"X-DeepSign-Signature": signature},
+        )
+    assert response.status_code == 200
+    handler.assert_called_once()
+
+
 def test_deepsign_signature_verification_helper():
     import deepsign_integration
 

--- a/tests/test_public_hardening.py
+++ b/tests/test_public_hardening.py
@@ -1,0 +1,149 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Hardening contract: fail-closed cron auth, verified webhooks, complete env
+template, gitignore coverage, no dead deploy surface."""
+
+import importlib
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+CRON_ENDPOINTS = (
+    "/api/cron/process-emails",
+    "/api/cron/refresh-public-data",
+    "/api/cron/backfill-elcom",
+    "/api/cron/process-billing",
+)
+
+# Every env var the code reads that a self-hoster may need to set.
+REQUIRED_ENV_EXAMPLE_VARS = (
+    "CRON_SECRET",
+    "REDIS_URL",
+    "DEEPSIGN_API_KEY",
+    "DEEPSIGN_API_URL",
+    "DEEPSIGN_WEBHOOK_SECRET",
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "STRIPE_PRICE_STARTER",
+    "STRIPE_PRICE_ENTERPRISE",
+    "DB_POOL_MIN",
+    "DB_POOL_MAX",
+)
+
+
+def _load_app(env_overrides, remove=()):
+    with patch.dict(
+        os.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "APP_BASE_URL": "http://localhost:5003",
+            **env_overrides,
+        },
+    ):
+        for key in remove:
+            os.environ.pop(key, None)
+        with (
+            patch("database.is_db_available", return_value=True),
+            patch("database._connection_pool", MagicMock()),
+        ):
+            import app as app_module
+
+            return importlib.reload(app_module)
+
+
+@pytest.fixture
+def app_without_cron_secret():
+    module = _load_app({}, remove=("CRON_SECRET",))
+    yield module
+
+
+@pytest.fixture
+def app_with_deepsign_secret():
+    import deepsign_integration
+
+    with patch.dict(os.environ, {"DEEPSIGN_WEBHOOK_SECRET": "test-webhook-secret"}):
+        importlib.reload(deepsign_integration)
+        module = _load_app({"DEEPSIGN_WEBHOOK_SECRET": "test-webhook-secret"})
+        yield module
+    importlib.reload(deepsign_integration)
+
+
+def test_cron_endpoints_fail_closed_without_secret(app_without_cron_secret):
+    client = app_without_cron_secret.app.test_client()
+    for endpoint in CRON_ENDPOINTS:
+        response = client.post(endpoint)
+        assert response.status_code == 403, (
+            f"{endpoint} must fail closed when CRON_SECRET is unset, "
+            f"got {response.status_code}"
+        )
+
+
+def test_deepsign_webhook_rejects_unsigned_when_secret_set(app_with_deepsign_secret):
+    client = app_with_deepsign_secret.app.test_client()
+    response = client.post(
+        "/webhook/deepsign",
+        json={"event": "document.signed", "document_id": "doc-1"},
+    )
+    assert response.status_code == 403
+
+
+def test_deepsign_signature_verification_helper():
+    import deepsign_integration
+
+    with patch.object(deepsign_integration, "WEBHOOK_SECRET", "s3cret"):
+        body = b'{"event":"document.signed"}'
+        good = deepsign_integration.sign_webhook_payload(body)
+        assert deepsign_integration.verify_webhook_signature(body, good)
+        assert not deepsign_integration.verify_webhook_signature(body, "bad")
+        assert not deepsign_integration.verify_webhook_signature(body, "")
+
+    with patch.object(deepsign_integration, "WEBHOOK_SECRET", ""):
+        # Without a configured secret the check is a no-op (dev mode).
+        assert deepsign_integration.verify_webhook_signature(b"x", "")
+
+
+def test_env_example_documents_all_required_vars():
+    content = Path(PROJECT_ROOT, ".env.example").read_text(encoding="utf-8")
+    missing = [var for var in REQUIRED_ENV_EXAMPLE_VARS if var not in content]
+    assert missing == []
+
+
+def test_gitignore_covers_local_artifacts():
+    should_ignore = (
+        ".env.staging",
+        ".env.backup",
+        "backups/dump.sql",
+        "snapshot.sql.gz",
+        "db.dump",
+        "output/anything.png",
+        "gitleaks.sarif",
+    )
+    unignored = []
+    for path in should_ignore:
+        result = subprocess.run(["git", "check-ignore", "-q", path], cwd=PROJECT_ROOT)
+        if result.returncode != 0:
+            unignored.append(path)
+    assert unignored == []
+
+    # Tracked keep-set must be excluded from the /*.md catch-all.
+    for path in (".env.example", "CLAUDE.md", "AGENTS.md"):
+        result = subprocess.run(["git", "check-ignore", "-q", path], cwd=PROJECT_ROOT)
+        assert result.returncode != 0, f"{path} must not be gitignored"
+
+
+def test_dead_deploy_configs_are_untracked():
+    tracked = subprocess.run(
+        ["git", "ls-files"],
+        cwd=PROJECT_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.splitlines()
+    for path in ("railway.toml", "Procfile", "passenger_wsgi.py"):
+        assert path not in tracked


### PR DESCRIPTION
Closes #129

## What

- **Cron endpoints fail closed**: `/api/cron/{process-emails,refresh-public-data,backfill-elcom,process-billing}` previously accepted unauthenticated calls whenever `CRON_SECRET` was unset (the default). They now share a `_require_cron_secret()` guard that 403s without a configured secret, mirroring `_require_admin`.
- **DeepSign webhook verification**: `/webhook/deepsign` verifies an HMAC-SHA256 signature (`X-DeepSign-Signature` over the raw body) when `DEEPSIGN_WEBHOOK_SECRET` is set; no-op in dev without a secret. Constant-time compare.
- **`.env.example` complete**: adds `CRON_SECRET`, `REDIS_URL`, `DB_POOL_MIN/MAX`, `DEEPSIGN_*`, `STRIPE_*` — every var the code reads.
- **`.gitignore` hardened**: `.env*` + `!.env.example`, `backups/`, `*.sql`, `*.sql.gz`, `*.dump`, `output/`, `gitleaks.sarif`, and negations for the tracked `/CLAUDE.md`/`/AGENTS.md` keep-set.
- **Dead deploy surface removed**: `Procfile`, `railway.toml`, `passenger_wsgi.py` (zero references anywhere; abandoned-host leftovers).

## Test-first

Red: 6 new failing tests in `tests/test_public_hardening.py` pinned the contract (fail-closed cron 403s, unsigned webhook 403, env template completeness, gitignore coverage via `git check-ignore`, dead configs untracked). Green: full gate `scripts/tdd_cycle.sh gate` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013wNouw1dNBHxJjNfvm8WDb

---
_Generated by [Claude Code](https://claude.ai/code/session_013wNouw1dNBHxJjNfvm8WDb)_