### PR TITLE
Phase 0: LEG registry positioning + goal doc + review rubric

### DIFF
--- a/docs/codex-execution.md
+++ b/docs/codex-execution.md
@@ -53,6 +53,34 @@ For a Claude Code cloud session driving Codex CLI:
   to `CLAUDE.md`, enforced by `tests/test_docs_boundary_contract.py`. Change
   both together, never one alone.
 
+## Review Rubric
+
+### Two axes: standards vs. spec
+
+Every review finding gets tagged against exactly one of two independent
+questions:
+
+- **Standards** — does the diff violate repo engineering conventions (style,
+  seam discipline via `database.get_connection`, security posture, test
+  patterns)?
+- **Spec** — does the diff actually implement the slice's contract, the one
+  pinned by the failing test written before implementation?
+
+Passing one does not imply passing the other: a diff can be clean,
+idiomatic code that solves the wrong problem, or a correct behavior wrapped
+in code that violates repo conventions. Conflating the two hides which
+failure mode actually occurred, so review comments should say which axis a
+finding belongs to.
+
+### The deletion test
+
+Before a new helper, module, or abstraction survives review, ask: if this
+were deleted, would anything break, or would nothing notice? A wrapper with
+exactly one caller that nothing else depends on should usually be inlined
+rather than kept. Complexity that vanishes when a module is deleted was
+pass-through cruft; complexity that reappears elsewhere was load-bearing and
+earns its keep.
+
 ## Alternative: Codex cloud tasks
 
 For delegating whole tasks to Codex cloud instead of the in-session CLI:

--- a/docs/leg-registry.md
+++ b/docs/leg-registry.md
@@ -58,9 +58,10 @@ requiring data that does not publicly exist.
   verdict.
 - **No automated import or scrape** from ElCom, BFE, or canton sources yet.
   Every registry entry starts as a human-moderated self-submission.
-- **No automatic re-verification job yet.** The data model reserves a
-  `last_verified_at` field so a future freshness pass does not require a
-  schema migration, but nothing populates or acts on it yet.
+- **No automatic re-verification job yet.** Phase 1's data model is planned
+  to reserve a `last_verified_at` field so a future freshness pass does not
+  require a schema migration, but as of this doc no registry data model
+  exists yet, and nothing populates or acts on that field.
 
 ## Related Docs
 

