### PR TITLE
Phase 1 Slice 4: LEG registry moderation queue in /admin/ops

### DIFF
--- a/app.py
+++ b/app.py
@@ -19,6 +19,7 @@ from flask import (
     jsonify,
     render_template,
     abort,
+    redirect,
     Response,
     g,
     send_from_directory,
@@ -806,10 +807,12 @@ def admin_ops():
     snapshots = db.get_ops_snapshots(limit=100)
     reports = db.get_lea_reports(limit=20)
     latest = _latest_snapshot_by_category(snapshots)
+    pending_registry = db.list_registry_entries(moderation_status="pending")
     response = {
         "latest": latest,
         "snapshots": snapshots[:20],
         "reports": reports,
+        "pending_registry": pending_registry,
         "counts": {
             "lea_inbox": sum(1 for s in snapshots if s.get("category") == "lea_inbox"),
             "github_monitor": sum(
@@ -821,6 +824,7 @@ def admin_ops():
             "stuck_formations": sum(
                 1 for s in snapshots if s.get("category") == "stuck_formations"
             ),
+            "registry_pending": db.get_registry_pending_count(),
         },
     }
     if "text/html" in (request.headers.get("Accept") or ""):
@@ -829,6 +833,21 @@ def admin_ops():
         json.dumps(response, default=str),
         mimetype="application/json",
     )
+
+
+@app.route("/admin/registry/<int:entry_id>/approve", methods=["POST"])
+def admin_registry_approve(entry_id):
+    _require_admin()
+    db.update_registry_entry_moderation(entry_id, "published", "")
+    return redirect(f"/admin/ops?token={ADMIN_TOKEN}")
+
+
+@app.route("/admin/registry/<int:entry_id>/reject", methods=["POST"])
+def admin_registry_reject(entry_id):
+    _require_admin()
+    reason = (request.form.get("reason") or "").strip()
+    db.update_registry_entry_moderation(entry_id, "rejected", reason)
+    return redirect(f"/admin/ops?token={ADMIN_TOKEN}")
 
 
 # --- Address API ---

--- a/templates/admin/ops.html
+++ b/templates/admin/ops.html
@@ -30,6 +30,49 @@
       <div class="text-sm text-gray-400">Stuck Formations</div>
       <div class="text-3xl font-bold">{{ counts.stuck_formations }}</div>
     </div>
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">LEG-Verzeichnis</div>
+      <div class="text-3xl font-bold">{{ counts.registry_pending }}</div>
+    </div>
+  </div>
+
+  <div class="mb-8">
+    <section class="bg-gray-900 rounded-lg overflow-hidden">
+      <div class="px-4 py-3 border-b border-gray-800">
+        <h2 class="font-semibold">Ausstehende LEG-Einträge</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead class="bg-gray-800">
+          <tr>
+            <th class="px-4 py-3 text-left">Name</th>
+            <th class="px-4 py-3 text-left">Ort</th>
+            <th class="px-4 py-3 text-left">Kontakt</th>
+            <th class="px-4 py-3 text-right">Aktion</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-gray-800">
+          {% for entry in pending_registry %}
+          <tr class="hover:bg-gray-800/40">
+            <td class="px-4 py-3">{{ entry.name }}</td>
+            <td class="px-4 py-3 text-gray-400">{{ entry.ort }}{% if entry.kanton %} ({{ entry.kanton }}){% endif %}</td>
+            <td class="px-4 py-3 text-gray-400">{{ entry.contact_email }}</td>
+            <td class="px-4 py-3 text-right">
+              <form method="post" action="/admin/registry/{{ entry.id }}/approve?token={{ request.args.get('token', '') }}" class="inline">
+                <button type="submit" class="bg-green-700 hover:bg-green-600 text-white text-xs px-3 py-1.5 rounded">Freischalten</button>
+              </form>
+              <form method="post" action="/admin/registry/{{ entry.id }}/reject?token={{ request.args.get('token', '') }}" class="inline ml-2">
+                <input type="hidden" name="reason" value="">
+                <button type="submit" class="bg-red-800 hover:bg-red-700 text-white text-xs px-3 py-1.5 rounded">Ablehnen</button>
+              </form>
+            </td>
+          </tr>
+          {% endfor %}
+          {% if not pending_registry %}
+          <tr><td colspan="4" class="px-4 py-8 text-center text-gray-500">Keine ausstehenden Einträge</td></tr>
+          {% endif %}
+        </tbody>
+      </table>
+    </section>
   </div>
 
   <div class="grid lg:grid-cols-2 gap-6 mb-8">

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -206,3 +206,133 @@ class TestAdminOpsRouteExists:
         assert "/admin/ops" in content
         assert "/api/internal/ops-snapshot" in content
         assert "/api/internal/agentmail" in content
+
+
+class TestAdminRegistryModeration:
+    def test_admin_ops_includes_registry_pending_count(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.get_ops_snapshots", return_value=[]),
+                patch("database.get_lea_reports", return_value=[]),
+                patch("database.list_registry_entries", return_value=[{"id": 1}]),
+                patch("database.get_registry_pending_count", return_value=1),
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.get(
+                        "/admin/ops",
+                        headers={"X-Admin-Token": "test123"},
+                    )
+                    assert resp.status_code == 200
+                    data = json.loads(resp.data)
+                    assert data["counts"]["registry_pending"] == 1
+                    assert data["pending_registry"] == [{"id": 1}]
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_admin_registry_approve_requires_admin_token(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch(
+                    "database.update_registry_entry_moderation", return_value=True
+                ) as mock_update,
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post("/admin/registry/1/approve")
+                    assert resp.status_code == 403
+                    mock_update.assert_not_called()
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_admin_registry_approve_calls_store_with_published(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch(
+                    "database.update_registry_entry_moderation", return_value=True
+                ) as mock_update,
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post(
+                        "/admin/registry/1/approve",
+                        headers={"X-Admin-Token": "test123"},
+                    )
+                    assert resp.status_code in (200, 302)
+                    mock_update.assert_called_once_with(1, "published", "")
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_admin_registry_reject_accepts_optional_reason(self):
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch(
+                    "database.update_registry_entry_moderation", return_value=True
+                ) as mock_update,
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.post(
+                        "/admin/registry/1/reject",
+                        data={"reason": "Duplikat"},
+                        headers={"X-Admin-Token": "test123"},
+                    )
+                    assert resp.status_code in (200, 302)
+                    mock_update.assert_called_once_with(1, "rejected", "Duplikat")
+                except Exception:
+                    pytest.skip("App import requires live DB")
+
+    def test_admin_ops_html_has_registry_moderation_section(self):
+        with open(os.path.join(PROJECT_ROOT, "templates", "admin", "ops.html")) as f:
+            content = f.read()
+        assert "pending_registry" in content
+        assert "/approve" in content
+        assert "/reject" in content


### PR DESCRIPTION
## Summary

Fourth code slice of Phase 1 (Open LEG Registry MVP), `docs/leg-registry.md`.

- `admin_ops()` gains `pending_registry` entries and a `registry_pending` count tile.
- New `POST /admin/registry/<id>/approve` and `POST /admin/registry/<id>/reject` (optional `reason` field), both `_require_admin()`-gated.
- `admin/ops.html` gets the first actionable (non-read-only) section in that template: a pending-entries table with inline approve/reject forms.

Closes #154

## Test plan

- [x] `tests/test_admin_ops.py` extended test-first with a new `TestAdminRegistryModeration` class (red confirmed on the template contract test; DB-dependent tests skip locally without a live Postgres, consistent with the rest of this test file).
- [x] `scripts/tdd_cycle.sh gate` green: 543 passed, 10 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_