### PR TITLE
Phase 2 Slice 3: staleness + ElCom plausibility surfaced in /admin/ops

### DIFF
--- a/app.py
+++ b/app.py
@@ -808,7 +808,12 @@ def admin_ops():
     snapshots = db.get_ops_snapshots(limit=100)
     reports = db.get_lea_reports(limit=20)
     latest = _latest_snapshot_by_category(snapshots)
-    pending_registry = db.list_registry_entries(moderation_status="pending")
+    pending_registry = leg_registry.annotate_vnb_plausibility(
+        db.list_registry_entries(moderation_status="pending")
+    )
+    stale_registry = db.get_registry_entries_needing_verification(
+        stale_days=leg_registry.VERIFICATION_STALE_DAYS, limit=1000
+    )
     response = {
         "latest": latest,
         "snapshots": snapshots[:20],
@@ -826,6 +831,7 @@ def admin_ops():
                 1 for s in snapshots if s.get("category") == "stuck_formations"
             ),
             "registry_pending": db.get_registry_pending_count(),
+            "registry_stale": len(stale_registry),
         },
     }
     if "text/html" in (request.headers.get("Accept") or ""):

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -291,3 +291,30 @@ def send_verification_nudges(base_url=""):
         result["sent"] += 1
 
     return result
+
+
+def annotate_vnb_plausibility(entries):
+    """Add a vnb_plausible flag to each entry: a moderator hint, not a verdict.
+
+    None when there's nothing to check (no bfs_number or no self-reported
+    vnb_name). Otherwise True/False based on a case-insensitive substring
+    match against ElCom's operator_name(s) for that municipality. This is a
+    plausibility signal only — see docs/leg-registry.md's honesty boundary:
+    it never confirms grid-topology eligibility.
+    """
+    annotated = []
+    for entry in entries:
+        entry = dict(entry)
+        bfs_number = entry.get("bfs_number")
+        vnb_name = (entry.get("vnb_name") or "").strip()
+        if not bfs_number or not vnb_name:
+            entry["vnb_plausible"] = None
+        else:
+            tariffs = db.get_elcom_tariffs(bfs_number)
+            operator_names = [(t.get("operator_name") or "").lower() for t in tariffs]
+            needle = vnb_name.lower()
+            entry["vnb_plausible"] = any(
+                needle in name or name in needle for name in operator_names if name
+            )
+        annotated.append(entry)
+    return annotated

--- a/templates/admin/ops.html
+++ b/templates/admin/ops.html
@@ -34,6 +34,10 @@
       <div class="text-sm text-gray-400">LEG-Verzeichnis</div>
       <div class="text-3xl font-bold">{{ counts.registry_pending }}</div>
     </div>
+    <div class="bg-gray-900 rounded-lg p-4">
+      <div class="text-sm text-gray-400">Unbestätigt (LEG-Verzeichnis)</div>
+      <div class="text-3xl font-bold">{{ counts.registry_stale }}</div>
+    </div>
   </div>
 
   <div class="mb-8">
@@ -47,6 +51,7 @@
             <th class="px-4 py-3 text-left">Name</th>
             <th class="px-4 py-3 text-left">Ort</th>
             <th class="px-4 py-3 text-left">Kontakt</th>
+            <th class="px-4 py-3 text-left">VNB-Plausibilität</th>
             <th class="px-4 py-3 text-right">Aktion</th>
           </tr>
         </thead>
@@ -56,6 +61,15 @@
             <td class="px-4 py-3">{{ entry.name }}</td>
             <td class="px-4 py-3 text-gray-400">{{ entry.ort }}{% if entry.kanton %} ({{ entry.kanton }}){% endif %}</td>
             <td class="px-4 py-3 text-gray-400">{{ entry.contact_email }}</td>
+            <td class="px-4 py-3">
+              {% if entry.vnb_plausible is none %}
+              <span class="text-xs text-gray-500">ungeprüft</span>
+              {% elif entry.vnb_plausible %}
+              <span class="text-xs text-green-400">plausibel</span>
+              {% else %}
+              <span class="text-xs text-yellow-400">Abweichung von ElCom</span>
+              {% endif %}
+            </td>
             <td class="px-4 py-3 text-right">
               <form method="post" action="/admin/registry/{{ entry.id }}/approve?token={{ request.args.get('token', '') }}" class="inline">
                 <button type="submit" class="bg-green-700 hover:bg-green-600 text-white text-xs px-3 py-1.5 rounded">Freischalten</button>

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -336,3 +336,51 @@ class TestAdminRegistryModeration:
         assert "pending_registry" in content
         assert "/approve" in content
         assert "/reject" in content
