### PR TITLE
Phase 4 Slice 1: fix community_id type mismatch across billing/documents tables

### DIFF
--- a/database.py
+++ b/database.py
@@ -515,7 +515,7 @@ def _create_tables():
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS billing_periods (
                     id SERIAL PRIMARY KEY,
-                    community_id INTEGER NOT NULL,
+                    community_id VARCHAR(64) NOT NULL,
                     period_start TIMESTAMP NOT NULL,
                     period_end TIMESTAMP NOT NULL,
                     total_production_kwh DECIMAL(12, 4) DEFAULT 0,
@@ -547,7 +547,7 @@ def _create_tables():
                 CREATE TABLE IF NOT EXISTS invoices (
                     id SERIAL PRIMARY KEY,
                     billing_period_id INTEGER REFERENCES billing_periods(id),
-                    community_id INTEGER NOT NULL,
+                    community_id VARCHAR(64) NOT NULL,
                     invoice_number VARCHAR(64) UNIQUE,
                     total_chf DECIMAL(10, 2) DEFAULT 0,
                     status VARCHAR(32) DEFAULT 'draft',
@@ -561,7 +561,7 @@ def _create_tables():
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS leg_documents (
                     id SERIAL PRIMARY KEY,
-                    community_id INTEGER NOT NULL,
+                    community_id VARCHAR(64) NOT NULL,
                     doc_type VARCHAR(64) NOT NULL,
                     filename VARCHAR(255),
                     pdf_data BYTEA,
@@ -571,6 +571,44 @@ def _create_tables():
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
                     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
+            """)
+
+            # Migration: align community_id columns with communities.community_id
+            # (VARCHAR(64) UUID strings). billing_periods, invoices and
+            # leg_documents historically declared INTEGER, making the join to
+            # communities impossible. INTEGER -> VARCHAR is a safe widening
+            # cast for any pre-existing rows.
+            cur.execute("""
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'billing_periods'
+                            AND column_name = 'community_id'
+                            AND data_type = 'integer'
+                    ) THEN
+                        ALTER TABLE billing_periods
+                            ALTER COLUMN community_id TYPE VARCHAR(64);
+                    END IF;
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'invoices'
+                            AND column_name = 'community_id'
+                            AND data_type = 'integer'
+                    ) THEN
+                        ALTER TABLE invoices
+                            ALTER COLUMN community_id TYPE VARCHAR(64);
+                    END IF;
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'leg_documents'
+                            AND column_name = 'community_id'
+                            AND data_type = 'integer'
+                    ) THEN
+                        ALTER TABLE leg_documents
+                            ALTER COLUMN community_id TYPE VARCHAR(64);
+                    END IF;
+                END $$
             """)
 
             # Migration: add stripe_subscription_id to utility_clients if missing

--- a/store/billing.py
+++ b/store/billing.py
@@ -24,7 +24,7 @@ def _get_connection():
 
 
 def save_billing_period(
-    community_id: int, period_start, period_end, summary: dict
+    community_id: str, period_start, period_end, summary: dict
 ) -> int:
     """Save billing period and line items from billing engine output."""
     try:

--- a/tests/test_community_id_schema.py
+++ b/tests/test_community_id_schema.py
@@ -1,0 +1,72 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Schema contract: community_id is joinable across community tables.
+
+communities.community_id is VARCHAR(64) (a UUID string). billing_periods and
+invoices historically declared community_id as INTEGER, which made the join
+to communities impossible. This contract pins the aligned types and the
+idempotent migration for pre-existing databases.
+"""
+
+import os
+import re
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _database_source() -> str:
+    with open(os.path.join(PROJECT_ROOT, "database.py"), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _create_block(source: str, table: str) -> str:
+    match = re.search(
+        rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\)\s*\"\"\"",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match, f"CREATE TABLE {table} block not found"
+    return match.group(1)
+
+
+def test_billing_periods_community_id_is_varchar():
+    block = _create_block(_database_source(), "billing_periods")
+    assert re.search(r"community_id VARCHAR\(64\)", block), (
+        "billing_periods.community_id must be VARCHAR(64) to join communities"
+    )
+    assert "community_id INTEGER" not in block
+
+
+def test_invoices_community_id_is_varchar():
+    block = _create_block(_database_source(), "invoices")
+    assert re.search(r"community_id VARCHAR\(64\)", block), (
+        "invoices.community_id must be VARCHAR(64) to join communities"
+    )
+    assert "community_id INTEGER" not in block
+
+
+def test_leg_documents_community_id_is_varchar():
+    block = _create_block(_database_source(), "leg_documents")
+    assert re.search(r"community_id VARCHAR\(64\)", block), (
+        "leg_documents.community_id must be VARCHAR(64) to join communities"
+    )
+    assert "community_id INTEGER" not in block
+
+
+def test_migration_converts_existing_integer_columns():
+    source = _database_source()
+    for table in ("billing_periods", "invoices", "leg_documents"):
+        assert re.search(
+            rf"ALTER TABLE {table}\s+ALTER COLUMN community_id TYPE VARCHAR\(64\)",
+            source,
+        ), f"idempotent migration for {table}.community_id missing"
+
+
+def test_store_billing_type_hint_matches_schema():
+    with open(
+        os.path.join(PROJECT_ROOT, "store", "billing.py"), encoding="utf-8"
+    ) as handle:
+        source = handle.read()
+    assert "community_id: int" not in source, (
+        "store/billing.py must not annotate community_id as int; the schema "
+        "uses VARCHAR(64) UUID strings"
+    )


### PR DESCRIPTION
## Summary

First slice of Phase 4 (LEG formation & maintenance dashboard), `docs/leg-registry.md`.

`communities.community_id` is `VARCHAR(64)` (UUID strings), but `billing_periods`, `invoices`, and `leg_documents` declared `community_id INTEGER` — the join to `communities` was impossible, blocking any dashboard showing formation + billing together (and Phase 5's document wiring).

- CREATE TABLE blocks aligned to `VARCHAR(64)`; idempotent `DO $$` migration converts pre-existing INTEGER columns (safe widening cast, guarded by `information_schema` checks).
- `store/billing.py` type hint fixed.

Closes #168

## Test plan

- [x] New `tests/test_community_id_schema.py` written test-first (4 red confirmed, then extended to `leg_documents`).
- [x] Migration exercised against a real local Postgres that had the old INTEGER columns — all four tables now aligned, join verified.
- [x] `scripts/tdd_cycle.sh gate` green: 575 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_