--- a/docs/leg-registry.md
+++ b/docs/leg-registry.md
@@ -1,0 +1,69 @@
+# LEG Registry
+
+## Goal
+
+Become the #1 **independent** LEG registry in Switzerland: open to every Lokale
+Elektrizitätsgemeinschaft (LEG) regardless of which platform formed it,
+self-service submit and claim, honestly scoped eligibility guidance, and a
+real freshness/verification pipeline so listings stay trustworthy over time.
+
+## Why This Matters
+
+Existing LEG tooling in Switzerland is largely sold through individual grid
+operators (VNB) to their own customers. A directory built that way can only
+ever show LEGs that went through one specific platform and one specific
+onboarded utility — it cannot become a neutral, nationwide source of truth.
+There is currently no comprehensive public data source that lists all Swiss
+LEGs: ElCom has no LEG-specific dataset yet, federal reporting is periodic
+rather than live, canton-level energy offices are inconsistent, and the
+commercial register is not a reliable source because a LEG is typically
+formed as an *einfache Gesellschaft* (simple partnership), not a registered
+legal entity. An open, self-service registry that any LEG can join — whoever
+formed it, on whatever platform — fills that gap.
+
+## Phase 0 — Positioning
+
+Sharpen the existing stakeholder pathway pages (`/fuer-bewohner`,
+`/fuer-gemeinden`, `/leg-gruenden`, `/open-source`) so the platform's real,
+already-shippable differentiators are explicit: transparent pricing, no
+lock-in to a single grid operator, and tooling that works the same way
+regardless of which Verteilnetzbetreiber serves an address. All positioning
+copy is competitor-neutral: it states what OpenLEG does, not a comparison to
+any named product.
+
+## Phase 1 — Open Registry MVP
+
+A public, searchable directory (`/leg-verzeichnis`) of Swiss LEGs, populated
+by self-service submission and gated by human moderation before anything
+goes public. Any LEG can list itself, independent of which platform (if any)
+was used to form it. Claim-by-email-verification lets a LEG's real operator
+take ownership of a self-submitted listing.
+
+## Phase 2 — Freshness and Verification Pipeline
+
+Periodic re-confirmation nudges to listed contacts, plausibility cross-checks
+against public reference data already used elsewhere in this codebase (ElCom
+grid-operator-per-municipality data, postal-code/canton resolution), and
+staleness surfaced to moderators. This keeps the registry accurate without
+requiring data that does not publicly exist.
+
+## Explicit Non-Goals (Right Now)
+
+- **No grid-topology (Netz-Topologie) eligibility verification.** Whether
+  specific buildings share a low-voltage grid segment is data held
+  individually by each Swiss grid operator, not public data. Nothing in the
+  registry, and nothing in any eligibility-check tooling built on top of it,
+  claims to verify this. A published listing means a LEG self-reported and
+  was moderated for plausibility — it is not a topology or eligibility
+  verdict.
+- **No automated import or scrape** from ElCom, BFE, or canton sources yet.
+  Every registry entry starts as a human-moderated self-submission.
+- **No automatic re-verification job yet.** The data model reserves a
+  `last_verified_at` field so a future freshness pass does not require a
+  schema migration, but nothing populates or acts on it yet.
+
+## Related Docs
+
+- `docs/codex-execution.md` — execution contract and review rubric.
+- `docs/architecture.md` — overall system architecture.
+- `docs/repo-boundary.md` — public/private repo boundary rules.

--- a/templates/fuer_bewohner.html
+++ b/templates/fuer_bewohner.html
@@ -84,7 +84,9 @@
         <li>&#10003; Open Source, gehostet in der Schweiz</li>
         <li>&#10003; Smart-Meter-Daten bleiben in Ihrer LEG</li>
         <li>&#10003; Kein Datenverkauf, jederzeit löschbar</li>
+        <li>&#10003; Funktioniert unabhängig vom Netzbetreiber</li>
       </ul>
+      <p class="text-sm text-ink-muted mt-4">Alle Funktionen sind kostenlos. Die <a href="/pricing" class="text-brand underline">Preisübersicht</a> zeigt das transparent, ganz ohne Anfrage.</p>
     </section>
   </main>
 {% endblock %}

--- a/templates/fuer_gemeinden.html
+++ b/templates/fuer_gemeinden.html
@@ -39,7 +39,7 @@
           <li>&#10003; Open Source (AGPL-3.0)</li>
           <li>&#10003; Volle Datenhoheit</li>
           <li>&#10003; Transparente Weiterentwicklung via GitHub</li>
-          <li>&#10003; Kein Anbieter-Lock-in, Code bleibt Ihr Eigentum</li>
+          <li>&#10003; Kein Anbieter-Lock-in, Code bleibt Open Source und jederzeit selbst betreibbar</li>
         </ul>
         <pre class="bg-ink text-slate-300 rounded-lg p-4 text-sm overflow-x-auto mb-4"><code>git clone https://github.com/Open-LEG-ch/openleg.git
 cd openleg

--- a/templates/fuer_gemeinden.html
+++ b/templates/fuer_gemeinden.html
@@ -39,6 +39,7 @@
           <li>&#10003; Open Source (AGPL-3.0)</li>
           <li>&#10003; Volle Datenhoheit</li>
           <li>&#10003; Transparente Weiterentwicklung via GitHub</li>
+          <li>&#10003; Kein Anbieter-Lock-in, Code bleibt Ihr Eigentum</li>
         </ul>
         <pre class="bg-ink text-slate-300 rounded-lg p-4 text-sm overflow-x-auto mb-4"><code>git clone https://github.com/Open-LEG-ch/openleg.git
 cd openleg
