### PR TITLE
Phase 1 Slice 1: store/registry.py + leg_registry schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,7 @@ Domain vocabulary lives in `CONTEXT.md`. Use those module/seam names.
   Shipped: `store/ranking` (PV/Rangliste), `store/profile` (municipality energy
   profile: ElCom tariffs, profiles, Sonnendach), `store/billing` (LEG community
   billing), `store/email_queue` (outbound email queue), `store/utility` (EVU/VNB
-  utility clients).
+  utility clients), `store/registry` (open LEG registry, see `docs/leg-registry.md`).
 - New storage code for a cohesive domain goes in `store/`, not into `database.py`.
 - Deepening roadmap and next extraction order: `prd/architecture-deepening.md`.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,7 +78,7 @@ Domain vocabulary lives in `CONTEXT.md`. Use those module/seam names.
   Shipped: `store/ranking` (PV/Rangliste), `store/profile` (municipality energy
   profile: ElCom tariffs, profiles, Sonnendach), `store/billing` (LEG community
   billing), `store/email_queue` (outbound email queue), `store/utility` (EVU/VNB
-  utility clients).
+  utility clients), `store/registry` (open LEG registry, see `docs/leg-registry.md`).
 - New storage code for a cohesive domain goes in `store/`, not into `database.py`.
 - Deepening roadmap and next extraction order: `prd/architecture-deepening.md`.
 

--- a/database.py
+++ b/database.py
@@ -462,6 +462,38 @@ def _create_tables():
                 )
             """)
 
+            # Open LEG registry: self-submitted, human-moderated directory of
+            # Swiss LEGs, independent of which platform (if any) formed them.
+            # See docs/leg-registry.md for the product contract.
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS leg_registry (
+                    id SERIAL PRIMARY KEY,
+                    slug VARCHAR(128) UNIQUE NOT NULL,
+                    name VARCHAR(255) NOT NULL,
+                    kanton VARCHAR(2),
+                    plz VARCHAR(10),
+                    ort VARCHAR(255),
+                    bfs_number INTEGER,
+                    vnb_name VARCHAR(255),
+                    member_count_estimate INTEGER,
+                    leg_status VARCHAR(32) DEFAULT 'planung',
+                    description TEXT,
+                    website_url VARCHAR(512),
+                    contact_email VARCHAR(255) NOT NULL,
+                    moderation_status VARCHAR(32) DEFAULT 'pending',
+                    moderation_note TEXT,
+                    source VARCHAR(32) DEFAULT 'self_submitted',
+                    community_id VARCHAR(64) REFERENCES communities(community_id),
+                    claim_token VARCHAR(128),
+                    claim_token_expires_at TIMESTAMP,
+                    claimed_at TIMESTAMP,
+                    claimed_by_email VARCHAR(255),
+                    last_verified_at TIMESTAMP,
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS billing_periods (
                     id SERIAL PRIMARY KEY,
@@ -697,6 +729,16 @@ def _create_tables():
             )
             cur.execute(
                 "CREATE INDEX IF NOT EXISTS idx_utility_clients_magic_token ON utility_clients(magic_link_token)"
+            )
+
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leg_registry_moderation_status ON leg_registry(moderation_status)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leg_registry_kanton ON leg_registry(kanton)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leg_registry_plz ON leg_registry(plz)"
             )
 
             # LEA autonomous reports (instance ops, posted via /api/internal/*)
@@ -1859,6 +1901,18 @@ from store.utility import (  # noqa: E402, F401
     update_utility_client_api_key,
     get_all_utility_clients,
     get_utility_client_stats,
+)
+
+from store.registry import (  # noqa: E402, F401
+    save_registry_entry,
+    get_registry_entry,
+    get_registry_entry_by_slug,
+    list_registry_entries,
+    update_registry_entry_moderation,
+    get_registry_pending_count,
+    set_registry_claim_token,
+    get_registry_entry_by_claim_token,
+    mark_registry_entry_claimed,
 )
 
 from store.meter import (  # noqa: E402, F401

--- a/database.py
+++ b/database.py
@@ -483,7 +483,8 @@ def _create_tables():
                     moderation_status VARCHAR(32) DEFAULT 'pending',
                     moderation_note TEXT,
                     source VARCHAR(32) DEFAULT 'self_submitted',
-                    community_id VARCHAR(64) REFERENCES communities(community_id),
+                    community_id VARCHAR(64)
+                        REFERENCES communities(community_id) ON DELETE SET NULL,
                     claim_token VARCHAR(128),
                     claim_token_expires_at TIMESTAMP,
                     claimed_at TIMESTAMP,
@@ -739,6 +740,9 @@ def _create_tables():
             )
             cur.execute(
                 "CREATE INDEX IF NOT EXISTS idx_leg_registry_plz ON leg_registry(plz)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_leg_registry_claim_token ON leg_registry(claim_token)"
             )
 
             # LEA autonomous reports (instance ops, posted via /api/internal/*)

--- a/store/registry.py
+++ b/store/registry.py
@@ -42,7 +42,11 @@ def save_registry_entry(
     website_url: str = "",
     source: str = "self_submitted",
 ) -> Optional[Dict]:
-    """Create a new registry entry, pending moderation. Returns the row id."""
+    """Create a new registry entry, pending moderation.
+
+    Returns the newly created row as a dict (e.g. {"id": ...}), or None on
+    failure.
+    """
     try:
         with _get_connection() as conn:
             with conn.cursor() as cur:
@@ -206,7 +210,8 @@ def set_registry_claim_token(
                     """
                     UPDATE leg_registry
                     SET claim_token = %s,
