### PR TITLE
Phase 3: honest LEG pre-check at /leg-check

### DIFF
--- a/app.py
+++ b/app.py
@@ -579,6 +579,7 @@ def sitemap_xml():
         ("/open-source", "0.8", "weekly", current_date),
         ("/gemeinde/verzeichnis", "0.9", "weekly", current_date),
         ("/leg-verzeichnis", "0.9", "weekly", current_date),
+        ("/leg-check", "0.9", "weekly", current_date),
         ("/rangliste", "0.9", "daily", current_date),
         ("/rangliste/fortschritte", "0.8", "daily", current_date),
         ("/rangliste/vergleich", "0.7", "weekly", current_date),

--- a/database.py
+++ b/database.py
@@ -1886,6 +1886,7 @@ from store.profile import (  # noqa: E402, F401
     get_profile_bfs_missing_elcom_tariffs,
     save_sonnendach_municipal,
     get_sonnendach_municipal,
+    search_municipality_profiles,
 )
 
 from store.billing import (  # noqa: E402, F401

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -260,6 +260,42 @@ def bestaetigen(token):
     )
 
 
+@registry_bp.route("/leg-check")
+def leg_check():
+    """Honest pre-check: what is knowable about a municipality today.
+
+    Resolves the municipality from locally cached public data (ElCom,
+    Sonnendach via municipality_profiles) and shows existing registry
+    entries. Never claims address-level or grid-topology eligibility.
+    """
+    q = _clean_param("q")
+    profiles = db.search_municipality_profiles(q) if q else []
+
+    profile = profiles[0] if len(profiles) == 1 else None
+    operators = []
+    entries = []
+    if profile:
+        tariffs = db.get_elcom_tariffs(profile["bfs_number"])
+        seen = set()
+        for tariff in tariffs:
+            name = (tariff.get("operator_name") or "").strip()
+            if name and name not in seen:
+                seen.add(name)
+                operators.append(name)
+        entries = db.list_registry_entries(q=profile["name"])
+
+    return render_template(
+        "leg_verzeichnis/leg_check.html",
+        q=q or "",
+        profile=profile,
+        matches=profiles if len(profiles) > 1 else [],
+        operators=operators,
+        entries=entries,
+        site_url=request.url_root.rstrip("/"),
+        canonical_path="/leg-check",
+    )
+
+
 def send_verification_nudges(base_url=""):
     """Email listed contacts whose entry is stale, asking them to reconfirm.
 

--- a/store/profile.py
+++ b/store/profile.py
@@ -199,6 +199,29 @@ def get_all_municipality_profiles(
         return []
 
 
+def search_municipality_profiles(q: str, limit: int = 10) -> List[Dict]:
+    """Search municipality profiles by name (case-insensitive substring)."""
+    q = (q or "").strip()
+    if not q:
+        return []
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM municipality_profiles
+                    WHERE name ILIKE %s
+                    ORDER BY name
+                    LIMIT %s
+                """,
+                    (f"%{q}%", max(1, min(int(limit), 50))),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error searching municipality profiles: {e}")
+        return []
+
+
 def get_all_municipality_profile_bfs_numbers() -> List[int]:
     """Get sorted BFS numbers from municipality_profiles."""
     try:

