### PR TITLE
Phase 4 Slice 3: formation actions from the LEG dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -1347,6 +1347,45 @@ def leg_dashboard_demo():
     )
 
 
+def _leg_dashboard_redirect(community_id, building_id):
+    return redirect(f"/leg/dashboard?cid={community_id}&bid={building_id}")
+
+
+@app.route("/leg/community/create", methods=["POST"])
+def leg_community_create():
+    name = request.form.get("name", "")
+    building_id = request.form.get("bid", "").strip()
+    model = request.form.get("distribution_model", "simple")
+    result = dashboard_module.leg_create(name, building_id, model)
+    if result["error"]:
+        return render_city_template(
+            "leg_dashboard.html", error=result["error"], community=None
+        ), 400
+    return _leg_dashboard_redirect(result["community_id"], building_id)
+
+
+@app.route("/leg/community/<community_id>/invite", methods=["POST"])
+def leg_community_invite(community_id):
+    building_id = request.form.get("bid", "").strip()
+    invite_building_id = request.form.get("invite_building_id", "").strip()
+    dashboard_module.leg_invite(community_id, building_id, invite_building_id)
+    return _leg_dashboard_redirect(community_id, building_id)
+
+
+@app.route("/leg/community/<community_id>/confirm", methods=["POST"])
+def leg_community_confirm(community_id):
+    building_id = request.form.get("bid", "").strip()
+    dashboard_module.leg_confirm(community_id, building_id)
+    return _leg_dashboard_redirect(community_id, building_id)
+
+
+@app.route("/leg/community/<community_id>/start-formation", methods=["POST"])
+def leg_community_start_formation(community_id):
+    building_id = request.form.get("bid", "").strip()
+    dashboard_module.leg_start_formation(community_id, building_id)
+    return _leg_dashboard_redirect(community_id, building_id)
+
+
 # --- Referral System ---
 @app.route("/api/referral/stats/<building_id>")
 def api_referral_stats(building_id):

--- a/app.py
+++ b/app.py
@@ -1348,7 +1348,7 @@ def leg_dashboard_demo():
 
 
 def _leg_dashboard_redirect(community_id, building_id):
-    return redirect(f"/leg/dashboard?cid={community_id}&bid={building_id}")
+    return redirect(dashboard_module.leg_dashboard_location(community_id, building_id))
 
 
 @app.route("/leg/community/create", methods=["POST"])

--- a/dashboard.py
+++ b/dashboard.py
@@ -1,8 +1,19 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """Dashboard readiness verb."""
 
+from urllib.parse import urlencode
+
 import database as db
 import formation_wizard
+
+
+def leg_dashboard_location(community_id: str, building_id: str) -> str:
+    """Build the dashboard redirect target with untrusted values encoded.
+
+    urlencode keeps the location a relative /leg/dashboard path no matter
+    what the caller passes (no protocol-relative //host, no fragments).
+    """
+    return "/leg/dashboard?" + urlencode({"cid": community_id, "bid": building_id})
 
 
 def readiness(building_id: str, *, city_id=None, app_base_url: str = "") -> dict:

--- a/dashboard.py
+++ b/dashboard.py
@@ -94,6 +94,73 @@ def leg_overview(community_id: str, building_id: str) -> dict:
     }
 
 
