### PR TITLE
Phase 8: SEO structured data (FAQPage + registry ItemList)

### DIFF
--- a/templates/leg_gruenden.html
+++ b/templates/leg_gruenden.html
@@ -25,6 +25,54 @@
     ]
   }
 </script>
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "Kann ich eine LEG gründen, wenn ich keine Solaranlage habe?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Nein, mindestens ein Teilnehmer muss Strom produzieren. Sie müssen aber nicht selbst der Produzent sein. Sie können einer LEG beitreten, bei der ein Nachbar die Solaranlage hat."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Wie viel Geld spare ich mit einer LEG?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Das hängt von Ihrem Verbrauch und der lokalen Produktion ab. Typischerweise sparen LEG-Mitglieder 10 bis 30% bei den Netznutzungsentgelten."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Muss ich einen Smart Meter haben?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ja, für LEGs ist eine 15-Minuten-Messung gesetzlich vorgeschrieben. Ihr Netzbetreiber installiert die Smart Meter nach Genehmigung der LEG."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Kann ich aus einer LEG wieder austreten?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Ja, die Austrittsregeln stehen in Ihren Statuten. Üblicherweise ist ein Austritt mit 3-6 Monaten Kündigungsfrist möglich."
+        }
+      },
+      {
+        "@type": "Question",
+        "name": "Was passiert, wenn meine Gemeinde keine LEG-Plattform hat?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "Sie können trotzdem eine LEG gründen. Es braucht dann mehr Eigenarbeit. Oder Sie schlagen Ihrer Gemeinde vor, bei OpenLEG mitzumachen. Für Gemeinden ist der Plattformstart kostenlos."
+        }
+      }
+    ]
+  }
+</script>
 {% endblock %}
 
 {% block content %}

--- a/templates/leg_verzeichnis/liste.html
+++ b/templates/leg_verzeichnis/liste.html
@@ -11,6 +11,28 @@
 ) }}
 {% endblock %}
 
+{% block head_extra %}
+{% if entries %}
+<script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    "name": "Offenes LEG-Verzeichnis Schweiz",
+    "itemListElement": [
+      {% for entry in entries %}
+      {
+        "@type": "ListItem",
+        "position": {{ loop.index }},
+        "name": {{ entry.name | tojson }},
+        "url": "{{ site_url }}/leg-verzeichnis/{{ entry.slug }}"
+      }{{ "," if not loop.last }}
+      {% endfor %}
+    ]
+  }
+</script>
+{% endif %}
+{% endblock %}
+
 {% block content %}
   <main class="max-w-6xl mx-auto px-4 py-12">
     <header class="max-w-3xl mb-8">

--- a/tests/test_seo_structured_data.py
+++ b/tests/test_seo_structured_data.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""SEO structured data: FAQPage on /leg-gruenden, ItemList on the registry.
+
+Phase 8 of docs/leg-registry.md. The FAQ answers must mirror the visible
+<details> content; the registry list emits an ItemList over published
+entries only (whatever the route already filtered).
+"""
+
+import os
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read(*parts):
+    with open(os.path.join(PROJECT_ROOT, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def test_leg_gruenden_has_faq_jsonld():
+    html = _read("templates", "leg_gruenden.html")
+    assert '"@type": "FAQPage"' in html
+    assert '"@type": "Question"' in html
+    assert '"@type": "Answer"' in html
+
+
+def test_leg_verzeichnis_liste_has_itemlist_jsonld():
+    html = _read("templates", "leg_verzeichnis", "liste.html")
+    assert '"@type": "ItemList"' in html
+    assert "itemListElement" in html


### PR DESCRIPTION
## Summary

Phase 8 of the LEG registry roadmap, `docs/leg-registry.md`.

- `/leg-gruenden` gains FAQPage JSON-LD mirroring the visible FAQ `<details>` content (same answers, nothing invented).
- `/leg-verzeichnis` gains ItemList JSON-LD over the published entries the route already renders (no additional data exposure).

Closes #176

## Test plan

- [x] New `tests/test_seo_structured_data.py` written test-first (2 red confirmed).
- [x] `scripts/tdd_cycle.sh gate` green: 598 passed, 11 skipped.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_