--- a/templates/leg_verzeichnis/leg_check.html
+++ b/templates/leg_verzeichnis/leg_check.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="LEG-Check: Was ist in Ihrer Gemeinde möglich? | OpenLEG",
+  description="Prüfen Sie, was heute über eine LEG in Ihrer Gemeinde bekannt ist: Netzbetreiber laut ElCom, Solarpotenzial und bestehende Stromgemeinschaften. Aus offenen Daten, ohne Anmeldung.",
+  path=canonical_path,
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-3xl mx-auto px-4 py-12">
+    <header class="mb-8">
+      <p class="text-sm font-semibold text-brand mb-2">LEG-Check</p>
+      <h1 class="text-4xl font-bold tracking-tight mb-3">Was ist in Ihrer Gemeinde möglich?</h1>
+      <p class="text-lg text-ink-muted">Aus offenen Daten, ohne Anmeldung: der Netzbetreiber laut ElCom, das Solarpotenzial Ihrer Gemeinde und bestehende Stromgemeinschaften aus dem offenen Verzeichnis. OpenLEG prüft keine Netz-Topologie: ob konkrete Adressen zusammen eine LEG bilden können, klären Sie abschliessend mit Ihren Nachbarn und Ihrem Netzbetreiber.</p>
+    </header>
+
+    <form method="get" class="flex gap-2 mb-10">
+      <input type="text" name="q" value="{{ q }}" placeholder="Gemeinde suchen, z.B. Baden"
+        class="flex-1 border rounded-lg px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+      <button type="submit" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Prüfen</button>
+    </form>
+
+    {% if profile %}
+    <section class="mb-8">
+      <h2 class="text-2xl font-bold mb-4">{{ profile.name }}{% if profile.kanton %} ({{ profile.kanton }}){% endif %}</h2>
+      <div class="grid sm:grid-cols-2 gap-4 mb-6">
+        <div class="bg-white rounded-xl border p-5">
+          <h3 class="text-sm text-ink-muted mb-1">Netzbetreiber laut ElCom</h3>
+          {% if operators %}
+          {% for op in operators %}
+          <p class="font-semibold">{{ op }}</p>
+          {% endfor %}
+          {% else %}
+          <p class="text-sm text-ink-muted">Keine ElCom-Daten hinterlegt.</p>
+          {% endif %}
+        </div>
+        <div class="bg-white rounded-xl border p-5">
+          <h3 class="text-sm text-ink-muted mb-1">Solarnutzung der Gemeinde</h3>
+          {% if profile.pv_score_pct is not none %}
+          <p class="font-semibold">{{ "%.0f"|format(profile.pv_score_pct|float) }}% des Dachpotenzials genutzt</p>
+          <p class="text-xs text-ink-muted mt-1"><a href="/gemeinde/profil/{{ profile.bfs_number }}" class="text-brand hover:underline">Zum Energieprofil</a></p>
+          {% else %}
+          <p class="text-sm text-ink-muted">Kein Solarprofil hinterlegt.</p>
+          {% endif %}
+        </div>
+      </div>
+
+      <div class="bg-white rounded-xl border p-5 mb-6">
+        <h3 class="text-sm text-ink-muted mb-2">Stromgemeinschaften im offenen Verzeichnis</h3>
+        {% if entries %}
+        <ul class="space-y-2">
+          {% for entry in entries %}
+          <li><a href="/leg-verzeichnis/{{ entry.slug }}" class="text-brand hover:underline font-semibold">{{ entry.name }}</a>{% if entry.leg_status %} <span class="text-xs text-ink-muted">({{ entry.leg_status }})</span>{% endif %}</li>
+          {% endfor %}
+        </ul>
+        {% else %}
+        <p class="text-sm text-ink-muted">Noch keine LEG aus {{ profile.name }} eingetragen. Vielleicht gründen Sie die erste?</p>
+        {% endif %}
+      </div>
+
+      <div class="bg-brand/5 border border-brand/20 rounded-xl p-5 mb-6">
+        <h3 class="font-bold mb-1">Was dieser Check bedeutet</h3>
+        <p class="text-sm text-ink-muted">Diese Angaben stammen aus offenen Daten (ElCom, BFE Sonnendach) und dem offenen Verzeichnis. OpenLEG prüft keine Netz-Topologie. Die abschliessende Bestätigung, welche Adressen zusammen eine LEG bilden können, geben Ihnen Ihre Nachbarn und Ihr Netzbetreiber.</p>
+      </div>
+
+      <div class="flex flex-col sm:flex-row gap-3">
+        <a href="/leg-gruenden" class="flex-1 text-center bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">LEG gründen: so geht es</a>
+        <a href="/leg-verzeichnis/eintragen" class="flex-1 text-center border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white">Bestehende LEG eintragen</a>
+      </div>
+    </section>
+    {% elif matches %}
+    <section class="mb-8">
+      <h2 class="text-xl font-bold mb-3">Mehrere Gemeinden gefunden</h2>
+      <ul class="space-y-2">
+        {% for m in matches %}
+        <li><a href="/leg-check?q={{ m.name }}" class="text-brand hover:underline font-semibold">{{ m.name }}{% if m.kanton %} ({{ m.kanton }}){% endif %}</a></li>
+        {% endfor %}
+      </ul>
+    </section>
+    {% elif q %}
+    <section class="bg-white rounded-xl border p-8 text-center mb-8">
+      <p class="text-ink-muted mb-2">Keine Gemeinde für "{{ q }}" gefunden.</p>
+      <p class="text-sm text-ink-muted">Prüfen Sie die Schreibweise oder durchsuchen Sie das <a href="/gemeinde/verzeichnis" class="text-brand hover:underline">Gemeindeverzeichnis</a>.</p>
+    </section>
+    {% endif %}
+  </main>
+{% endblock %}

