### PR TITLE
Phase 7: municipality LEG reporting on profil pages

### DIFF
--- a/municipality.py
+++ b/municipality.py
@@ -307,9 +307,12 @@ def profil(bfs):
     seo_title, seo_description = _profile_seo(name, h4)
     jsonld = _profile_jsonld(profile, bfs, h4, site_url, canonical_url)
 
+    leg_entries = db.list_registry_entries(q=name) if name else []
+
     return render_template(
         "gemeinde/profil.html",
         profile=profile,
+        leg_entries=leg_entries,
         tariffs=tariffs,
         solar=solar,
         value_gap=value_gap,

--- a/templates/fuer_gemeinden.html
+++ b/templates/fuer_gemeinden.html
@@ -27,7 +27,7 @@
 
     <section class="bg-brand/5 border border-brand/20 rounded-xl p-6 mb-10 text-center">
       <h2 class="text-xl font-bold mb-2">Wo steht Ihre Gemeinde bei der Solarnutzung?</h2>
-      <p class="text-ink-muted max-w-2xl mx-auto mb-4">Die Rangliste vergleicht Ihre Gemeinde mit ähnlichen Gemeinden und zeigt, wie viele Dächer bis zum oberen Viertel fehlen. Aus offenen Daten von BFE und BFS, ohne Anmeldung.</p>
+      <p class="text-ink-muted max-w-2xl mx-auto mb-4">Die Rangliste vergleicht Ihre Gemeinde mit ähnlichen Gemeinden und zeigt, wie viele Dächer bis zum oberen Viertel fehlen. Aus offenen Daten von BFE und BFS, ohne Anmeldung. Das offene <a href="/leg-verzeichnis" class="text-brand underline">LEG-Verzeichnis</a> zeigt zudem, welche Stromgemeinschaften in Ihrer Gemeinde schon aktiv sind.</p>
       <a href="/rangliste" class="inline-block bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Rangliste ansehen</a>
     </section>
 

--- a/templates/gemeinde/profil.html
+++ b/templates/gemeinde/profil.html
@@ -251,6 +251,24 @@
         </div>
         {% endif %}
 
+        <!-- LEG-Stand: was im offenen Verzeichnis für diese Gemeinde bekannt ist -->
+        <div class="mt-8 bg-white rounded-xl p-6 shadow-sm border">
+            <h2 class="text-xl font-semibold mb-2">Lokale Elektrizitätsgemeinschaften in {{ profile.name }}</h2>
+            {% if leg_entries %}
+            <ul class="space-y-2 mb-4">
+                {% for entry in leg_entries %}
+                <li><a href="/leg-verzeichnis/{{ entry.slug }}" class="text-brand hover:underline font-semibold">{{ entry.name }}</a>{% if entry.leg_status %} <span class="text-xs text-ink-muted">({{ entry.leg_status }})</span>{% endif %}</li>
+                {% endfor %}
+            </ul>
+            {% else %}
+            <p class="text-sm text-ink-muted mb-4">Im offenen Verzeichnis ist noch keine LEG aus {{ profile.name }} eingetragen. Einträge sind moderierte Selbstauskünfte, unabhängig von der Gründungsplattform.</p>
+            {% endif %}
+            <div class="flex flex-col sm:flex-row gap-2">
+                <a href="/leg-check?q={{ profile.name }}" class="inline-block text-center bg-brand text-white px-5 py-2 rounded-lg text-sm font-semibold hover:bg-brand-dark">Zum LEG-Check</a>
+                <a href="/leg-verzeichnis/eintragen" class="inline-block text-center border border-ink/20 text-ink px-5 py-2 rounded-lg text-sm font-semibold hover:bg-slate-50">Bestehende LEG eintragen</a>
+            </div>
+        </div>
+
         <!-- Bewohner-CTA: wer hier landet, sucht meist den eigenen Tarif -->
         <div class="mt-8 bg-brand rounded-xl p-6 text-white md:flex md:items-center md:justify-between gap-6">
             <div>

--- a/tests/test_municipality_leg_section.py
+++ b/tests/test_municipality_leg_section.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Municipality profile pages report the local LEG picture.
+
+Phase 7 of docs/leg-registry.md: a Gemeinde page shows published entries
+from the open registry for that municipality, funnels into /leg-check,
+and the municipalities pathway page links the registry.
+"""
+
+import os
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(*parts):
+    with open(os.path.join(PROJECT_ROOT, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def test_profil_route_loads_registry_entries():
+    source = _read("municipality.py")
+    assert "list_registry_entries" in source
+
+
+def test_profil_template_has_leg_section():
+    html = _read("templates", "gemeinde", "profil.html")
+    assert "Lokale Elektrizitätsgemeinschaften" in html
+    assert "leg_entries" in html
+    assert 'href="/leg-check?q=' in html
+    assert 'href="/leg-verzeichnis/eintragen"' in html
+
+
+def test_fuer_gemeinden_links_registry():
+    html = _read("templates", "fuer_gemeinden.html")
+    assert 'href="/leg-verzeichnis"' in html


### PR DESCRIPTION
## Summary

Phase 7 of the LEG registry roadmap, `docs/leg-registry.md`.

- `GET /gemeinde/profil/<bfs>` gains a "Lokale Elektrizitätsgemeinschaften in \<Gemeinde\>" section: published registry entries for that municipality + CTAs into `/leg-check?q=` and `/leg-verzeichnis/eintragen`, with an honest empty state.
- `/fuer-gemeinden` links the open registry.

The municipality-facing reporting angle a utility-white-label platform structurally can't offer.

Closes #174

## Test plan

- [x] New `tests/test_municipality_leg_section.py` written test-first (3 red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 596 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_