+
+    def test_admin_ops_includes_stale_registry_count_and_vnb_plausibility(self):
+        stale_entry = {
+            "id": 1,
+            "name": "LEG Stale",
+            "bfs_number": 4021,
+            "vnb_name": "Regionalwerke Baden",
+            "contact_email": "info@example.ch",
+        }
+        with patch.dict(
+            os.environ,
+            {
+                "DATABASE_URL": "postgresql://x:x@localhost/x",
+                "ADMIN_TOKEN": "test123",
+                "INTERNAL_TOKEN": "secret-internal",
+            },
+        ):
+            with (
+                patch("database.init_db", return_value=True),
+                patch("database._connection_pool", MagicMock()),
+                patch("database.is_db_available", return_value=True),
+                patch("database.get_ops_snapshots", return_value=[]),
+                patch("database.get_lea_reports", return_value=[]),
+                patch("database.list_registry_entries", return_value=[stale_entry]),
+                patch("database.get_registry_pending_count", return_value=1),
+                patch(
+                    "database.get_registry_entries_needing_verification",
+                    return_value=[stale_entry],
+                ),
+                patch(
+                    "database.get_elcom_tariffs",
+                    return_value=[{"operator_name": "Regionalwerke Baden AG"}],
+                ),
+            ):
+                try:
+                    from app import app
+
+                    client = app.test_client()
+                    resp = client.get(
+                        "/admin/ops",
+                        headers={"X-Admin-Token": "test123"},
+                    )
+                    assert resp.status_code == 200
+                    data = json.loads(resp.data)
+                    assert data["counts"]["registry_stale"] == 1
+                    assert data["pending_registry"][0]["vnb_plausible"] is True
+                except Exception:
+                    pytest.skip("App import requires live DB")

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -369,6 +369,45 @@ def test_cron_verify_registry_entries_requires_secret(monkeypatch):
             assert resp.status_code == 403
 
 
+def test_annotate_vnb_plausibility_flags_mismatch(monkeypatch):
+    entry = {**SAMPLE_ENTRY, "bfs_number": 4021, "vnb_name": "Regionalwerke Baden"}
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_elcom_tariffs",
+        MagicMock(return_value=[{"operator_name": "Regionalwerke Baden AG"}]),
+    )
+    annotated = leg_registry_module.annotate_vnb_plausibility([entry])
+    assert annotated[0]["vnb_plausible"] is True
+
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_elcom_tariffs",
+        MagicMock(return_value=[{"operator_name": "Ganz Anderer Netzbetreiber"}]),
+    )
+    annotated = leg_registry_module.annotate_vnb_plausibility([entry])
+    assert annotated[0]["vnb_plausible"] is False
+
+
+def test_annotate_vnb_plausibility_none_without_bfs_number(monkeypatch):
+    entry = {**SAMPLE_ENTRY, "bfs_number": None, "vnb_name": "Regionalwerke Baden"}
+    mock_tariffs = MagicMock()
+    monkeypatch.setattr(leg_registry_module.db, "get_elcom_tariffs", mock_tariffs)
+
+    annotated = leg_registry_module.annotate_vnb_plausibility([entry])
+    assert annotated[0]["vnb_plausible"] is None
+    mock_tariffs.assert_not_called()
+
+
+def test_annotate_vnb_plausibility_none_without_vnb_name(monkeypatch):
+    entry = {**SAMPLE_ENTRY, "bfs_number": 4021, "vnb_name": ""}
+    mock_tariffs = MagicMock()
+    monkeypatch.setattr(leg_registry_module.db, "get_elcom_tariffs", mock_tariffs)
+
+    annotated = leg_registry_module.annotate_vnb_plausibility([entry])
+    assert annotated[0]["vnb_plausible"] is None
+    mock_tariffs.assert_not_called()
+
+
 def test_cron_verify_registry_entries_calls_nudge_job(monkeypatch):
     import importlib
     import os as os_module


### PR DESCRIPTION
## Summary

Third and final code slice of Phase 2 (Freshness & Verification Pipeline), `docs/leg-registry.md`.

- `admin_ops()` gains a `registry_stale` count tile.
- New `leg_registry.annotate_vnb_plausibility(entries)`: cross-checks self-reported `vnb_name` against ElCom's `operator_name` for the entry's `bfs_number` when set — a moderator hint only, no auto-publish/auto-reject, no new geocoding (only checked when `bfs_number` is already present).
- `admin/ops.html`'s pending-entries table gains a "VNB-Plausibilität" column.

Closes #162. This completes Phase 2.

## Test plan

- [x] `tests/test_leg_registry_routes.py` and `tests/test_admin_ops.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 561 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_