@@ -56,8 +57,10 @@ docker compose up -d</code></pre>
           <li>&#10003; Setup und Betrieb durch uns (SLA optional)</li>
           <li>&#10003; Schulungen, Onboarding, SDAT-CH Integration (optional)</li>
           <li>&#10003; Keine Abopflicht, kein Datenverkauf</li>
+          <li>&#10003; Unabhängig vom Netzbetreiber, für jede Gemeinde nutzbar</li>
         </ul>
         <a href="/gemeinde/onboarding" class="block text-center bg-brand text-white py-3 rounded-lg font-semibold hover:bg-brand-dark mb-2">Gemeinde anmelden</a>
+        <a href="/pricing" class="block text-center border border-ink/20 text-ink py-3 rounded-lg font-semibold hover:bg-slate-50 mb-2">Preise ansehen</a>
         <a href="mailto:hallo@openleg.ch?subject=OpenLEG%20Gemeinde%20Projektsupport" class="block text-center border border-ink/20 text-ink py-3 rounded-lg font-semibold hover:bg-slate-50">Projektsupport anfragen</a>
       </section>
     </div>

--- a/templates/leg_gruenden.html
+++ b/templates/leg_gruenden.html
@@ -54,6 +54,7 @@
           <div class="text-sm text-ink-muted">Mindestgrösse</div>
         </div>
       </div>
+      <p class="text-sm text-ink-muted mt-4">Diese Kosten betreffen externe Beratung und Zähler. OpenLEGs Software für Abrechnung, Dokumente und Mitgliederverwaltung ist kostenlos, siehe <a href="/pricing" class="text-brand underline">Preisübersicht</a>.</p>
     </section>
 
     <!-- Step-by-Step Guide -->
@@ -239,6 +240,7 @@
                 <span><strong>Netznutzungsvertrag:</strong> Reduzierte Netznutzungsgebühr für lokal verbrauchten Strom</span>
               </li>
             </ul>
+            <p class="text-sm text-ink-muted mb-4">Diese Anmeldung funktioniert bei jedem Schweizer Netzbetreiber. OpenLEG ist nicht auf einzelne Partner-Netzbetreiber beschränkt.</p>
             <div class="p-4 bg-slate-100 rounded-lg">
               <p class="text-sm text-ink-muted">
                 <strong>Bearbeitungszeit:</strong> Der VNB hat 2-4 Wochen Zeit zur Prüfung. Bei Ablehnung muss er dies begründen.

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -110,6 +110,7 @@ docker compose up -d</code></pre>
     <section class="bg-brand/5 border border-brand/20 rounded-xl p-6">
       <h2 class="text-xl font-bold mb-2">Warum offen?</h2>
       <p class="text-ink-muted">Lokale Stromgemeinschaften brauchen Vertrauen. Gemeinden, Bewohner und Entwickler sollen prüfen können, welche Daten genutzt werden, welche Annahmen in Berechnungen stecken und wie die Plattform betrieben werden kann. OpenLEG verkauft keine Bürgerdaten.</p>
+      <p class="text-ink-muted mt-3">OpenLEG bindet sich nicht an einzelne Netzbetreiber. Code und Datenmodell sind neutrale Infrastruktur, nutzbar unabhängig davon, welcher Verteilnetzbetreiber eine Gemeinde bedient.</p>
     </section>
   </main>
 {% endblock %}

