### PR TITLE
Phase 3: funnel cross-links to /leg-check

### DIFF
--- a/templates/fuer_bewohner.html
+++ b/templates/fuer_bewohner.html
@@ -44,7 +44,7 @@
         <li class="rounded-2xl border border-slate-200 bg-white p-5 border-t-4 border-t-brand">
           <div class="text-sm font-semibold text-brand">Schritt 1</div>
           <div class="font-semibold text-lg mt-1">Adresse prüfen</div>
-          <p class="text-sm text-ink-muted mt-1">Sie sehen anonymisiert, wer in Ihrer Nähe mitmachen will, und erhalten eine erste Schätzung zum Solarpotenzial.</p>
+          <p class="text-sm text-ink-muted mt-1">Sie sehen anonymisiert, wer in Ihrer Nähe mitmachen will, und erhalten eine erste Schätzung zum Solarpotenzial. Der <a href="/leg-check" class="text-brand underline">LEG-Check</a> zeigt zudem, was in Ihrer Gemeinde schon läuft.</p>
         </li>
         <li class="rounded-2xl border border-slate-200 bg-white p-5 border-t-4 border-t-brand">
           <div class="text-sm font-semibold text-brand">Schritt 2</div>

--- a/templates/leg_verzeichnis/liste.html
+++ b/templates/leg_verzeichnis/liste.html
@@ -17,8 +17,9 @@
       <p class="text-sm font-semibold text-brand mb-2">LEG-Verzeichnis</p>
       <h1 class="text-4xl font-bold tracking-tight mb-3">Lokale Elektrizitätsgemeinschaften in der Schweiz</h1>
       <p class="text-lg text-ink-muted">Offen für jede LEG, unabhängig davon, welche Plattform bei der Gründung half. Einträge sind moderierte Selbstauskünfte: OpenLEG prüft keine Netz-Topologie und keine Eignung einzelner Adressen. Details dazu stehen bei jedem Eintrag.</p>
-      <div class="mt-5">
-        <a href="/leg-verzeichnis/eintragen" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Eigene LEG eintragen</a>
+      <div class="mt-5 flex flex-col sm:flex-row gap-3">
+        <a href="/leg-verzeichnis/eintragen" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Eigene LEG eintragen</a>
+        <a href="/leg-check" class="inline-block border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">Was ist in meiner Gemeinde möglich?</a>
       </div>
     </header>
 

--- a/tests/test_leg_check.py
+++ b/tests/test_leg_check.py
@@ -103,6 +103,20 @@ def test_leg_check_multiple_matches_shows_disambiguation(monkeypatch):
     assert "Badenweiler" in html
 
 
+def test_fuer_bewohner_funnels_to_leg_check():
+    path = os.path.join(PROJECT_ROOT, "templates", "fuer_bewohner.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert 'href="/leg-check"' in html
+
+
+def test_leg_verzeichnis_liste_funnels_to_leg_check():
+    path = os.path.join(PROJECT_ROOT, "templates", "leg_verzeichnis", "liste.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert 'href="/leg-check"' in html
+
+
 def test_leg_check_no_match_shows_empty_state(monkeypatch):
     client = _check_client(monkeypatch, profiles=[])
     resp = client.get("/leg-check?q=Nirgendwo")


### PR DESCRIPTION
## Summary

Final slice of Phase 3, `docs/leg-registry.md`.

Links from `templates/fuer_bewohner.html` (Schritt 1) and `templates/leg_verzeichnis/liste.html` (header CTA row) to `/leg-check`, pinned by tests.

Closes #166. This completes Phase 3.

## Test plan

- [x] `tests/test_leg_check.py` extended test-first (red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 570 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_