### PR TITLE
Phase 2 Slice 2: cron job to send registry re-confirmation nudges

### DIFF
--- a/app.py
+++ b/app.py
@@ -85,6 +85,7 @@ from api_public import public_api_bp
 from health import health_bp
 from utility_portal import utility_bp
 from rangliste import rangliste_bp
+import leg_registry
 from leg_registry import registry_bp
 
 # --- Cron Secret ---
@@ -1531,6 +1532,14 @@ def api_cron_process_billing():
         # Billing processing runs per active community.
         processed += 1
     return jsonify({"processed": processed, "communities": len(communities)})
+
+
+@app.route("/api/cron/verify-registry-entries", methods=["POST"])
+def api_cron_verify_registry_entries():
+    _require_cron_secret()
+
+    result = leg_registry.send_verification_nudges(base_url=SITE_URL)
+    return jsonify(result)
 
 
 @app.route("/api/billing/community/<community_id>/period/<int:period_id>")

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -258,3 +258,36 @@ def bestaetigen(token):
         site_url=request.url_root.rstrip("/"),
         canonical_path=f"/leg-verzeichnis/{entry['slug']}",
     )
+
+
+def send_verification_nudges(base_url=""):
+    """Email listed contacts whose entry is stale, asking them to reconfirm.
+
+    Called from the /api/cron/verify-registry-entries cron endpoint. Skips
+    entries where setting the token fails rather than emailing a dead link.
+    """
+    candidates = db.get_registry_entries_needing_verification(
+        stale_days=VERIFICATION_STALE_DAYS
+    )
+    result = {"candidates": len(candidates), "sent": 0, "errors": 0}
+
+    for entry in candidates:
+        token = secrets.token_urlsafe(32)
+        token_set = db.set_registry_verification_token(
+            entry["id"], token, ttl_seconds=VERIFICATION_TOKEN_TTL_SECONDS
+        )
+        if not token_set:
+            result["errors"] += 1
+            continue
+
+        confirm_url = f"{base_url}/leg-verzeichnis/bestaetigen/{token}"
+        email_utils.send_email(
+            entry["contact_email"],
+            "Ist Ihr LEG-Eintrag bei OpenLEG noch aktuell?",
+            f'Bitte bestätigen Sie, dass der Eintrag "{entry["name"]}" im '
+            f"OpenLEG-Verzeichnis noch aktuell ist (Link 14 Tage gültig):\n\n"
+            f"{confirm_url}",
+        )
+        result["sent"] += 1
+
+    return result

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -287,3 +287,117 @@ def test_verify_confirm_rejects_expired_or_unknown_token(monkeypatch):
     resp = client.get("/leg-verzeichnis/bestaetigen/badtoken")
     assert resp.status_code == 404
     mock_mark.assert_not_called()
+
+
+# --- Re-confirmation nudge job ---
+
+
+def test_send_verification_nudges_sends_email_and_sets_token(monkeypatch):
+    stale_entry = {**SAMPLE_ENTRY, "id": 7}
+    mock_candidates = MagicMock(return_value=[stale_entry])
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_registry_entries_needing_verification",
+        mock_candidates,
+    )
+    mock_set_token = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        leg_registry_module.db, "set_registry_verification_token", mock_set_token
+    )
+    mock_send = MagicMock(return_value=True)
+    monkeypatch.setattr(leg_registry_module.email_utils, "send_email", mock_send)
+
+    result = leg_registry_module.send_verification_nudges()
+
+    assert result["candidates"] == 1
+    assert result["sent"] == 1
+    mock_set_token.assert_called_once()
+    args, _ = mock_set_token.call_args
+    assert args[0] == 7
+    mock_send.assert_called_once()
+    send_args, send_kwargs = mock_send.call_args
+    to_email = send_args[0] if send_args else send_kwargs.get("to_email")
+    assert to_email == stale_entry["contact_email"]
+
+
+def test_send_verification_nudges_counts_errors_without_raising(monkeypatch):
+    stale_entry = {**SAMPLE_ENTRY, "id": 8}
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_registry_entries_needing_verification",
+        MagicMock(return_value=[stale_entry]),
+    )
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "set_registry_verification_token",
+        MagicMock(return_value=False),
+    )
+    mock_send = MagicMock(return_value=True)
+    monkeypatch.setattr(leg_registry_module.email_utils, "send_email", mock_send)
+
+    result = leg_registry_module.send_verification_nudges()
+
+    assert result["candidates"] == 1
+    assert result["sent"] == 0
+    assert result["errors"] == 1
+    mock_send.assert_not_called()
+
+
+def test_cron_verify_registry_entries_requires_secret(monkeypatch):
+    import importlib
+    import os as os_module
+    from unittest.mock import patch
+
+    with patch.dict(
+        os_module.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "APP_BASE_URL": "http://localhost:5003",
+            "CRON_SECRET": "test-cron-secret",
+        },
+    ):
+        with (
+            patch("database.is_db_available", return_value=True),
+            patch("database._connection_pool", MagicMock()),
+        ):
+            import app as app_module
+
+            app_module = importlib.reload(app_module)
+            client = app_module.app.test_client()
+            resp = client.post("/api/cron/verify-registry-entries")
+            assert resp.status_code == 403
+
+
+def test_cron_verify_registry_entries_calls_nudge_job(monkeypatch):
+    import importlib
+    import os as os_module
+    from unittest.mock import patch
+
+    with patch.dict(
+        os_module.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "APP_BASE_URL": "http://localhost:5003",
+            "CRON_SECRET": "test-cron-secret",
+        },
+    ):
+        with (
+            patch("database.is_db_available", return_value=True),
+            patch("database._connection_pool", MagicMock()),
+        ):
+            import app as app_module
+
+            app_module = importlib.reload(app_module)
+            with patch(
+                "leg_registry.send_verification_nudges",
+                return_value={"candidates": 0, "sent": 0, "errors": 0},
+            ) as mock_job:
+                client = app_module.app.test_client()
+                resp = client.post(
+                    "/api/cron/verify-registry-entries",
+                    headers={"X-Cron-Secret": "test-cron-secret"},
+                )
+                assert resp.status_code == 200
+                mock_job.assert_called_once()

--- a/tests/test_public_hardening.py
+++ b/tests/test_public_hardening.py
@@ -18,6 +18,7 @@ CRON_ENDPOINTS = (
     "/api/cron/refresh-public-data",
     "/api/cron/backfill-elcom",
     "/api/cron/process-billing",
+    "/api/cron/verify-registry-entries",
 )
 
 # Every env var the code reads that a self-hoster may need to set.


### PR DESCRIPTION
## Summary

Second code slice of Phase 2 (Freshness & Verification Pipeline), `docs/leg-registry.md`.

- `leg_registry.send_verification_nudges(base_url)`: finds published entries needing re-confirmation, generates a token, emails a confirm link via `email_utils.send_email` (direct send, same pattern established in Phase 1's claim flow — not the building-scoped `store/email_queue.py`).
- New `POST /api/cron/verify-registry-entries` (CRON_SECRET-gated), added to the existing fail-closed hardening contract test alongside the other cron endpoints.

Closes #160

## Test plan

- [x] `tests/test_leg_registry_routes.py` and `tests/test_public_hardening.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 558 passed, 10 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_