### PR TITLE
Phase 4 Slice 2: LEG operator dashboard read view

### DIFF
--- a/app.py
+++ b/app.py
@@ -1330,6 +1330,23 @@ def dashboard_demo():
     return render_city_template("dashboard.html", **dashboard_module.demo_readiness())
 
 
+@app.route("/leg/dashboard")
+def leg_dashboard():
+    community_id = request.args.get("cid", "").strip()
+    building_id = request.args.get("bid", "").strip()
+    return render_city_template(
+        "leg_dashboard.html",
+        **dashboard_module.leg_overview(community_id, building_id),
+    )
+
+
+@app.route("/leg/dashboard/demo")
+def leg_dashboard_demo():
+    return render_city_template(
+        "leg_dashboard.html", **dashboard_module.leg_demo_overview()
+    )
+
+
 # --- Referral System ---
 @app.route("/api/referral/stats/<building_id>")
 def api_referral_stats(building_id):

--- a/dashboard.py
+++ b/dashboard.py
@@ -2,6 +2,7 @@
 """Dashboard readiness verb."""
 
 import database as db
+import formation_wizard
 
 
 def readiness(building_id: str, *, city_id=None, app_base_url: str = "") -> dict:
@@ -61,6 +62,89 @@ def readiness(building_id: str, *, city_id=None, app_base_url: str = "") -> dict
         "neighbor_count": neighbor_count,
         "referral_link": referral_link,
         "error": None,
+    }
+
+
+def leg_overview(community_id: str, building_id: str) -> dict:
+    """Operator view of one community, gated on membership.
+
+    Same capability-URL model as the resident dashboard: the caller must
+    present a building_id that is a member of the community. Non-members
+    get the error view, never another community's data.
+    """
+    if not community_id or not building_id:
+        return {"error": "Kein Zugriff.", "community": None}
+
+    status = formation_wizard.get_community_status(db, community_id)
+    if not status:
+        return {"error": "LEG nicht gefunden.", "community": None}
+
+    member = next(
+        (m for m in status["members"] or [] if m["building_id"] == building_id),
+        None,
+    )
+    if not member:
+        return {"error": "Kein Zugriff.", "community": None}
+
+    return {
+        "error": None,
+        "community": status,
+        "viewer_building_id": building_id,
+        "is_admin": member.get("role") == "admin",
+    }
+
+
+def leg_demo_overview() -> dict:
+    """Fake, click-through LEG operator dashboard data for demos."""
+    return {
+        "error": None,
+        "viewer_building_id": "demo-building",
+        "is_admin": True,
+        "community": {
+            "community_id": "demo-leg",
+            "name": "LEG Musterweg",
+            "status": "formation_started",
+            "distribution_model": "proportional",
+            "member_count": {"total": 5, "confirmed": 4, "invited": 1},
+            "readiness_score": 60,
+            "members": [
+                {
+                    "building_id": "demo-building",
+                    "role": "admin",
+                    "status": "confirmed",
+                    "address": "Musterweg 1, 5400 Baden",
+                },
+                {
+                    "building_id": "demo-2",
+                    "role": "member",
+                    "status": "confirmed",
+                    "address": "Musterweg 3, 5400 Baden",
+                },
+                {
+                    "building_id": "demo-3",
+                    "role": "member",
+                    "status": "confirmed",
+                    "address": "Musterweg 5, 5400 Baden",
+                },
+                {
+                    "building_id": "demo-4",
+                    "role": "member",
+                    "status": "confirmed",
+                    "address": "Musterweg 7, 5400 Baden",
+                },
+                {
+                    "building_id": "demo-5",
+                    "role": "member",
+                    "status": "invited",
+                    "address": "Musterweg 9, 5400 Baden",
+                },
+            ],
+            "documents": None,
+            "next_steps": [
+                "Generate legal documents",
+                "Review community agreement",
+            ],
+        },
     }
 
 

