### PR TITLE
Phase 1 Slice 5: LEG registry claim flow

### DIFF
--- a/leg_registry.py
+++ b/leg_registry.py
@@ -8,12 +8,16 @@ verified grid-topology eligibility signal.
 
 import logging
 import re
+import secrets
 
 from flask import Blueprint, abort, render_template, request
 
 import database as db
+import email_utils
 import security_utils
 from cantons import SWISS_CANTON_OPTIONS
+
+CLAIM_TOKEN_TTL_SECONDS = 24 * 60 * 60
 
 logger = logging.getLogger(__name__)
 
@@ -183,4 +187,56 @@ def _eintragen_error(message, form, status):
             form=form,
         ),
         status,
+    )
+
+
+@registry_bp.route("/leg-verzeichnis/<slug>/beanspruchen", methods=["GET", "POST"])
+def beanspruchen(slug):
+    entry = db.get_registry_entry_by_slug(slug)
+    if not entry:
+        abort(404)
+
+    if request.method == "GET":
+        return render_template(
+            "leg_verzeichnis/beanspruchen.html",
+            entry=entry,
+            sent=False,
+            site_url=request.url_root.rstrip("/"),
+            canonical_path=f"/leg-verzeichnis/{slug}/beanspruchen",
+        )
+
+    token = secrets.token_urlsafe(32)
+    db.set_registry_claim_token(entry["id"], token, ttl_seconds=CLAIM_TOKEN_TTL_SECONDS)
+
+    confirm_url = f"{request.url_root.rstrip('/')}/leg-verzeichnis/beanspruchen/{token}"
+    email_utils.send_email(
+        entry["contact_email"],
+        "Bestätigen Sie Ihren LEG-Eintrag bei OpenLEG",
+        f'Um den Eintrag "{entry["name"]}" im OpenLEG-Verzeichnis zu '
+        f"beanspruchen, öffnen Sie diesen Link (24 Stunden gültig):\n\n"
+        f"{confirm_url}",
+    )
+
+    return render_template(
+        "leg_verzeichnis/beanspruchen.html",
+        entry=entry,
+        sent=True,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path=f"/leg-verzeichnis/{slug}/beanspruchen",
+    )
+
+
+@registry_bp.route("/leg-verzeichnis/beanspruchen/<token>")
+def beanspruchen_bestaetigen(token):
+    entry = db.get_registry_entry_by_claim_token(token)
+    if not entry:
+        abort(404)
+
+    db.mark_registry_entry_claimed(entry["id"], entry["contact_email"])
+
+    return render_template(
+        "leg_verzeichnis/beanspruchen_bestaetigt.html",
+        entry=entry,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path=f"/leg-verzeichnis/{entry['slug']}",
     )

--- a/templates/leg_verzeichnis/beanspruchen.html
+++ b/templates/leg_verzeichnis/beanspruchen.html
@@ -1,0 +1,32 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="Eintrag beanspruchen: " ~ entry.name ~ " | OpenLEG",
+  description="Bestätigen Sie per E-Mail, dass Sie diesen LEG-Eintrag im offenen Verzeichnis betreiben.",
+  path=canonical_path,
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-xl mx-auto px-4 py-12">
+    <p class="text-sm mb-4"><a href="/leg-verzeichnis/{{ entry.slug }}" class="text-brand hover:underline">&larr; Zurück zum Eintrag</a></p>
+
+    {% if sent %}
+    <div class="bg-green-50 border border-green-200 rounded-xl p-6">
+      <p class="font-semibold text-green-900 mb-1">E-Mail unterwegs.</p>
+      <p class="text-sm text-green-800">Wir haben einen Bestätigungslink an die beim Eintrag hinterlegte Adresse gesendet. Der Link ist 24 Stunden gültig.</p>
+    </div>
+    {% else %}
+    <header class="mb-6">
+      <h1 class="text-2xl font-bold mb-2">Eintrag beanspruchen</h1>
+      <p class="text-ink-muted">Wir senden einen Bestätigungslink an die E-Mail-Adresse, die beim Eintrag "{{ entry.name }}" hinterlegt ist. Nur wer Zugriff auf diese Adresse hat, kann den Eintrag beanspruchen.</p>
+    </header>
+    <form method="post">
+      <button type="submit" class="w-full bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Bestätigungslink senden</button>
+    </form>
+    {% endif %}
+  </main>
+{% endblock %}

