### PR TITLE
Phase 1 Slice 3: self-service LEG registry submission

### DIFF
--- a/leg_registry.py
+++ b/leg_registry.py
@@ -7,10 +7,12 @@ verified grid-topology eligibility signal.
 """
 
 import logging
+import re
 
 from flask import Blueprint, abort, render_template, request
 
 import database as db
+import security_utils
 from cantons import SWISS_CANTON_OPTIONS
 
 logger = logging.getLogger(__name__)
@@ -25,12 +27,32 @@ LEG_STATUS_OPTIONS = [
     ("pausiert", "Pausiert"),
 ]
 
+_UMLAUT_MAP = str.maketrans(
+    {"ä": "ae", "ö": "oe", "ü": "ue", "Ä": "ae", "Ö": "oe", "Ü": "ue", "ß": "ss"}
+)
+
 
 def _clean_param(name):
     value = (request.args.get(name) or "").strip()
     if not value or value.upper() == "ALL":
         return None
     return value
+
+
+def _slugify(name: str) -> str:
+    base = name.translate(_UMLAUT_MAP).lower()
+    base = re.sub(r"[^a-z0-9]+", "-", base).strip("-")
+    return base or "leg"
+
+
+def _unique_slug(name: str) -> str:
+    base = _slugify(name)
+    slug = base
+    suffix = 2
+    while db.get_registry_entry_by_slug(slug) is not None:
+        slug = f"{base}-{suffix}"
+        suffix += 1
+    return slug
 
 
 @registry_bp.route("/leg-verzeichnis")
@@ -72,4 +94,93 @@ def detail(slug):
         entry=entry,
         site_url=request.url_root.rstrip("/"),
         canonical_path=f"/leg-verzeichnis/{slug}",
+    )
+
+
+@registry_bp.route("/leg-verzeichnis/eintragen", methods=["GET", "POST"])
+def eintragen():
+    if request.method == "GET":
+        return render_template(
+            "leg_verzeichnis/eintragen.html",
+            canton_options=SWISS_CANTON_OPTIONS,
+            leg_status_options=LEG_STATUS_OPTIONS,
+            site_url=request.url_root.rstrip("/"),
+            canonical_path="/leg-verzeichnis/eintragen",
+            error=None,
+            form=None,
+        )
+
+    form = request.form
+    name = (form.get("name") or "").strip()
+    contact_email = (form.get("contact_email") or "").strip()
+
+    if not name or not contact_email:
+        return _eintragen_error(
+            "Name und Kontakt-E-Mail sind erforderlich.", form, status=400
+        )
+
+    is_valid, normalized_email, email_error = security_utils.validate_email_address(
+        contact_email
+    )
+    if not is_valid:
+        return _eintragen_error(email_error, form, status=400)
+
+    leg_status = (form.get("leg_status") or "planung").strip()
+    if leg_status not in {code for code, _ in LEG_STATUS_OPTIONS if code}:
+        leg_status = "planung"
+
+    member_count_raw = (form.get("member_count_estimate") or "").strip()
+    member_count_estimate = (
+        int(member_count_raw) if member_count_raw.isdigit() else None
+    )
+    kanton = (form.get("kanton") or "").strip().upper()
+
+    slug = _unique_slug(name)
+    saved = db.save_registry_entry(
+        slug=slug,
+        name=name,
+        contact_email=normalized_email,
+        kanton=kanton,
+        plz=(form.get("plz") or "").strip(),
+        ort=(form.get("ort") or "").strip(),
+        vnb_name=(form.get("vnb_name") or "").strip(),
+        member_count_estimate=member_count_estimate,
+        leg_status=leg_status,
+        description=(form.get("description") or "").strip(),
+        website_url=(form.get("website_url") or "").strip(),
+        source="self_submitted",
+    )
+    if not saved:
+        return _eintragen_error(
+            "Der Eintrag konnte nicht gespeichert werden. Bitte später erneut versuchen.",
+            form,
+            status=500,
+        )
+
+    db.track_event("registry_entry_submitted", data={"slug": slug, "kanton": kanton})
+
+    return render_template(
+        "leg_verzeichnis/eintragen.html",
+        canton_options=SWISS_CANTON_OPTIONS,
+        leg_status_options=LEG_STATUS_OPTIONS,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path="/leg-verzeichnis/eintragen",
+        error=None,
+        form=None,
+        submitted=True,
+    )
+
+
+def _eintragen_error(message, form, status):
+    return (
+        render_template(
+            "leg_verzeichnis/eintragen.html",
+            canton_options=SWISS_CANTON_OPTIONS,
+            leg_status_options=LEG_STATUS_OPTIONS,
+            site_url=request.url_root.rstrip("/"),
+            canonical_path="/leg-verzeichnis/eintragen",
+            error=message,
+            form=form,
+        ),
+        status,
     )

--- a/templates/leg_verzeichnis/eintragen.html
+++ b/templates/leg_verzeichnis/eintragen.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="LEG eintragen | LEG-Verzeichnis | OpenLEG",
+  description="Eigene Lokale Elektrizitätsgemeinschaft im offenen LEG-Verzeichnis eintragen. Kostenlos, unabhängig von der Gründungsplattform, manuell geprüft vor Veröffentlichung.",
+  path=canonical_path,
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-2xl mx-auto px-4 py-12">
+    <p class="text-sm mb-4"><a href="/leg-verzeichnis" class="text-brand hover:underline">&larr; Zurück zum Verzeichnis</a></p>
+
+    <header class="mb-8">
+      <h1 class="text-3xl font-bold tracking-tight mb-3">LEG eintragen</h1>
+      <p class="text-ink-muted">Jede Lokale Elektrizitätsgemeinschaft kann sich eintragen, unabhängig davon, welche Plattform bei der Gründung half. Ihr Eintrag wird manuell geprüft, bevor er öffentlich sichtbar ist. OpenLEG prüft keine Netz-Topologie und keine Eignung einzelner Adressen: dieser Eintrag ist eine Selbstauskunft.</p>
+    </header>
+
+    {% if submitted %}
+    <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+      <p class="font-semibold text-green-900 mb-1">Danke für Ihren Eintrag.</p>
+      <p class="text-sm text-green-800">Wir prüfen ihn manuell und schalten ihn danach frei.</p>
+    </div>
+    {% else %}
+
+    {% if error %}
+    <div class="bg-red-50 border border-red-200 rounded-xl p-4 mb-6 text-sm text-red-800">{{ error }}</div>
+    {% endif %}
+
+    <form method="post" class="space-y-4">
+      <div>
+        <label class="block text-sm font-medium mb-1" for="name">Name der LEG *</label>
+        <input type="text" id="name" name="name" required value="{{ form.get('name', '') if form else '' }}"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="contact_email">Kontakt-E-Mail *</label>
+        <input type="email" id="contact_email" name="contact_email" required value="{{ form.get('contact_email', '') if form else '' }}"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        <p class="text-xs text-ink-muted mt-1">Wird nicht veröffentlicht, nur für die Prüfung und spätere Beanspruchung des Eintrags.</p>
+      </div>
+      <div class="grid grid-cols-2 gap-4">
+        <div>
+          <label class="block text-sm font-medium mb-1" for="plz">PLZ</label>
+          <input type="text" id="plz" name="plz" value="{{ form.get('plz', '') if form else '' }}"
+            class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        </div>
+        <div>
+          <label class="block text-sm font-medium mb-1" for="ort">Ort</label>
+          <input type="text" id="ort" name="ort" value="{{ form.get('ort', '') if form else '' }}"
+            class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="kanton">Kanton</label>
+        <select id="kanton" name="kanton" class="w-full border rounded-lg px-3 py-2 text-sm bg-white">
+          {% for code, label in canton_options %}
+          <option value="{{ code }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="leg_status">Status</label>
+        <select id="leg_status" name="leg_status" class="w-full border rounded-lg px-3 py-2 text-sm bg-white">
+          {% for code, label in leg_status_options if code %}
+          <option value="{{ code }}">{{ label }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="vnb_name">Netzbetreiber (Selbstauskunft, optional)</label>
+        <input type="text" id="vnb_name" name="vnb_name" value="{{ form.get('vnb_name', '') if form else '' }}"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="member_count_estimate">Mitgliederzahl (geschätzt, optional)</label>
+        <input type="number" min="0" id="member_count_estimate" name="member_count_estimate" value="{{ form.get('member_count_estimate', '') if form else '' }}"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="website_url">Website (optional)</label>
+        <input type="url" id="website_url" name="website_url" value="{{ form.get('website_url', '') if form else '' }}"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      </div>
+      <div>
+        <label class="block text-sm font-medium mb-1" for="description">Kurzbeschreibung (optional)</label>
+        <textarea id="description" name="description" rows="3"
+          class="w-full border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">{{ form.get('description', '') if form else '' }}</textarea>
+      </div>
+      <button type="submit" class="w-full bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">LEG eintragen</button>
+    </form>
+    {% endif %}
+  </main>
+{% endblock %}

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -101,3 +101,85 @@ def test_detail_404s_for_unpublished_entry(monkeypatch):
     client, _, _ = _make_client(monkeypatch, detail_return=pending_entry)
     resp = client.get("/leg-verzeichnis/leg-baden")
     assert resp.status_code == 404
+
+
+# --- Self-service submission ---
+
+
+def _submit_client(monkeypatch, save_return=None):
+    mock_save = MagicMock(
+        return_value=save_return if save_return is not None else {"id": 1}
+    )
+    monkeypatch.setattr(leg_registry_module.db, "save_registry_entry", mock_save)
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_registry_entry_by_slug",
+        MagicMock(return_value=None),
+    )
+    mock_track = MagicMock(return_value=True)
+    monkeypatch.setattr(leg_registry_module.db, "track_event", mock_track)
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client(), mock_save, mock_track
+
+
+def test_eintragen_get_renders_form_with_honesty_boundary(monkeypatch):
+    client, _, _ = _submit_client(monkeypatch)
+    resp = client.get("/leg-verzeichnis/eintragen")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "prüft keine Netz-Topologie" in html
+    assert "manuell" in html.lower() or "geprüft" in html.lower()
+
+
+def test_eintragen_post_creates_pending_self_submitted_entry(monkeypatch):
+    client, mock_save, mock_track = _submit_client(monkeypatch)
+    resp = client.post(
+        "/leg-verzeichnis/eintragen",
+        data={
+            "name": "LEG Baden",
+            "contact_email": "info@example.ch",
+            "kanton": "AG",
+            "plz": "5400",
+            "ort": "Baden",
+        },
+    )
+    assert resp.status_code in (200, 302)
+    assert mock_save.called
+    _, kwargs = mock_save.call_args
+    assert kwargs["name"] == "LEG Baden"
+    assert kwargs["contact_email"] == "info@example.ch"
+    assert mock_track.called
+
+
+def test_eintragen_post_rejects_missing_required_fields(monkeypatch):
+    client, mock_save, _ = _submit_client(monkeypatch)
+    resp = client.post(
+        "/leg-verzeichnis/eintragen",
+        data={"kanton": "AG"},
+    )
+    assert resp.status_code == 400
+    assert not mock_save.called
+
+
+def test_eintragen_post_rejects_invalid_email(monkeypatch):
+    client, mock_save, _ = _submit_client(monkeypatch)
+    resp = client.post(
+        "/leg-verzeichnis/eintragen",
+        data={"name": "LEG Baden", "contact_email": "not-an-email"},
+    )
+    assert resp.status_code == 400
+    assert not mock_save.called
+
+
+def test_eintragen_post_generates_slug_from_name(monkeypatch):
+    client, mock_save, _ = _submit_client(monkeypatch)
+    client.post(
+        "/leg-verzeichnis/eintragen",
+        data={"name": "LEG Müswangen-Süd", "contact_email": "info@example.ch"},
+    )
+    _, kwargs = mock_save.call_args
+    assert kwargs["slug"]
+    assert " " not in kwargs["slug"]
+    assert kwargs["slug"] == kwargs["slug"].lower()


### PR DESCRIPTION
## Summary

Third code slice of Phase 1 (Open LEG Registry MVP), `docs/leg-registry.md`.

- `GET/POST /leg-verzeichnis/eintragen` on the existing `leg_registry.py` blueprint.
- GET renders the submission form with the honesty-boundary copy on the form itself.
- POST validates required fields (name, contact_email via `security_utils.validate_email_address`), generates a collision-checked slug, saves via `store.registry.save_registry_entry` (defaults `pending`/`self_submitted`), tracks a `registry_entry_submitted` analytics event.
- 400 + re-rendered form with inline error on missing/invalid fields.

Closes #152

## Test plan

- [x] `tests/test_leg_registry_routes.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 542 passed, 6 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_