### PR TITLE
Phase 2 Slice 1: verification token schema + store functions

### DIFF
--- a/database.py
+++ b/database.py
@@ -490,9 +490,26 @@ def _create_tables():
                     claimed_at TIMESTAMP,
                     claimed_by_email VARCHAR(255),
                     last_verified_at TIMESTAMP,
+                    verification_token VARCHAR(128),
+                    verification_token_expires_at TIMESTAMP,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
+            """)
+
+            # Migration: add verification_token columns to leg_registry if missing
+            # (leg_registry shipped in Phase 1 without these Phase 2 columns).
+            cur.execute("""
+                DO $$
+                BEGIN
+                    IF NOT EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'leg_registry' AND column_name = 'verification_token'
+                    ) THEN
+                        ALTER TABLE leg_registry ADD COLUMN verification_token VARCHAR(128);
+                        ALTER TABLE leg_registry ADD COLUMN verification_token_expires_at TIMESTAMP;
+                    END IF;
+                END $$
             """)
 
             cur.execute("""
@@ -1917,6 +1934,10 @@ from store.registry import (  # noqa: E402, F401
     set_registry_claim_token,
     get_registry_entry_by_claim_token,
     mark_registry_entry_claimed,
+    set_registry_verification_token,
+    get_registry_entry_by_verification_token,
+    mark_registry_entry_verified,
+    get_registry_entries_needing_verification,
 )
 
 from store.meter import (  # noqa: E402, F401

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -18,6 +18,8 @@ import security_utils
 from cantons import SWISS_CANTON_OPTIONS
 
 CLAIM_TOKEN_TTL_SECONDS = 24 * 60 * 60
+VERIFICATION_TOKEN_TTL_SECONDS = 14 * 24 * 60 * 60
+VERIFICATION_STALE_DAYS = 90
 
 logger = logging.getLogger(__name__)
 
@@ -236,6 +238,22 @@ def beanspruchen_bestaetigen(token):
 
     return render_template(
         "leg_verzeichnis/beanspruchen_bestaetigt.html",
+        entry=entry,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path=f"/leg-verzeichnis/{entry['slug']}",
+    )
+
+
+@registry_bp.route("/leg-verzeichnis/bestaetigen/<token>")
+def bestaetigen(token):
+    entry = db.get_registry_entry_by_verification_token(token)
+    if not entry:
+        abort(404)
+
+    db.mark_registry_entry_verified(entry["id"])
+
+    return render_template(
+        "leg_verzeichnis/bestaetigt.html",
         entry=entry,
         site_url=request.url_root.rstrip("/"),
         canonical_path=f"/leg-verzeichnis/{entry['slug']}",

--- a/store/registry.py
+++ b/store/registry.py
@@ -242,6 +242,107 @@ def get_registry_entry_by_claim_token(token: str) -> Optional[Dict]:
         return None
 
 
+def set_registry_verification_token(
+    entry_id: int, token: str, ttl_seconds: int = 86400
+) -> bool:
+    """Set a re-confirmation verification token for a registry entry."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leg_registry
+                    SET verification_token = %s,
+                        verification_token_expires_at = CURRENT_TIMESTAMP
+                            + %s * INTERVAL '1 second',
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (token, ttl_seconds, entry_id),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error setting registry verification token: {e}")
+        return False
+
+
+def get_registry_entry_by_verification_token(token: str) -> Optional[Dict]:
+    """Get a registry entry by verification token (only if not expired)."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM leg_registry
+                    WHERE verification_token = %s
+                        AND verification_token_expires_at > CURRENT_TIMESTAMP
+                """,
+                    (token,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting registry entry by verification token: {e}")
+        return None
+
+
+def mark_registry_entry_verified(entry_id: int) -> bool:
+    """Record a re-confirmation: update last_verified_at, clear the token."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    UPDATE leg_registry
+                    SET last_verified_at = CURRENT_TIMESTAMP,
+                        verification_token = NULL,
+                        verification_token_expires_at = NULL,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = %s
+                """,
+                    (entry_id,),
+                )
+                return cur.rowcount > 0
+    except Exception as e:
+        logger.error(f"[DB] Error marking registry entry verified: {e}")
+        return False
+
+
+def get_registry_entries_needing_verification(
+    stale_days: int = 90, limit: int = 50
+) -> List[Dict]:
+    """Published entries never verified, or not verified in stale_days.
+
+    Excludes entries that already have a live (unexpired) verification
+    token so a nudge isn't re-sent while one is pending.
+    """
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM leg_registry
+                    WHERE moderation_status = 'published'
+                        AND (
+                            last_verified_at IS NULL
+                            OR last_verified_at < CURRENT_TIMESTAMP
+                                - %s * INTERVAL '1 day'
+                        )
+                        AND (
+                            verification_token IS NULL
+                            OR verification_token_expires_at <= CURRENT_TIMESTAMP
+                        )
+                    ORDER BY last_verified_at ASC NULLS FIRST
+                    LIMIT %s
+                """,
+                    (stale_days, limit),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error listing registry entries needing verification: {e}")
+        return []
+
+
 def mark_registry_entry_claimed(entry_id: int, claimed_by_email: str) -> bool:
     """Mark a registry entry as claimed and clear its claim token."""
     try:

--- a/templates/leg_verzeichnis/bestaetigt.html
+++ b/templates/leg_verzeichnis/bestaetigt.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="Eintrag bestätigt: " ~ entry.name ~ " | OpenLEG",
+  description="Ihr LEG-Eintrag im offenen Verzeichnis ist weiterhin aktuell.",
+  path=canonical_path,
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-xl mx-auto px-4 py-12">
+    <div class="bg-green-50 border border-green-200 rounded-xl p-6 mb-6">
+      <p class="font-semibold text-green-900 mb-1">Danke für die Bestätigung.</p>
+      <p class="text-sm text-green-800">"{{ entry.name }}" bleibt als aktuell markiert im Verzeichnis.</p>
+    </div>
+    <a href="/leg-verzeichnis/{{ entry.slug }}" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Zum Eintrag</a>
+  </main>
+{% endblock %}

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -255,3 +255,35 @@ def test_claim_confirm_rejects_expired_or_unknown_token(monkeypatch):
     resp = client.get("/leg-verzeichnis/beanspruchen/badtoken")
     assert resp.status_code == 404
     mock_mark.assert_not_called()
+
+
+# --- Re-confirmation (freshness) ---
+
+
+def _verify_client(monkeypatch, entry=None):
+    mock_lookup = MagicMock(return_value=entry)
+    monkeypatch.setattr(
+        leg_registry_module.db, "get_registry_entry_by_verification_token", mock_lookup
+    )
+    mock_mark = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        leg_registry_module.db, "mark_registry_entry_verified", mock_mark
+    )
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client(), mock_mark
+
+
+def test_verify_confirm_marks_entry_verified_with_valid_token(monkeypatch):
+    client, mock_mark = _verify_client(monkeypatch, entry=SAMPLE_ENTRY)
+    resp = client.get("/leg-verzeichnis/bestaetigen/validtoken123")
+    assert resp.status_code == 200
+    mock_mark.assert_called_once_with(SAMPLE_ENTRY["id"])
+
+
+def test_verify_confirm_rejects_expired_or_unknown_token(monkeypatch):
+    client, mock_mark = _verify_client(monkeypatch, entry=None)
+    resp = client.get("/leg-verzeichnis/bestaetigen/badtoken")
+    assert resp.status_code == 404
+    mock_mark.assert_not_called()

--- a/tests/test_store_registry.py
+++ b/tests/test_store_registry.py
@@ -25,6 +25,10 @@ _REEXPORTED = (
     "set_registry_claim_token",
     "get_registry_entry_by_claim_token",
     "mark_registry_entry_claimed",
+    "set_registry_verification_token",
+    "get_registry_entry_by_verification_token",
+    "mark_registry_entry_verified",
+    "get_registry_entries_needing_verification",
 )
 
 
@@ -140,3 +144,41 @@ def test_get_registry_pending_count_returns_zero_by_default(monkeypatch):
     monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
 
     assert registry.get_registry_pending_count() == 0
+
+
+def test_set_registry_verification_token_updates_expiry(monkeypatch):
+    cur = _FakeCursor(rowcount=1)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert (
+        registry.set_registry_verification_token(5, "vtok123", ttl_seconds=3600) is True
+    )
+    assert "verification_token" in cur.executed[0][0]
+
+
+def test_get_registry_entry_by_verification_token_missing_returns_none(monkeypatch):
+    cur = _FakeCursor(one=None)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert registry.get_registry_entry_by_verification_token("nope") is None
+
+
+def test_mark_registry_entry_verified_clears_token(monkeypatch):
+    cur = _FakeCursor(rowcount=1)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert registry.mark_registry_entry_verified(5) is True
+    assert "last_verified_at" in cur.executed[0][0]
+    assert "verification_token = NULL" in cur.executed[0][0]
+
+
+def test_get_registry_entries_needing_verification_defaults_published_only(
+    monkeypatch,
+):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    registry.get_registry_entries_needing_verification(stale_days=90)
+    query = cur.executed[0][0]
+    assert "leg_registry" in query
+    assert "moderation_status = 'published'" in query


### PR DESCRIPTION
## Summary

First code slice of Phase 2 (Freshness & Verification Pipeline), `docs/leg-registry.md`.

- Idempotent migration adds `verification_token`/`verification_token_expires_at` to the already-shipped `leg_registry` table.
- New `store/registry.py` functions: `set_registry_verification_token`, `get_registry_entry_by_verification_token`, `mark_registry_entry_verified`, `get_registry_entries_needing_verification`.
- New `GET /leg-verzeichnis/bestaetigen/<token>` route.

Closes #158

## Test plan

- [x] `tests/test_store_registry.py` and `tests/test_leg_registry_routes.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 554 passed, 10 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_