+def _require_role(community_id: str, building_id: str, role: str):
+    """Return the member row if building_id has the given role, else None."""
+    status = formation_wizard.get_community_status(db, community_id)
+    if not status:
+        return None
+    return next(
+        (
+            m
+            for m in status["members"] or []
+            if m["building_id"] == building_id and m.get("role") == role
+        ),
+        None,
+    )
+
+
+def leg_create(name: str, building_id: str, distribution_model: str) -> dict:
+    """Create a community with building_id as admin."""
+    name = (name or "").strip()
+    if not name or not building_id:
+        return {"error": "Name und Profil sind erforderlich.", "community_id": None}
+    if distribution_model not in ("simple", "proportional", "custom"):
+        distribution_model = "simple"
+    created = formation_wizard.create_community(
+        db, name, building_id, distribution_model
+    )
+    if not created:
+        return {
+            "error": "LEG konnte nicht erstellt werden.",
+            "community_id": None,
+        }
+    return {"error": None, "community_id": created["community_id"]}
+
+
+def leg_invite(community_id: str, building_id: str, invite_building_id: str) -> dict:
+    """Invite a building; only the community admin may invite."""
+    if not _require_role(community_id, building_id, "admin"):
+        return {"error": "Nur die Administration kann einladen."}
+    if not invite_building_id:
+        return {"error": "Kein Profil zum Einladen angegeben."}
+    ok = formation_wizard.invite_member(
+        db, community_id, invite_building_id, building_id
+    )
+    if not ok:
+        return {"error": "Einladung nicht möglich (bereits Mitglied?)."}
+    return {"error": None}
+
+
+def leg_confirm(community_id: str, building_id: str) -> dict:
+    """Confirm one's own invited membership."""
+    if not community_id or not building_id:
+        return {"error": "Kein Zugriff."}
+    ok = formation_wizard.confirm_membership(db, community_id, building_id)
+    if not ok:
+        return {"error": "Keine offene Einladung gefunden."}
+    return {"error": None}
+
+
+def leg_start_formation(community_id: str, building_id: str) -> dict:
+    """Start formal formation; only the community admin may start."""
+    if not _require_role(community_id, building_id, "admin"):
+        return {"error": "Nur die Administration kann die Gründung starten."}
+    ok = formation_wizard.start_formation(db, community_id)
+    if not ok:
+        return {"error": "Gründung noch nicht möglich (genug bestätigte Mitglieder?)."}
+    return {"error": None}
+
+
 def leg_demo_overview() -> dict:
     """Fake, click-through LEG operator dashboard data for demos."""
     return {

--- a/templates/leg_dashboard.html
+++ b/templates/leg_dashboard.html
@@ -80,6 +80,39 @@
         </tbody>
       </table>
     </section>
+
+    {% set viewer = (community.members | selectattr("building_id", "equalto", viewer_building_id) | list | first) if community.members else none %}
+    {% if viewer and viewer.status == 'invited' %}
+    <section class="bg-white rounded-xl border p-6 mb-8">
+      <h2 class="font-bold mb-2">Ihre Einladung</h2>
+      <p class="text-sm text-ink-muted mb-4">Sie sind eingeladen, bei "{{ community.name }}" mitzumachen.</p>
+      <form method="post" action="/leg/community/{{ community.community_id }}/confirm">
+        <input type="hidden" name="bid" value="{{ viewer_building_id }}">
+        <button type="submit" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Teilnahme bestätigen</button>
+      </form>
+    </section>
+    {% endif %}
+
+    {% if is_admin %}
+    <section class="bg-white rounded-xl border p-6 mb-8">
+      <h2 class="font-bold mb-2">Mitglied einladen</h2>
+      <form method="post" action="/leg/community/{{ community.community_id }}/invite" class="flex flex-col sm:flex-row gap-3">
+        <input type="hidden" name="bid" value="{{ viewer_building_id }}">
+        <input type="text" name="invite_building_id" placeholder="Profil-ID des Nachbarn"
+          class="flex-1 border rounded-lg px-4 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        <button type="submit" class="bg-brand text-white px-6 py-2 rounded-lg font-semibold hover:bg-brand-dark">Einladen</button>
+      </form>
+    </section>
+
+    <section class="bg-white rounded-xl border p-6">
+      <h2 class="font-bold mb-2">Gründung starten</h2>
+      <p class="text-sm text-ink-muted mb-4">Sobald genug Mitglieder bestätigt haben, starten Sie hier den formellen Gründungsprozess.</p>
+      <form method="post" action="/leg/community/{{ community.community_id }}/start-formation">
+        <input type="hidden" name="bid" value="{{ viewer_building_id }}">
+        <button type="submit" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-slate-50">Gründung starten</button>
+      </form>
+    </section>
+    {% endif %}
     {% endif %}
   </main>
 {% endblock %}

--- a/tests/test_leg_dashboard.py
+++ b/tests/test_leg_dashboard.py
@@ -206,6 +206,15 @@ def test_leg_start_formation_as_admin(monkeypatch):
     mock_start.assert_called_once()
 
 
+def test_leg_dashboard_location_encodes_untrusted_values():
+    # CodeQL: user-provided cid/bid must not be able to steer the redirect
+    # off /leg/dashboard (e.g. protocol-relative //evil.com or fragments).
+    location = dashboard_module.leg_dashboard_location("//evil.com", "b?x=1#y")
+    assert location.startswith("/leg/dashboard?")
+    assert "//evil.com" not in location
+    assert "#" not in location
+
+
 def test_formation_action_routes_in_source():
     with open(os.path.join(PROJECT_ROOT, "app.py"), encoding="utf-8") as handle:
         source = handle.read()

--- a/tests/test_leg_dashboard.py
+++ b/tests/test_leg_dashboard.py
@@ -112,3 +112,113 @@ def test_leg_dashboard_template_contract():
     assert "cdn.tailwindcss.com" not in html
     assert "readiness_score" in html
     assert "next_steps" in html
+
+
+# --- Formation actions (Slice 3) ---
+
+
+def _patch_status(monkeypatch, status=None):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS) if status is None else status),
+    )
+
+
+def test_leg_create_calls_formation_wizard(monkeypatch):
+    created = {"community_id": "new-cid", "name": "LEG Neu"}
+    mock_create = MagicMock(return_value=created)
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "create_community", mock_create
+    )
+    result = dashboard_module.leg_create("LEG Neu", "b-admin", "simple")
+    assert result["error"] is None
+    assert result["community_id"] == "new-cid"
+    args, _ = mock_create.call_args
+    assert args[1] == "LEG Neu"
+    assert args[2] == "b-admin"
+
+
+def test_leg_create_requires_name_and_bid(monkeypatch):
+    mock_create = MagicMock()
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "create_community", mock_create
+    )
+    assert dashboard_module.leg_create("", "b-admin", "simple")["error"]
+    assert dashboard_module.leg_create("LEG Neu", "", "simple")["error"]
+    mock_create.assert_not_called()
+
+
+def test_leg_invite_requires_admin(monkeypatch):
+    _patch_status(monkeypatch)
+    mock_invite = MagicMock(return_value=True)
+    monkeypatch.setattr(dashboard_module.formation_wizard, "invite_member", mock_invite)
+
+    result = dashboard_module.leg_invite("c0ffee", "b-guest", "b-new")
+    assert result["error"]
+    mock_invite.assert_not_called()
+
+
+def test_leg_invite_as_admin_calls_wizard(monkeypatch):
+    _patch_status(monkeypatch)
+    mock_invite = MagicMock(return_value=True)
+    monkeypatch.setattr(dashboard_module.formation_wizard, "invite_member", mock_invite)
+
+    result = dashboard_module.leg_invite("c0ffee", "b-admin", "b-new")
+    assert result["error"] is None
+    args, _ = mock_invite.call_args
+    assert args[1] == "c0ffee"
+    assert args[2] == "b-new"
+    assert args[3] == "b-admin"
+
+
+def test_leg_confirm_confirms_own_membership(monkeypatch):
+    mock_confirm = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "confirm_membership", mock_confirm
+    )
+    result = dashboard_module.leg_confirm("c0ffee", "b-guest")
+    assert result["error"] is None
+    args, _ = mock_confirm.call_args
+    assert args[1] == "c0ffee"
+    assert args[2] == "b-guest"
+
+
+def test_leg_start_formation_requires_admin(monkeypatch):
+    _patch_status(monkeypatch)
+    mock_start = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "start_formation", mock_start
+    )
+    result = dashboard_module.leg_start_formation("c0ffee", "b-guest")
+    assert result["error"]
+    mock_start.assert_not_called()
+
+
+def test_leg_start_formation_as_admin(monkeypatch):
+    _patch_status(monkeypatch)
+    mock_start = MagicMock(return_value=True)
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "start_formation", mock_start
+    )
+    result = dashboard_module.leg_start_formation("c0ffee", "b-admin")
+    assert result["error"] is None
+    mock_start.assert_called_once()
+
+
+def test_formation_action_routes_in_source():
+    with open(os.path.join(PROJECT_ROOT, "app.py"), encoding="utf-8") as handle:
+        source = handle.read()
+    assert '"/leg/community/create"' in source
+    assert '"/leg/community/<community_id>/invite"' in source
+    assert '"/leg/community/<community_id>/confirm"' in source
+    assert '"/leg/community/<community_id>/start-formation"' in source
+
+
+def test_leg_dashboard_template_has_action_forms():
+    path = os.path.join(PROJECT_ROOT, "templates", "leg_dashboard.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert "/invite" in html
+    assert "/start-formation" in html
+    assert "/confirm" in html


### PR DESCRIPTION
## Summary

Final code slice of Phase 4, `docs/leg-registry.md`.

- New `dashboard.py` verbs wrapping `formation_wizard` with role checks: `leg_create` (creator becomes admin), `leg_invite` (admin only), `leg_confirm` (own membership only), `leg_start_formation` (admin only).
- POST routes `/leg/community/create`, `/leg/community/<id>/invite`, `/leg/community/<id>/confirm`, `/leg/community/<id>/start-formation`.
- `leg_dashboard.html` gains the action forms (invite + start-formation for admins, confirm for invited viewers).

Closes #172

## Test plan

- [x] `tests/test_leg_dashboard.py` extended test-first (9 red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 592 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_