--- a/tests/test_leg_check.py
+++ b/tests/test_leg_check.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the honest LEG pre-check (/leg-check).
+
+Contract: /leg-check resolves a municipality from locally cached public data
+and shows what is honestly knowable (ElCom grid operator, solar score,
+existing registry entries). It never claims grid-topology eligibility; the
+honesty boundary is pinned here as hard assertions.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+import leg_registry as leg_registry_module
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+BADEN_PROFILE = {
+    "bfs_number": 4021,
+    "name": "Baden",
+    "kanton": "AG",
+    "pv_score_pct": 42.0,
+}
+
+REGISTRY_ENTRY = {
+    "id": 1,
+    "slug": "leg-baden",
+    "name": "LEG Baden",
+    "ort": "Baden",
+    "kanton": "AG",
+    "moderation_status": "published",
+}
+
+
+def _check_client(monkeypatch, profiles=None, tariffs=None, entries=None):
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "search_municipality_profiles",
+        MagicMock(return_value=profiles if profiles is not None else []),
+    )
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "get_elcom_tariffs",
+        MagicMock(return_value=tariffs if tariffs is not None else []),
+    )
+    monkeypatch.setattr(
+        leg_registry_module.db,
+        "list_registry_entries",
+        MagicMock(return_value=entries if entries is not None else []),
+    )
+    app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
+    app.config["TESTING"] = True
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client()
+
+
+def test_leg_check_form_renders_with_honesty_boundary(monkeypatch):
+    client = _check_client(monkeypatch)
+    resp = client.get("/leg-check")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "prüft keine Netz-Topologie" in html
+
+
+def test_leg_check_result_shows_operator_solar_and_registry(monkeypatch):
+    client = _check_client(
+        monkeypatch,
+        profiles=[BADEN_PROFILE],
+        tariffs=[{"operator_name": "Regionalwerke Baden AG"}],
+        entries=[REGISTRY_ENTRY],
+    )
+    resp = client.get("/leg-check?q=Baden")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "Regionalwerke Baden AG" in html
+    assert "LEG Baden" in html
+    # the honesty boundary must be present on the RESULT view, not just the form
+    assert "prüft keine Netz-Topologie" in html
+    assert "Netzbetreiber" in html
+    # funnels onward
+    assert 'href="/leg-gruenden"' in html
+    assert 'href="/leg-verzeichnis/eintragen"' in html
+
+
+def test_leg_check_result_never_claims_eligibility(monkeypatch):
+    client = _check_client(
+        monkeypatch,
+        profiles=[BADEN_PROFILE],
+        tariffs=[{"operator_name": "Regionalwerke Baden AG"}],
+        entries=[],
+    )
+    html = client.get("/leg-check?q=Baden").data.decode("utf-8", errors="ignore")
+    for forbidden in ("geeignet für eine LEG", "Eignung bestätigt", "berechtigt"):
+        assert forbidden not in html
+
+
+def test_leg_check_multiple_matches_shows_disambiguation(monkeypatch):
+    second = {**BADEN_PROFILE, "bfs_number": 261, "name": "Badenweiler"}
+    client = _check_client(monkeypatch, profiles=[BADEN_PROFILE, second])
+    html = client.get("/leg-check?q=Bade").data.decode("utf-8", errors="ignore")
+    assert "Baden" in html
+    assert "Badenweiler" in html
+
+
+def test_leg_check_no_match_shows_empty_state(monkeypatch):
+    client = _check_client(monkeypatch, profiles=[])
+    resp = client.get("/leg-check?q=Nirgendwo")
+    assert resp.status_code == 200
+    html = resp.data.decode("utf-8", errors="ignore")
+    assert "keine gemeinde" in html.lower() or "nicht gefunden" in html.lower()

--- a/tests/test_store_profile.py
+++ b/tests/test_store_profile.py
@@ -25,6 +25,7 @@ _REEXPORTED = (
     "get_profile_bfs_missing_elcom_tariffs",
     "save_sonnendach_municipal",
     "get_sonnendach_municipal",
+    "search_municipality_profiles",
 )
 
 
@@ -107,3 +108,23 @@ def test_get_all_municipality_profiles_filters_by_kanton(monkeypatch):
 
 def test_save_elcom_tariffs_empty_returns_zero():
     assert profile.save_elcom_tariffs([]) == 0
+
+
+def test_search_municipality_profiles_matches_name_case_insensitive(monkeypatch):
+    cur = _FakeCursor(rows=[{"bfs_number": 4021, "name": "Baden"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = profile.search_municipality_profiles("bad")
+    assert rows == [{"bfs_number": 4021, "name": "Baden"}]
+    query, params = cur.executed[0]
+    assert "municipality_profiles" in query
+    assert "ILIKE" in query
+    assert params[0] == "%bad%"
+
+
+def test_search_municipality_profiles_blank_query_returns_empty(monkeypatch):
+    cur = _FakeCursor(rows=[{"bfs_number": 1, "name": "X"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert profile.search_municipality_profiles("   ") == []
+    assert cur.executed == []


### PR DESCRIPTION
## Summary

First slice of Phase 3 (honest eligibility pre-check), `docs/leg-registry.md`.

- New `search_municipality_profiles(q)` in `store/profile.py` (re-exported from `database.py`).
- New `GET /leg-check`: municipality search → ElCom-listed grid operator(s), solar score, published registry entries, CTAs into `/leg-gruenden` and `/leg-verzeichnis/eintragen`. Disambiguation list on multiple matches, honest empty state on none.
- Honesty boundary pinned by hard assertions on form and result views ("prüft keine Netz-Topologie"); a dedicated test asserts eligibility-claiming phrases never appear.
- Resolves municipalities entirely from already-cached open data — no external API dependency.

Closes #164

## Test plan

- [x] `tests/test_store_profile.py` extended and new `tests/test_leg_check.py` written test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 568 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_