--- a/templates/leg_dashboard.html
+++ b/templates/leg_dashboard.html
@@ -1,0 +1,85 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="LEG-Dashboard | OpenLEG",
+  description="Gründung und Betrieb Ihrer Lokalen Elektrizitätsgemeinschaft: Status, Mitglieder und nächste Schritte auf einen Blick.",
+  path="/leg/dashboard",
+  site_url=site_url|default(""),
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-4xl mx-auto px-4 py-12">
+    {% if error %}
+    <div class="bg-red-50 border border-red-200 rounded-xl p-8 text-center">
+      <p class="font-semibold text-red-900 mb-1">{{ error }}</p>
+      <p class="text-sm text-red-800">Prüfen Sie Ihren Zugangslink oder öffnen Sie die <a href="/leg/dashboard/demo" class="underline">Demo-Ansicht</a>.</p>
+    </div>
+    {% else %}
+    <header class="mb-8">
+      <p class="text-sm font-semibold text-brand mb-2">LEG-Dashboard</p>
+      <h1 class="text-3xl font-bold tracking-tight mb-1">{{ community.name }}</h1>
+      <p class="text-ink-muted">Status: <span class="font-semibold">{{ community.status }}</span> &middot; Verteilmodell: {{ community.distribution_model }}</p>
+    </header>
+
+    <section class="grid sm:grid-cols-3 gap-4 mb-8">
+      <div class="bg-white rounded-xl border p-5">
+        <p class="text-sm text-ink-muted mb-1">Bereitschaft</p>
+        <p class="text-3xl font-bold text-brand">{{ community.readiness_score }}%</p>
+      </div>
+      <div class="bg-white rounded-xl border p-5">
+        <p class="text-sm text-ink-muted mb-1">Bestätigte Mitglieder</p>
+        <p class="text-3xl font-bold">{{ community.member_count.confirmed }}<span class="text-lg text-ink-muted">/{{ community.member_count.total }}</span></p>
+      </div>
+      <div class="bg-white rounded-xl border p-5">
+        <p class="text-sm text-ink-muted mb-1">Eingeladen</p>
+        <p class="text-3xl font-bold">{{ community.member_count.invited }}</p>
+      </div>
+    </section>
+
+    <section class="bg-brand/5 border border-brand/20 rounded-xl p-6 mb-8">
+      <h2 class="font-bold mb-3">Nächste Schritte</h2>
+      <ol class="space-y-2 text-sm text-ink-muted list-decimal list-inside">
+        {% for step in community.next_steps %}
+        <li>{{ step }}</li>
+        {% endfor %}
+        {% if not community.next_steps %}
+        <li>Keine offenen Schritte.</li>
+        {% endif %}
+      </ol>
+    </section>
+
+    <section class="bg-white rounded-xl border overflow-hidden mb-8">
+      <div class="px-5 py-3 border-b">
+        <h2 class="font-bold">Mitglieder</h2>
+      </div>
+      <table class="w-full text-sm">
+        <thead class="bg-slate-50">
+          <tr>
+            <th class="px-5 py-3 text-left">Adresse</th>
+            <th class="px-5 py-3 text-left">Rolle</th>
+            <th class="px-5 py-3 text-left">Status</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y">
+          {% for member in community.members %}
+          <tr>
+            <td class="px-5 py-3">{{ member.address or member.building_id }}{% if member.building_id == viewer_building_id %} <span class="text-xs text-brand">(Sie)</span>{% endif %}</td>
+            <td class="px-5 py-3 text-ink-muted">{{ member.role }}</td>
+            <td class="px-5 py-3">
+              {% if member.status == 'confirmed' %}
+              <span class="text-xs text-green-700 font-semibold">bestätigt</span>
+              {% else %}
+              <span class="text-xs text-yellow-600 font-semibold">{{ member.status }}</span>
+              {% endif %}
+            </td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </section>
+    {% endif %}
+  </main>
+{% endblock %}