-                        claim_token_expires_at = CURRENT_TIMESTAMP + INTERVAL '%s seconds',
+                        claim_token_expires_at = CURRENT_TIMESTAMP
+                            + %s * INTERVAL '1 second',
                         updated_at = CURRENT_TIMESTAMP
                     WHERE id = %s
                 """,

--- a/store/registry.py
+++ b/store/registry.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Open LEG registry repository.
+
+Repository module for the LEG registry domain: the ``leg_registry`` table
+holds self-submitted, human-moderated listings of Swiss Lokale
+Elektrizitätsgemeinschaften, independent of which platform (if any) formed
+them. See ``docs/leg-registry.md`` for the product contract, in particular
+the honesty boundary: a published entry is a moderated self-report, never a
+verified grid-topology eligibility signal. The connection seam is resolved
+via ``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working
+unchanged and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Optional, Dict, List
+
+logger = logging.getLogger(__name__)
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+# === Registry Entry Operations ===
+
+
+def save_registry_entry(
+    slug: str,
+    name: str,
+    contact_email: str,
+    kanton: str = "",
+    plz: str = "",
+    ort: str = "",
+    bfs_number: Optional[int] = None,
+    vnb_name: str = "",
+    member_count_estimate: Optional[int] = None,
+    leg_status: str = "planung",
+    description: str = "",
+    website_url: str = "",
+    source: str = "self_submitted",
+) -> Optional[Dict]:
+    """Create a new registry entry, pending moderation. Returns the row id."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO leg_registry (
+                        slug, name, contact_email, kanton, plz, ort,
+                        bfs_number, vnb_name, member_count_estimate,
+                        leg_status, description, website_url,
+                        moderation_status, source
+                    ) VALUES (
+                        %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                        %s, %s
+                    )
+                    RETURNING id
+                """,
+                    (
+                        slug,
+                        name,
+                        contact_email,
+                        kanton,
+                        plz,
+                        ort,
+                        bfs_number,
+                        vnb_name,
+                        member_count_estimate,
+                        leg_status,
+                        description,
+                        website_url,
+                        "pending",
+                        source,
+                    ),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error saving registry entry: {e}")
+        return None
+
+
+def get_registry_entry(entry_id: int) -> Optional[Dict]:
+    """Get a registry entry by id, regardless of moderation status."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM leg_registry WHERE id = %s", (entry_id,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting registry entry: {e}")
+        return None
+
+
+def get_registry_entry_by_slug(slug: str) -> Optional[Dict]:
+    """Get a registry entry by slug, regardless of moderation status.
+
+    Callers that serve public pages must filter on moderation_status
+    themselves; this helper does not apply that filter.
+    """
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute("SELECT * FROM leg_registry WHERE slug = %s", (slug,))
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting registry entry by slug: {e}")
+        return None
+
+
+def list_registry_entries(
+    kanton: Optional[str] = None,
+    plz: Optional[str] = None,
+    leg_status: Optional[str] = None,
+    q: Optional[str] = None,
+    moderation_status: str = "published",
+) -> List[Dict]:
+    """List registry entries, defaulting to published-only.
+
+    Every caller that serves a public page must rely on this default (or
+    pass moderation_status='published' explicitly) rather than trust a
+    client-supplied moderation status.
+    """
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                clauses = ["moderation_status = %s"]
+                params: List = [moderation_status]
+                if kanton:
+                    clauses.append("kanton = %s")
+                    params.append(kanton)
+                if plz:
+                    clauses.append("plz = %s")
+                    params.append(plz)
+                if leg_status:
+                    clauses.append("leg_status = %s")
+                    params.append(leg_status)
+                if q:
+                    clauses.append("(name ILIKE %s OR ort ILIKE %s)")
+                    params.extend([f"%{q}%", f"%{q}%"])
+                where = " AND ".join(clauses)
+                cur.execute(
+                    f"""
+                    SELECT * FROM leg_registry
+                    WHERE {where}
+                    ORDER BY created_at DESC
+                """,
+                    tuple(params),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error listing registry entries: {e}")
+        return []
+
+
+def update_registry_entry_moderation(
+    entry_id: int, moderation_status: str, moderation_note: str = ""
+) -> bool:
+    """Approve or reject a pending registry entry."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leg_registry
+                    SET moderation_status = %s, moderation_note = %s,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (moderation_status, moderation_note, entry_id),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error updating registry entry moderation: {e}")
+        return False
+
+
+def get_registry_pending_count() -> int:
+    """Count entries awaiting moderation."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT COUNT(*) as count FROM leg_registry WHERE moderation_status = 'pending'"
+                )
+                row = cur.fetchone()
+                return dict(row)["count"] if row else 0
+    except Exception as e:
+        logger.error(f"[DB] Error counting pending registry entries: {e}")
+        return 0
+
+
+def set_registry_claim_token(
+    entry_id: int, token: str, ttl_seconds: int = 86400
+) -> bool:
+    """Set a claim-verification token for a registry entry."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leg_registry
+                    SET claim_token = %s,
+                        claim_token_expires_at = CURRENT_TIMESTAMP + INTERVAL '%s seconds',
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (token, ttl_seconds, entry_id),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error setting registry claim token: {e}")
+        return False
+
+
+def get_registry_entry_by_claim_token(token: str) -> Optional[Dict]:
+    """Get a registry entry by claim token (only if not expired)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM leg_registry
+                    WHERE claim_token = %s AND claim_token_expires_at > CURRENT_TIMESTAMP
+                """,
+                    (token,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting registry entry by claim token: {e}")
+        return None
+
+
+def mark_registry_entry_claimed(entry_id: int, claimed_by_email: str) -> bool:
+    """Mark a registry entry as claimed and clear its claim token."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leg_registry
+                    SET source = 'claimed', claimed_at = CURRENT_TIMESTAMP,
+                        claimed_by_email = %s, claim_token = NULL,
+                        claim_token_expires_at = NULL, updated_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (claimed_by_email, entry_id),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error marking registry entry claimed: {e}")
+        return False

--- a/tests/test_store_registry.py
+++ b/tests/test_store_registry.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the LEG registry repository (store.registry).
+
+Verifies the extracted module resolves the connection seam via
+`database.get_connection` and that `database` re-exports the identical objects,
+so legacy callers and existing monkeypatches keep working unchanged. Mirrors
+`test_store_utility.py`; the seam is the test surface.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import registry
+
+
+_REEXPORTED = (
+    "save_registry_entry",
+    "get_registry_entry",
+    "get_registry_entry_by_slug",
+    "list_registry_entries",
+    "update_registry_entry_moderation",
+    "get_registry_pending_count",
+    "set_registry_claim_token",
+    "get_registry_entry_by_claim_token",
+    "mark_registry_entry_claimed",
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None, rowcount=0):
+        self.rows = rows or []
+        self.one = one
+        self.rowcount = rowcount
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    for name in _REEXPORTED:
+        assert getattr(database, name) is getattr(registry, name), name
+
+
+def test_store_registry_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.registry; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_registry_uses_database_connection_seam(monkeypatch):
+    cur = _FakeCursor(
+        rows=[{"id": 1, "slug": "leg-baden", "moderation_status": "published"}]
+    )
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = registry.list_registry_entries(moderation_status="published")
+    assert rows == [{"id": 1, "slug": "leg-baden", "moderation_status": "published"}]
+    assert "leg_registry" in cur.executed[0][0]
+    assert "moderation_status = %s" in cur.executed[0][0]
+
+
+def test_list_registry_entries_always_includes_moderation_status_param(monkeypatch):
+    # A caller must never be able to omit the moderation filter and see
+    # everything; the function signature defaults it to 'published'.
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    registry.list_registry_entries()
+    assert cur.executed[0][1][0] == "published"
+
+
+def test_get_registry_entry_by_slug_missing_returns_none(monkeypatch):
+    cur = _FakeCursor(one=None)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert registry.get_registry_entry_by_slug("nope") is None
+
+
+def test_save_registry_entry_defaults_to_pending_moderation(monkeypatch):
+    cur = _FakeCursor(one={"id": 5})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    registry.save_registry_entry(
+        slug="leg-baden",
+        name="LEG Baden",
+        contact_email="info@example.ch",
+    )
+    query, params = cur.executed[0]
+    assert "leg_registry" in query
+    assert "pending" in params
+    assert "self_submitted" in params
+
+
+def test_set_registry_claim_token_updates_expiry(monkeypatch):
+    cur = _FakeCursor(rowcount=1)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert registry.set_registry_claim_token(5, "tok123", ttl_seconds=3600) is True
+    assert "claim_token" in cur.executed[0][0]
+
+
+def test_get_registry_pending_count_returns_zero_by_default(monkeypatch):
+    cur = _FakeCursor(one={"count": 0})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert registry.get_registry_pending_count() == 0


### PR DESCRIPTION
## Summary

First code slice of Phase 1 (Open LEG Registry MVP), part of the LEG registry roadmap (`docs/leg-registry.md`).

- New `store/registry.py` module + `leg_registry` table, following the existing `store/utility.py` pattern.
- `list_registry_entries` defaults `moderation_status='published'` so no caller can accidentally list unmoderated entries.
- `community_id` FK to `communities` reserved (nullable) for a future auto-link job, not used yet.
- `CLAUDE.md`/`AGENTS.md` Data Layer bullet updated together.

Closes #148

## Test plan

- [x] `tests/test_store_registry.py` written test-first (red confirmed before implementation), mirrors `tests/test_store_utility.py`.
- [x] `scripts/tdd_cycle.sh gate` green: 530 passed, 6 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_