--- a/templates/leg_verzeichnis/beanspruchen_bestaetigt.html
+++ b/templates/leg_verzeichnis/beanspruchen_bestaetigt.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="Eintrag bestätigt: " ~ entry.name ~ " | OpenLEG",
+  description="Ihr LEG-Eintrag im offenen Verzeichnis wurde erfolgreich beansprucht.",
+  path=canonical_path,
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-xl mx-auto px-4 py-12">
+    <div class="bg-green-50 border border-green-200 rounded-xl p-6 mb-6">
+      <p class="font-semibold text-green-900 mb-1">Eintrag bestätigt.</p>
+      <p class="text-sm text-green-800">Sie sind jetzt als Betreiber von "{{ entry.name }}" hinterlegt.</p>
+    </div>
+    <a href="/leg-verzeichnis/{{ entry.slug }}" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Zum Eintrag</a>
+  </main>
+{% endblock %}

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -22,6 +22,7 @@ SAMPLE_ENTRY = {
     "member_count_estimate": 12,
     "description": "Nachbarschaftliche Stromgemeinschaft in Baden.",
     "website_url": "",
+    "contact_email": "info@example.ch",
     "moderation_status": "published",
 }
 
@@ -183,3 +184,74 @@ def test_eintragen_post_generates_slug_from_name(monkeypatch):
     assert kwargs["slug"]
     assert " " not in kwargs["slug"]
     assert kwargs["slug"] == kwargs["slug"].lower()
+
+
+# --- Claim flow ---
+
+
+def _claim_client(monkeypatch, entry=None, claim_lookup=None):
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_registry_entry_by_slug",
+        MagicMock(return_value=entry),
+    )
+    mock_set_token = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        leg_registry_module.db, "set_registry_claim_token", mock_set_token
+    )
+    mock_send = MagicMock(return_value=True)
+    monkeypatch.setattr(leg_registry_module.email_utils, "send_email", mock_send)
+    mock_lookup = MagicMock(return_value=claim_lookup)
+    monkeypatch.setattr(
+        leg_registry_module.db, "get_registry_entry_by_claim_token", mock_lookup
+    )
+    mock_mark = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        leg_registry_module.db, "mark_registry_entry_claimed", mock_mark
+    )
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client(), mock_set_token, mock_send, mock_mark
+
+
+def test_claim_request_get_renders_confirm_page(monkeypatch):
+    client, _, _, _ = _claim_client(monkeypatch, entry=SAMPLE_ENTRY)
+    resp = client.get("/leg-verzeichnis/leg-baden/beanspruchen")
+    assert resp.status_code == 200
+    assert "LEG Baden" in resp.data.decode("utf-8", errors="ignore")
+
+
+def test_claim_request_get_404s_for_unknown_slug(monkeypatch):
+    client, _, _, _ = _claim_client(monkeypatch, entry=None)
+    resp = client.get("/leg-verzeichnis/nope/beanspruchen")
+    assert resp.status_code == 404
+
+
+def test_claim_request_post_generates_token_and_sends_email(monkeypatch):
+    client, mock_set_token, mock_send, _ = _claim_client(
+        monkeypatch, entry=SAMPLE_ENTRY
+    )
+    resp = client.post("/leg-verzeichnis/leg-baden/beanspruchen")
+    assert resp.status_code == 200
+    assert mock_set_token.called
+    args, _ = mock_set_token.call_args
+    assert args[0] == SAMPLE_ENTRY["id"]
+    assert mock_send.called
+    send_args, send_kwargs = mock_send.call_args
+    to_email = send_args[0] if send_args else send_kwargs.get("to_email")
+    assert to_email == SAMPLE_ENTRY["contact_email"]
+
+
+def test_claim_confirm_marks_entry_claimed_with_valid_token(monkeypatch):
+    client, _, _, mock_mark = _claim_client(monkeypatch, claim_lookup=SAMPLE_ENTRY)
+    resp = client.get("/leg-verzeichnis/beanspruchen/validtoken123")
+    assert resp.status_code == 200
+    mock_mark.assert_called_once_with(SAMPLE_ENTRY["id"], SAMPLE_ENTRY["contact_email"])
+
+
+def test_claim_confirm_rejects_expired_or_unknown_token(monkeypatch):
+    client, _, _, mock_mark = _claim_client(monkeypatch, claim_lookup=None)
+    resp = client.get("/leg-verzeichnis/beanspruchen/badtoken")
+    assert resp.status_code == 404
+    mock_mark.assert_not_called()


### PR DESCRIPTION
## Summary

Fifth and final code slice of Phase 1 (Open LEG Registry MVP), `docs/leg-registry.md`.

- `GET/POST /leg-verzeichnis/<slug>/beanspruchen`: GET renders a confirm page, POST generates a claim token (`secrets.token_urlsafe`), stores it via `store.registry.set_registry_claim_token`, emails a confirmation link via `email_utils.send_email` (direct send — the building-scoped `store/email_queue.py` FK-joins to `buildings` and would silently never deliver a non-building email).
- `GET /leg-verzeichnis/beanspruchen/<token>`: looks up the entry by token (404 if unknown/expired), marks it claimed.

Closes #156. This completes Phase 1.

## Test plan

- [x] `tests/test_leg_registry_routes.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 548 passed, 10 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_