--- a/tests/test_leg_dashboard.py
+++ b/tests/test_leg_dashboard.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the LEG operator dashboard (/leg/dashboard).
+
+The dashboard surfaces formation_wizard.get_community_status (readiness
+score, members, next steps) to community members via the same
+capability-URL pattern as the resident dashboard (?cid=...&bid=...).
+Non-members get the error view, never another community's data.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import dashboard as dashboard_module
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+STATUS = {
+    "community_id": "c0ffee",
+    "name": "LEG Musterweg",
+    "status": "interested",
+    "distribution_model": "simple",
+    "admin_building_id": "b-admin",
+    "created_at": None,
+    "formation_started_at": None,
+    "dso_submitted_at": None,
+    "member_count": {"total": 2, "confirmed": 1, "invited": 1},
+    "readiness_score": 0,
+    "members": [
+        {"building_id": "b-admin", "role": "admin", "status": "confirmed"},
+        {"building_id": "b-guest", "role": "member", "status": "invited"},
+    ],
+    "documents": None,
+    "next_steps": ["Invite at least 2 more neighbors"],
+}
+
+
+def test_leg_overview_returns_status_for_member(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    result = dashboard_module.leg_overview("c0ffee", "b-admin")
+    assert result["error"] is None
+    assert result["community"]["name"] == "LEG Musterweg"
+    assert result["is_admin"] is True
+    assert result["viewer_building_id"] == "b-admin"
+
+
+def test_leg_overview_member_is_not_admin(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    result = dashboard_module.leg_overview("c0ffee", "b-guest")
+    assert result["error"] is None
+    assert result["is_admin"] is False
+
+
+def test_leg_overview_rejects_non_member(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    result = dashboard_module.leg_overview("c0ffee", "b-stranger")
+    assert result["error"]
+    assert result["community"] is None
+
+
+def test_leg_overview_missing_params(monkeypatch):
+    called = MagicMock()
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "get_community_status", called
+    )
+    assert dashboard_module.leg_overview("", "b-admin")["error"]
+    assert dashboard_module.leg_overview("c0ffee", "")["error"]
+    called.assert_not_called()
+
+
+def test_leg_overview_unknown_community(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=None),
+    )
+    result = dashboard_module.leg_overview("nope", "b-admin")
+    assert result["error"]
+    assert result["community"] is None
+
+
+def test_leg_demo_overview_is_selfcontained():
+    result = dashboard_module.leg_demo_overview()
+    assert result["error"] is None
+    assert result["community"]["readiness_score"] > 0
+    assert result["community"]["next_steps"]
+
+
+def test_leg_dashboard_routes_in_source():
+    with open(os.path.join(PROJECT_ROOT, "app.py"), encoding="utf-8") as handle:
+        source = handle.read()
+    assert '"/leg/dashboard"' in source
+    assert '"/leg/dashboard/demo"' in source
+
+
+def test_leg_dashboard_template_contract():
+    path = os.path.join(PROJECT_ROOT, "templates", "leg_dashboard.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert '{% extends "base.html" %}' in html
+    assert "cdn.tailwindcss.com" not in html
+    assert "readiness_score" in html
+    assert "next_steps" in html


### PR DESCRIPTION
## Summary

Second slice of Phase 4, `docs/leg-registry.md`.

- New `dashboard.leg_overview(community_id, building_id)`: surfaces `formation_wizard.get_community_status` (readiness, members, next steps), gated on membership — non-members get the error view, never another community's data.
- Routes `GET /leg/dashboard?cid=&bid=` + `GET /leg/dashboard/demo` (same capability-URL pattern as the resident `/dashboard`).
- `templates/leg_dashboard.html` on the violet brand system (the amber-token contract test caught my first attempt — fixed to the allowed palette).

First UI ever wired to the `formation_wizard` backend.

Closes #170

## Test plan

- [x] New `tests/test_leg_dashboard.py` written test-first (8 red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 583 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_