--- a/tests/test_codex_execution_doc.py
+++ b/tests/test_codex_execution_doc.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract tests for the codex-execution review rubric."""
+
+from pathlib import Path
+
+
+DOC_PATH = Path("docs/codex-execution.md")
+
+
+def _doc_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_codex_execution_doc_has_review_rubric_section() -> None:
+    text = _doc_text()
+    assert "## Review Rubric" in text
+
+
+def test_codex_execution_doc_has_two_axis_review() -> None:
+    text = _doc_text()
+    assert "### Two axes: standards vs. spec" in text
+
+
+def test_codex_execution_doc_has_deletion_test() -> None:
+    text = _doc_text()
+    assert "### The deletion test" in text

--- a/tests/test_leg_registry_doc.py
+++ b/tests/test_leg_registry_doc.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract tests for the durable LEG registry goal doc."""
+
+from pathlib import Path
+
+
+DOC_PATH = Path("docs/leg-registry.md")
+
+
+def _doc_text() -> str:
+    return DOC_PATH.read_text(encoding="utf-8")
+
+
+def test_leg_registry_doc_exists() -> None:
+    assert DOC_PATH.exists(), "docs/leg-registry.md must exist"
+
+
+def test_leg_registry_doc_includes_required_sections() -> None:
+    text = _doc_text()
+    for section in (
+        "## Goal",
+        "## Why This Matters",
+        "## Phase 0",
+        "## Phase 1",
+        "## Phase 2",
+        "## Explicit Non-Goals",
+        "## Related Docs",
+    ):
+        assert section in text, section
+
+
+def test_leg_registry_doc_states_topology_honesty_boundary() -> None:
+    text = _doc_text().lower()
+    assert "netz-topologie" in text or "netztopologie" in text

--- a/tests/test_stakeholder_pathways.py
+++ b/tests/test_stakeholder_pathways.py
@@ -144,6 +144,33 @@ def test_fuer_bewohner_in_sitemap(full_app_module, monkeypatch):
     assert "/fuer-bewohner" in xml
 
 
+# --- Phase 0: positioning copy (no vendor lock-in, transparent pricing) ---
+
+
+def test_fuer_bewohner_positions_against_vendor_lockin_and_links_pricing():
+    html = _read("fuer_bewohner.html")
+    assert "unabhängig vom Netzbetreiber" in html
+    assert 'href="/pricing"' in html
+
+
+def test_fuer_gemeinden_positions_against_vendor_lockin_and_links_pricing():
+    html = _read("fuer_gemeinden.html")
+    assert "Kein Anbieter-Lock-in" in html
+    assert "Unabhängig vom Netzbetreiber" in html
+    assert 'href="/pricing"' in html
+
+
+def test_leg_gruenden_positions_free_tooling_and_links_pricing():
+    html = _read("leg_gruenden.html")
+    assert 'href="/pricing"' in html
+    assert "jedem Schweizer Netzbetreiber" in html
+
+
+def test_open_source_positions_as_grid_operator_neutral():
+    html = _read("open_source.html")
+    assert "nicht an einzelne Netzbetreiber" in html
+
+
 # --- Profile page rebrand + resident CTA ---
 
 


### PR DESCRIPTION
## Summary

First slice of the LEG registry roadmap (goal: become the #1 independent LEG registry in Switzerland — open to any LEG regardless of formation platform, honestly scoped, transparent).

- Adds competitor-neutral positioning copy to the four stakeholder pathway pages (`fuer_bewohner`, `fuer_gemeinden`, `leg_gruenden`, `open_source`): no vendor lock-in to a single grid operator, transparent pricing via `/pricing`. Every claim is backed by real, already-shippable functionality — no comparisons to any named product.
- Adds `docs/leg-registry.md`: the durable goal + phase doc, including an explicit non-goals section pinning the honesty boundary that OpenLEG never claims to verify low-voltage grid-topology eligibility (that data isn't public — it's held individually by each Swiss grid operator).
- Adds a `## Review Rubric` section to `docs/codex-execution.md`: a two-axis (standards vs. spec) review split and a "deletion test" heuristic for judging new abstractions, adapted from ideas in Matt Pocock's public engineering skills collection.

Closes #141
Closes #142

## Test plan

- [x] New assertions added test-first in `tests/test_stakeholder_pathways.py`, `tests/test_leg_registry_doc.py`, `tests/test_codex_execution_doc.py`, confirmed red before implementation.
- [x] `scripts/tdd_cycle.sh gate` (full pytest + ruff check + ruff format --check) green: 522 passed, 6 skipped.
- [x] No competitor named or disparaged anywhere in shipped copy.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_