### PR TITLE
Phase 1 Slice 2: public LEG registry list + detail routes

### DIFF
--- a/app.py
+++ b/app.py
@@ -84,6 +84,7 @@ from api_public import public_api_bp
 from health import health_bp
 from utility_portal import utility_bp
 from rangliste import rangliste_bp
+from leg_registry import registry_bp
 
 # --- Cron Secret ---
 CRON_SECRET = os.getenv("CRON_SECRET", "").strip()
@@ -188,6 +189,7 @@ app.register_blueprint(public_api_bp)
 app.register_blueprint(health_bp)
 app.register_blueprint(utility_bp)
 app.register_blueprint(rangliste_bp)
+app.register_blueprint(registry_bp)
 
 # --- Multi-tenant middleware ---
 tenant_module.init_tenant_middleware(app, db=db)
@@ -574,6 +576,7 @@ def sitemap_xml():
         ("/pricing", "0.7", "monthly", current_date),
         ("/open-source", "0.8", "weekly", current_date),
         ("/gemeinde/verzeichnis", "0.9", "weekly", current_date),
+        ("/leg-verzeichnis", "0.9", "weekly", current_date),
         ("/rangliste", "0.9", "daily", current_date),
         ("/rangliste/fortschritte", "0.8", "daily", current_date),
         ("/rangliste/vergleich", "0.7", "weekly", current_date),

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Open LEG registry: public directory, self-service submission, and claim flow.
+
+See docs/leg-registry.md for the product contract — in particular the
+honesty boundary: a published entry is a moderated self-report, never a
+verified grid-topology eligibility signal.
+"""
+
+import logging
+
+from flask import Blueprint, abort, render_template, request
+
+import database as db
+from cantons import SWISS_CANTON_OPTIONS
+
+logger = logging.getLogger(__name__)
+
+registry_bp = Blueprint("registry", __name__)
+
+LEG_STATUS_OPTIONS = [
+    ("", "Alle Status"),
+    ("planung", "In Planung"),
+    ("gruendung", "In Gründung"),
+    ("aktiv", "Aktiv"),
+    ("pausiert", "Pausiert"),
+]
+
+
+def _clean_param(name):
+    value = (request.args.get(name) or "").strip()
+    if not value or value.upper() == "ALL":
+        return None
+    return value
+
+
+@registry_bp.route("/leg-verzeichnis")
+def liste():
+    kanton = _clean_param("kanton")
+    plz = _clean_param("plz")
+    leg_status = _clean_param("leg_status")
+    q = _clean_param("q")
+
+    entries = db.list_registry_entries(
+        kanton=kanton.upper() if kanton else None,
+        plz=plz,
+        leg_status=leg_status,
+        q=q,
+    )
+
+    return render_template(
+        "leg_verzeichnis/liste.html",
+        entries=entries,
+        kanton=kanton or "",
+        plz=plz or "",
+        leg_status=leg_status or "",
+        q=q or "",
+        canton_options=SWISS_CANTON_OPTIONS,
+        leg_status_options=LEG_STATUS_OPTIONS,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path="/leg-verzeichnis",
+    )
+
+
+@registry_bp.route("/leg-verzeichnis/<slug>")
+def detail(slug):
+    entry = db.get_registry_entry_by_slug(slug)
+    if not entry or entry.get("moderation_status") != "published":
+        abort(404)
+
+    return render_template(
+        "leg_verzeichnis/detail.html",
+        entry=entry,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path=f"/leg-verzeichnis/{slug}",
+    )

--- a/templates/leg_verzeichnis/detail.html
+++ b/templates/leg_verzeichnis/detail.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title=entry.name ~ " | LEG-Verzeichnis | OpenLEG",
+  description="Eintrag im offenen LEG-Verzeichnis: " ~ entry.name ~ (", " ~ entry.ort if entry.ort else "") ~ ". Moderierte Selbstauskunft, unabhängig von der Gründungsplattform.",
+  path=canonical_path,
+  og_type="article",
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-3xl mx-auto px-4 py-12">
+    <p class="text-sm mb-4"><a href="/leg-verzeichnis" class="text-brand hover:underline">&larr; Zurück zum Verzeichnis</a></p>
+
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold tracking-tight mb-2">{{ entry.name }}</h1>
+      <p class="text-ink-muted">{{ entry.ort }}{% if entry.kanton %} ({{ entry.kanton }}){% endif %}{% if entry.plz %} &middot; {{ entry.plz }}{% endif %}</p>
+    </header>
+
+    {% if entry.description %}
+    <p class="text-ink-muted mb-6">{{ entry.description }}</p>
+    {% endif %}
+
+    <dl class="grid sm:grid-cols-2 gap-4 mb-8">
+      {% if entry.leg_status %}
+      <div class="bg-white rounded-xl border p-4">
+        <dt class="text-sm text-ink-muted">Status</dt>
+        <dd class="font-semibold">{{ entry.leg_status }}</dd>
+      </div>
+      {% endif %}
+      {% if entry.member_count_estimate %}
+      <div class="bg-white rounded-xl border p-4">
+        <dt class="text-sm text-ink-muted">Mitglieder (geschätzt)</dt>
+        <dd class="font-semibold">ca. {{ entry.member_count_estimate }}</dd>
+      </div>
+      {% endif %}
+      {% if entry.vnb_name %}
+      <div class="bg-white rounded-xl border p-4">
+        <dt class="text-sm text-ink-muted">Netzbetreiber (Selbstauskunft)</dt>
+        <dd class="font-semibold">{{ entry.vnb_name }}</dd>
+      </div>
+      {% endif %}
+      {% if entry.website_url %}
+      <div class="bg-white rounded-xl border p-4">
+        <dt class="text-sm text-ink-muted">Website</dt>
+        <dd class="font-semibold"><a href="{{ entry.website_url }}" target="_blank" rel="noopener" class="text-brand hover:underline">{{ entry.website_url }}</a></dd>
+      </div>
+      {% endif %}
+    </dl>
+
+    <section class="bg-brand/5 border border-brand/20 rounded-xl p-6 mb-8">
+      <h2 class="font-bold mb-2">Was dieser Eintrag bedeutet</h2>
+      <p class="text-sm text-ink-muted">Dieser Eintrag ist eine moderierte Selbstauskunft der LEG. OpenLEG prüft keine Netz-Topologie und bestätigt nicht, welche Adressen konkret teilnehmen können. Diese Angabe zum Netzbetreiber stammt von der LEG selbst und ist nicht verifiziert.</p>
+    </section>
+
+    <div class="flex flex-col sm:flex-row gap-3">
+      <a href="/leg-verzeichnis/{{ entry.slug }}/beanspruchen" class="inline-block border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">Diese LEG betreiben Sie? Eintrag beanspruchen</a>
+    </div>
+  </main>
+{% endblock %}

--- a/templates/leg_verzeichnis/liste.html
+++ b/templates/leg_verzeichnis/liste.html
@@ -1,0 +1,63 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="LEG-Verzeichnis: Lokale Elektrizitätsgemeinschaften in der Schweiz | OpenLEG",
+  description="Offenes Verzeichnis Schweizer Lokaler Elektrizitätsgemeinschaften (LEG), unabhängig davon, welche Plattform bei der Gründung half. Selbst eintragen oder nach Kanton und PLZ suchen.",
+  path=canonical_path,
+  og_type="website",
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-6xl mx-auto px-4 py-12">
+    <header class="max-w-3xl mb-8">
+      <p class="text-sm font-semibold text-brand mb-2">LEG-Verzeichnis</p>
+      <h1 class="text-4xl font-bold tracking-tight mb-3">Lokale Elektrizitätsgemeinschaften in der Schweiz</h1>
+      <p class="text-lg text-ink-muted">Offen für jede LEG, unabhängig davon, welche Plattform bei der Gründung half. Einträge sind moderierte Selbstauskünfte: OpenLEG prüft keine Netz-Topologie und keine Eignung einzelner Adressen. Details dazu stehen bei jedem Eintrag.</p>
+      <div class="mt-5">
+        <a href="/leg-verzeichnis/eintragen" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Eigene LEG eintragen</a>
+      </div>
+    </header>
+
+    <form method="get" class="flex flex-col md:flex-row gap-3 mb-6">
+      <input type="text" name="q" value="{{ q }}" placeholder="Name oder Ort suchen..."
+        class="flex-1 border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      <input type="text" name="plz" value="{{ plz }}" placeholder="PLZ"
+        class="w-full md:w-28 border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      <select name="kanton" class="border rounded-lg px-3 py-2 text-sm bg-white">
+        {% for code, label in canton_options %}
+        <option value="{{ code }}" {{ 'selected' if kanton == code }}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <select name="leg_status" class="border rounded-lg px-3 py-2 text-sm bg-white">
+        {% for code, label in leg_status_options %}
+        <option value="{{ code }}" {{ 'selected' if leg_status == code }}>{{ label }}</option>
+        {% endfor %}
+      </select>
+      <button type="submit" class="bg-brand text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-brand-dark">Suchen</button>
+    </form>
+
+    {% if entries %}
+    <div class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+      {% for entry in entries %}
+      <a href="/leg-verzeichnis/{{ entry.slug }}" class="bg-white rounded-xl p-5 shadow-sm border hover:shadow-md hover:border-brand/30 transition-all">
+        <h2 class="font-semibold text-lg mb-1">{{ entry.name }}</h2>
+        <p class="text-sm text-ink-muted mb-2">{{ entry.ort }}{% if entry.kanton %} ({{ entry.kanton }}){% endif %}</p>
+        {% if entry.member_count_estimate %}
+        <p class="text-sm text-ink-muted">ca. {{ entry.member_count_estimate }} Mitglieder</p>
+        {% endif %}
+      </a>
+      {% endfor %}
+    </div>
+    <p class="text-sm text-ink-muted mt-6">{{ entries|length }} LEGs gefunden. OpenLEG prüft keine Netz-Topologie: ein Eintrag ist eine moderierte Selbstauskunft, kein Eignungsnachweis für eine bestimmte Adresse.</p>
+    {% else %}
+    <div class="bg-white rounded-xl p-8 text-center shadow-sm border">
+      <p class="text-ink-muted mb-2">Keine LEGs gefunden{% if q %} für "{{ q }}"{% endif %}.</p>
+      <p class="text-sm text-ink-muted">Fehlt Ihre LEG? <a href="/leg-verzeichnis/eintragen" class="text-brand hover:underline">Jetzt eintragen</a>. OpenLEG prüft keine Netz-Topologie: das Verzeichnis lebt von Selbstauskünften.</p>
+    </div>
+    {% endif %}
+  </main>
+{% endblock %}

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the public LEG registry routes (/leg-verzeichnis)."""
+
+import os
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+import leg_registry as leg_registry_module
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SAMPLE_ENTRY = {
+    "id": 1,
+    "slug": "leg-baden",
+    "name": "LEG Baden",
+    "kanton": "AG",
+    "plz": "5400",
+    "ort": "Baden",
+    "vnb_name": "Regionalwerke Baden",
+    "leg_status": "aktiv",
+    "member_count_estimate": 12,
+    "description": "Nachbarschaftliche Stromgemeinschaft in Baden.",
+    "website_url": "",
+    "moderation_status": "published",
+}
+
+
+def _make_client(monkeypatch, list_return=None, detail_return=None):
+    mock_list = MagicMock(return_value=list_return if list_return is not None else [])
+    mock_detail = MagicMock(return_value=detail_return)
+    monkeypatch.setattr(leg_registry_module.db, "list_registry_entries", mock_list)
+    monkeypatch.setattr(
+        leg_registry_module.db, "get_registry_entry_by_slug", mock_detail
+    )
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client(), mock_list, mock_detail
+
+
+def test_liste_renders_published_entries(monkeypatch):
+    client, mock_list, _ = _make_client(monkeypatch, list_return=[SAMPLE_ENTRY])
+    resp = client.get("/leg-verzeichnis")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "LEG Baden" in html
+    assert "Baden" in html
+
+
+def test_liste_never_passes_client_supplied_moderation_status(monkeypatch):
+    # A malicious query string must not be able to widen what's listed;
+    # the route must not accept/forward a moderation_status override at all.
+    client, mock_list, _ = _make_client(monkeypatch, list_return=[])
+    client.get("/leg-verzeichnis?moderation_status=pending")
+    _, kwargs = mock_list.call_args
+    assert "moderation_status" not in kwargs
+
+
+def test_liste_filters_by_kanton_plz_and_status(monkeypatch):
+    client, mock_list, _ = _make_client(monkeypatch, list_return=[])
+    client.get("/leg-verzeichnis?kanton=ag&plz=5400&leg_status=aktiv&q=Baden")
+    _, kwargs = mock_list.call_args
+    assert kwargs["kanton"] == "AG"
+    assert kwargs["plz"] == "5400"
+    assert kwargs["leg_status"] == "aktiv"
+    assert kwargs["q"] == "Baden"
+
+
+def test_liste_states_no_grid_topology_verification():
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    import unittest.mock as mock
+
+    with mock.patch.object(
+        leg_registry_module.db, "list_registry_entries", return_value=[]
+    ):
+        html = app.test_client().get("/leg-verzeichnis").data.decode("utf-8")
+    assert "prüft keine Netz-Topologie" in html
+
+
+def test_detail_renders_published_entry(monkeypatch):
+    client, _, mock_detail = _make_client(monkeypatch, detail_return=SAMPLE_ENTRY)
+    resp = client.get("/leg-verzeichnis/leg-baden")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "LEG Baden" in html
+    assert "prüft keine Netz-Topologie" in html
+    mock_detail.assert_called_once_with("leg-baden")
+
+
+def test_detail_404s_for_unknown_slug(monkeypatch):
+    client, _, _ = _make_client(monkeypatch, detail_return=None)
+    resp = client.get("/leg-verzeichnis/nope")
+    assert resp.status_code == 404
+
+
+def test_detail_404s_for_unpublished_entry(monkeypatch):
+    pending_entry = {**SAMPLE_ENTRY, "moderation_status": "pending"}
+    client, _, _ = _make_client(monkeypatch, detail_return=pending_entry)
+    resp = client.get("/leg-verzeichnis/leg-baden")
+    assert resp.status_code == 404


### PR DESCRIPTION
## Summary

Second code slice of Phase 1 (Open LEG Registry MVP), `docs/leg-registry.md`.

- New `leg_registry.py` blueprint (no url_prefix, mirrors `rangliste.py`): `GET /leg-verzeichnis` (list/filter by kanton, PLZ, status, free-text) and `GET /leg-verzeichnis/<slug>` (detail, 404 if unknown or unpublished).
- The list route never accepts or forwards a client-supplied moderation status — `store.list_registry_entries` always defaults to `moderation_status='published'`, pinned by a test that tries `?moderation_status=pending` and confirms it has no effect.
- Honesty-boundary copy ("prüft keine Netz-Topologie") pinned by tests on both templates.
- Registered in `app.py`, added to `sitemap.xml`.

Closes #150

## Test plan

- [x] `tests/test_leg_registry_routes.py` written test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 537 passed, 6 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_