### PR TITLE
Phases 5+6: contract builder + correspondence ledger — HOLD: maintainer sign-off required

### DIFF
--- a/app.py
+++ b/app.py
@@ -1386,6 +1386,28 @@ def leg_community_start_formation(community_id):
     return _leg_dashboard_redirect(community_id, building_id)
 
 
+@app.route("/leg/community/<community_id>/documents", methods=["POST"])
+def leg_community_documents(community_id):
+    building_id = request.form.get("bid", "").strip()
+    dashboard_module.leg_generate_documents(community_id, building_id)
+    return _leg_dashboard_redirect(community_id, building_id)
+
+
+@app.route("/leg/document/<int:doc_id>")
+def leg_document_download(doc_id):
+    building_id = request.args.get("bid", "").strip()
+    doc = dashboard_module.leg_document_for_member(doc_id, building_id)
+    if not doc:
+        abort(404)
+    return Response(
+        bytes(doc["pdf_data"]),
+        mimetype="application/pdf",
+        headers={
+            "Content-Disposition": f"inline; filename={doc['filename']}",
+        },
+    )
+
+
 # --- Referral System ---
 @app.route("/api/referral/stats/<building_id>")
 def api_referral_stats(building_id):

--- a/app.py
+++ b/app.py
@@ -1393,6 +1393,21 @@ def leg_community_documents(community_id):
     return _leg_dashboard_redirect(community_id, building_id)
 
 
+@app.route("/leg/community/<community_id>/correspondence", methods=["POST"])
+def leg_community_correspondence(community_id):
+    building_id = request.form.get("bid", "").strip()
+    dashboard_module.leg_log_correspondence(
+        community_id,
+        building_id,
+        direction=request.form.get("direction", ""),
+        channel=request.form.get("channel", ""),
+        counterparty=request.form.get("counterparty", ""),
+        subject=request.form.get("subject", ""),
+        notes=request.form.get("notes", ""),
+    )
+    return _leg_dashboard_redirect(community_id, building_id)
+
+
 @app.route("/leg/document/<int:doc_id>")
 def leg_document_download(doc_id):
     building_id = request.args.get("bid", "").strip()

--- a/dashboard.py
+++ b/dashboard.py
@@ -4,6 +4,7 @@
 from urllib.parse import urlencode
 
 import database as db
+import document_generator
 import formation_wizard
 
 
@@ -102,6 +103,7 @@ def leg_overview(community_id: str, building_id: str) -> dict:
         "community": status,
         "viewer_building_id": building_id,
         "is_admin": member.get("role") == "admin",
+        "leg_documents": db.list_leg_documents(community_id),
     }
 
 
@@ -170,6 +172,80 @@ def leg_start_formation(community_id: str, building_id: str) -> dict:
     if not ok:
         return {"error": "Gründung noch nicht möglich (genug bestätigte Mitglieder?)."}
     return {"error": None}
+
+
+def leg_generate_documents(community_id: str, building_id: str) -> dict:
+    """Generate the community agreement and participant contracts as PDFs.
+
+    Admin-only. Uses confirmed members as participants; a member counts as
+    producer when its building has PV potential. Real PDFs land in
+    leg_documents; formation_wizard.generate_documents runs the status
+    transition. The documents are templates, not legal advice — the
+    dashboard says so explicitly.
+    """
+    if not _require_role(community_id, building_id, "admin"):
+        return {"error": "Nur die Administration kann Dokumente erstellen."}
+
+    status = formation_wizard.get_community_status(db, community_id)
+    participants = []
+    for member in status["members"] or []:
+        if member["status"] != "confirmed":
+            continue
+        building = db.get_building_for_dashboard(member["building_id"]) or {}
+        pv = building.get("potential_pv_kwp") or 0
+        participants.append(
+            {
+                "name": member.get("email") or member["building_id"],
+                "address": member.get("address") or "",
+                "role": "producer" if pv and float(pv) > 0 else "consumer",
+            }
+        )
+
+    try:
+        agreement_pdf = document_generator.generate_gemeinschaftsvereinbarung(
+            community_name=status["name"],
+            participants=participants,
+            municipality="",
+            distribution_model=status["distribution_model"],
+        )
+    except ValueError as exc:
+        return {"error": str(exc)}
+
+    db.store_leg_document(
+        community_id,
+        "gemeinschaftsvereinbarung",
+        agreement_pdf,
+        "gemeinschaftsvereinbarung.pdf",
+    )
+
+    for participant in participants:
+        contract_pdf = document_generator.generate_teilnehmervertrag(
+            participant_name=participant["name"],
+            participant_address=participant["address"],
+            community_name=status["name"],
+            role=participant["role"],
+        )
+        db.store_leg_document(
+            community_id,
+            "teilnehmervertrag",
+            contract_pdf,
+            f"teilnehmervertrag-{participant['name']}.pdf",
+        )
+
+    formation_wizard.generate_documents(db, community_id)
+    return {"error": None, "generated": 1 + len(participants)}
+
+
+def leg_document_for_member(doc_id: int, building_id: str):
+    """Return a stored document only if building_id belongs to its community."""
+    doc = db.get_leg_document(doc_id)
+    if not doc:
+        return None
+    status = formation_wizard.get_community_status(db, doc["community_id"])
+    if not status:
+        return None
+    is_member = any(m["building_id"] == building_id for m in status["members"] or [])
+    return doc if is_member else None
 
 
 def leg_demo_overview() -> dict:

--- a/dashboard.py
+++ b/dashboard.py
@@ -104,6 +104,7 @@ def leg_overview(community_id: str, building_id: str) -> dict:
         "viewer_building_id": building_id,
         "is_admin": member.get("role") == "admin",
         "leg_documents": db.list_leg_documents(community_id),
+        "correspondence": db.list_correspondence(community_id),
     }
 
 
@@ -246,6 +247,36 @@ def leg_document_for_member(doc_id: int, building_id: str):
         return None
     is_member = any(m["building_id"] == building_id for m in status["members"] or [])
     return doc if is_member else None
+
+
+def leg_log_correspondence(
+    community_id: str,
+    building_id: str,
+    direction: str,
+    channel: str,
+    counterparty: str,
+    subject: str,
+    notes: str = "",
+) -> dict:
+    """Append a ledger entry; any confirmed or invited member may log."""
+    status = formation_wizard.get_community_status(db, community_id)
+    if not status or not any(
+        m["building_id"] == building_id for m in status["members"] or []
+    ):
+        return {"error": "Kein Zugriff."}
+
+    entry_id = db.log_correspondence(
+        community_id=community_id,
+        direction=direction,
+        channel=channel,
+        counterparty=(counterparty or "").strip(),
+        subject=(subject or "").strip(),
+        notes=(notes or "").strip(),
+        logged_by=building_id,
+    )
+    if entry_id is None:
+        return {"error": "Eintrag ungültig (Richtung oder Kanal unbekannt)."}
+    return {"error": None, "entry_id": entry_id}
 
 
 def leg_demo_overview() -> dict:

--- a/database.py
+++ b/database.py
@@ -1746,7 +1746,7 @@ def update_document_signing_status(deepsign_document_id: str, status: str) -> bo
 
 
 def store_leg_document(
-    community_id: int, doc_type: str, pdf_bytes: bytes, filename: str
+    community_id: str, doc_type: str, pdf_bytes: bytes, filename: str
 ) -> int:
     """Store generated LEG document PDF."""
     try:
@@ -1765,7 +1765,27 @@ def store_leg_document(
         return 0
 
 
-def list_leg_documents(community_id: int) -> List[Dict]:
+def get_leg_document(doc_id: int) -> Optional[Dict]:
+    """Get one stored LEG document including its PDF bytes."""
+    try:
+        with get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT id, community_id, doc_type, filename, pdf_data,
+                           signing_status, created_at
+                    FROM leg_documents WHERE id = %s
+                """,
+                    (doc_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting leg document: {e}")
+        return None
+
+
+def list_leg_documents(community_id: str) -> List[Dict]:
     """List all documents for a community."""
     try:
         with get_connection() as conn:

--- a/database.py
+++ b/database.py
@@ -800,6 +800,26 @@ def _create_tables():
                 "CREATE INDEX IF NOT EXISTS idx_leg_registry_claim_token ON leg_registry(claim_token)"
             )
 
+            # Community correspondence ledger: shared in/out mail log per LEG
+            # (email and physical post, manually logged). Phase 6 MVP, see
+            # docs/leg-registry.md.
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS correspondence_log (
+                    id SERIAL PRIMARY KEY,
+                    community_id VARCHAR(64) NOT NULL,
+                    direction VARCHAR(8) NOT NULL,
+                    channel VARCHAR(16) NOT NULL,
+                    counterparty VARCHAR(255),
+                    subject VARCHAR(255),
+                    notes TEXT,
+                    logged_by VARCHAR(64),
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_correspondence_log_community ON correspondence_log(community_id)"
+            )
+
             # LEA autonomous reports (instance ops, posted via /api/internal/*)
             cur.execute("""
                 CREATE TABLE IF NOT EXISTS lea_reports (
@@ -1759,7 +1779,7 @@ def store_leg_document(
                 """,
                     (community_id, doc_type, filename, pdf_bytes),
                 )
-                return cur.fetchone()[0]
+                return dict(cur.fetchone())["id"]
     except Exception as e:
         logger.error(f"[DB] Error storing leg document: {e}")
         return 0
@@ -1997,6 +2017,11 @@ from store.registry import (  # noqa: E402, F401
     get_registry_entry_by_verification_token,
     mark_registry_entry_verified,
     get_registry_entries_needing_verification,
+)
+
+from store.correspondence import (  # noqa: E402, F401
+    log_correspondence,
+    list_correspondence,
 )
 
 from store.meter import (  # noqa: E402, F401

--- a/formation_wizard.py
+++ b/formation_wizard.py
@@ -390,7 +390,10 @@ def generate_documents(db, community_id: str) -> Optional[Dict]:
                             }
                         )
 
-                # Save documents to database
+                # Save documents to database (JSONB column: adapt via JSON
+                # string; psycopg2 cannot adapt a raw dict)
+                import json
+
                 cur.execute(
                     """
                     INSERT INTO community_documents (community_id, documents, generated_at)
@@ -399,7 +402,7 @@ def generate_documents(db, community_id: str) -> Optional[Dict]:
                         documents = EXCLUDED.documents,
                         generated_at = EXCLUDED.generated_at
                 """,
-                    (community_id, documents),
+                    (community_id, json.dumps(documents)),
                 )
 
                 # Update community status

--- a/store/correspondence.py
+++ b/store/correspondence.py
@@ -1,0 +1,86 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Correspondence ledger repository.
+
+Repository module for the community correspondence domain: one shared log
+per LEG of outgoing and incoming mail (email and physical post), manually
+logged by members. Phase 6 MVP of ``docs/leg-registry.md`` — deliberately
+no external mail provider; a hybrid-mail integration is a separate,
+explicit business decision. The connection seam is resolved via
+``database.get_connection`` at call time so existing tests that
+``monkeypatch.setattr(database, "get_connection", ...)`` keep working
+unchanged and ``database`` can re-export these functions for legacy callers.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+DIRECTIONS = {"in", "out"}
+CHANNELS = {"email", "post"}
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+def log_correspondence(
+    community_id: str,
+    direction: str,
+    channel: str,
+    counterparty: str,
+    subject: str,
+    notes: str = "",
+    logged_by: str = "",
+) -> Optional[int]:
+    """Append one ledger entry. Returns the row id, or None on invalid input."""
+    if direction not in DIRECTIONS or channel not in CHANNELS:
+        return None
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO correspondence_log (
+                        community_id, direction, channel, counterparty,
+                        subject, notes, logged_by
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s)
+                    RETURNING id
+                """,
+                    (
+                        community_id,
+                        direction,
+                        channel,
+                        counterparty,
+                        subject,
+                        notes,
+                        logged_by,
+                    ),
+                )
+                row = cur.fetchone()
+                return dict(row)["id"] if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error logging correspondence: {e}")
+        return None
+
+
+def list_correspondence(community_id: str, limit: int = 100) -> List[Dict]:
+    """List a community's ledger entries, newest first."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT * FROM correspondence_log
+                    WHERE community_id = %s
+                    ORDER BY created_at DESC
+                    LIMIT %s
+                """,
+                    (community_id, max(1, min(int(limit), 500))),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error listing correspondence: {e}")
+        return []

--- a/templates/leg_dashboard.html
+++ b/templates/leg_dashboard.html
@@ -93,6 +93,29 @@
     </section>
     {% endif %}
 
+    <section class="bg-white rounded-xl border p-6 mb-8">
+      <h2 class="font-bold mb-2">Dokumente</h2>
+      <p class="text-sm text-ink-muted mb-4">Diese Vorlagen sind automatisch erstellte Entwürfe und keine Rechtsberatung. Lassen Sie die Dokumente vor der Unterzeichnung juristisch prüfen.</p>
+      {% if leg_documents %}
+      <ul class="space-y-2 mb-4">
+        {% for doc in leg_documents %}
+        <li class="flex items-center justify-between text-sm">
+          <span>{{ doc.filename }} <span class="text-xs text-ink-muted">({{ doc.signing_status }})</span></span>
+          <a href="/leg/document/{{ doc.id }}?bid={{ viewer_building_id }}" class="text-brand hover:underline font-semibold">PDF öffnen</a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p class="text-sm text-ink-muted mb-4">Noch keine Dokumente erstellt.</p>
+      {% endif %}
+      {% if is_admin %}
+      <form method="post" action="/leg/community/{{ community.community_id }}/documents">
+        <input type="hidden" name="bid" value="{{ viewer_building_id }}">
+        <button type="submit" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Vertragsentwürfe erstellen</button>
+      </form>
+      {% endif %}
+    </section>
+
     {% if is_admin %}
     <section class="bg-white rounded-xl border p-6 mb-8">
       <h2 class="font-bold mb-2">Mitglied einladen</h2>

--- a/templates/leg_dashboard.html
+++ b/templates/leg_dashboard.html
@@ -116,6 +116,55 @@
       {% endif %}
     </section>
 
+    <section class="bg-white rounded-xl border p-6 mb-8">
+      <h2 class="font-bold mb-2">Korrespondenz</h2>
+      <p class="text-sm text-ink-muted mb-4">Gemeinsames Journal aller ein- und ausgehenden Briefe und E-Mails, zum Beispiel mit dem Netzbetreiber. So sieht die ganze LEG, was gesendet wurde und was beantwortet ist.</p>
+      {% if correspondence %}
+      <table class="w-full text-sm mb-4">
+        <thead class="bg-slate-50">
+          <tr>
+            <th class="px-3 py-2 text-left">Richtung</th>
+            <th class="px-3 py-2 text-left">Kanal</th>
+            <th class="px-3 py-2 text-left">Gegenstelle</th>
+            <th class="px-3 py-2 text-left">Betreff</th>
+            <th class="px-3 py-2 text-right">Datum</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y">
+          {% for entry in correspondence %}
+          <tr>
+            <td class="px-3 py-2">{{ "Eingang" if entry.direction == "in" else "Ausgang" }}</td>
+            <td class="px-3 py-2 text-ink-muted">{{ "Brief" if entry.channel == "post" else "E-Mail" }}</td>
+            <td class="px-3 py-2">{{ entry.counterparty }}</td>
+            <td class="px-3 py-2">{{ entry.subject }}</td>
+            <td class="px-3 py-2 text-right text-xs text-ink-muted">{{ entry.created_at }}</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+      {% else %}
+      <p class="text-sm text-ink-muted mb-4">Noch keine Einträge.</p>
+      {% endif %}
+      <form method="post" action="/leg/community/{{ community.community_id }}/correspondence" class="grid sm:grid-cols-2 gap-3">
+        <input type="hidden" name="bid" value="{{ viewer_building_id }}">
+        <select name="direction" class="border rounded-lg px-3 py-2 text-sm bg-white">
+          <option value="out">Ausgang</option>
+          <option value="in">Eingang</option>
+        </select>
+        <select name="channel" class="border rounded-lg px-3 py-2 text-sm bg-white">
+          <option value="email">E-Mail</option>
+          <option value="post">Brief</option>
+        </select>
+        <input type="text" name="counterparty" placeholder="Gegenstelle, z.B. Netzbetreiber"
+          class="border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        <input type="text" name="subject" placeholder="Betreff"
+          class="border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        <input type="text" name="notes" placeholder="Notiz (optional)"
+          class="sm:col-span-2 border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-brand/30">
+        <button type="submit" class="sm:col-span-2 bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark">Eintrag hinzufügen</button>
+      </form>
+    </section>
+
     {% if is_admin %}
     <section class="bg-white rounded-xl border p-6 mb-8">
       <h2 class="font-bold mb-2">Mitglied einladen</h2>

--- a/tests/test_leg_documents.py
+++ b/tests/test_leg_documents.py
@@ -157,3 +157,150 @@ def test_dashboard_template_has_documents_section_with_disclaimer():
     assert "/documents" in html
     assert "keine Rechtsberatung" in html
     assert "leg_documents" in html
+
+
+# --- Regressions found driving the real app (RealDictCursor compat) ---
+
+
+class _DictCursor:
+    def __init__(self, one=None):
+        self.one = one
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _DictConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def test_store_leg_document_returns_id_with_dict_rows(monkeypatch):
+    # get_connection uses RealDictCursor: fetchone() returns a dict, so
+    # row[0] raised KeyError and rolled back the insert.
+    import database
+    from contextlib import contextmanager
+
+    cur = _DictCursor(one={"id": 42})
+
+    @contextmanager
+    def _conn():
+        yield _DictConnection(cur)
+
+    monkeypatch.setattr(database, "get_connection", _conn)
+    assert database.store_leg_document("c0ffee", "t", b"%PDF", "f.pdf") == 42
+
+
+def test_formation_wizard_serializes_documents_for_jsonb(monkeypatch):
+    # community_documents.documents is JSONB; psycopg2 can't adapt a raw
+    # dict, so the INSERT must receive a JSON string.
+    import json
+    import formation_wizard
+    from contextlib import contextmanager
+
+    cur = _DictCursor(
+        one={
+            "community_id": "c0ffee",
+            "name": "LEG Musterweg",
+            "members": [{"building_id": "b1", "role": "admin", "status": "confirmed"}],
+        }
+    )
+
+    @contextmanager
+    def _conn():
+        yield _DictConnection(cur)
+
+    class _Db:
+        get_connection = staticmethod(_conn)
+
+    result = formation_wizard.generate_documents(_Db, "c0ffee")
+    assert result is not None
+    insert = next((q, p) for q, p in cur.executed if "community_documents" in q)
+    documents_param = insert[1][1]
+    assert isinstance(documents_param, str)
+    assert json.loads(documents_param)["community_agreement"]
+
+
+# --- Correspondence ledger (Phase 6 MVP) ---
+
+
+def test_leg_log_correspondence_requires_membership(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    mock_log = MagicMock(return_value=1)
+    monkeypatch.setattr(dashboard_module.db, "log_correspondence", mock_log)
+
+    result = dashboard_module.leg_log_correspondence(
+        "c0ffee", "b-stranger", "out", "email", "VNB", "Anfrage", ""
+    )
+    assert result["error"]
+    mock_log.assert_not_called()
+
+
+def test_leg_log_correspondence_as_member(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    mock_log = MagicMock(return_value=1)
+    monkeypatch.setattr(dashboard_module.db, "log_correspondence", mock_log)
+
+    result = dashboard_module.leg_log_correspondence(
+        "c0ffee", "b-2", "in", "post", "Regionalwerke", "Antwort VNB", "Brief"
+    )
+    assert result["error"] is None
+    _, kwargs = mock_log.call_args
+    assert kwargs["community_id"] == "c0ffee"
+    assert kwargs["direction"] == "in"
+    assert kwargs["channel"] == "post"
+    assert kwargs["logged_by"] == "b-2"
+
+
+def test_leg_overview_includes_correspondence(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    monkeypatch.setattr(
+        dashboard_module.db, "list_leg_documents", MagicMock(return_value=[])
+    )
+    monkeypatch.setattr(
+        dashboard_module.db,
+        "list_correspondence",
+        MagicMock(return_value=[{"id": 1, "subject": "Antwort VNB"}]),
+    )
+    result = dashboard_module.leg_overview("c0ffee", "b-admin")
+    assert result["correspondence"] == [{"id": 1, "subject": "Antwort VNB"}]
+
+
+def test_correspondence_route_in_source():
+    with open(os.path.join(PROJECT_ROOT, "app.py"), encoding="utf-8") as handle:
+        source = handle.read()
+    assert '"/leg/community/<community_id>/correspondence"' in source
+
+
+def test_dashboard_template_has_correspondence_section():
+    path = os.path.join(PROJECT_ROOT, "templates", "leg_dashboard.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert "/correspondence" in html
+    assert "Korrespondenz" in html
+    assert "correspondence" in html

--- a/tests/test_leg_documents.py
+++ b/tests/test_leg_documents.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the contract builder wiring (Phase 5).
+
+dashboard.leg_generate_documents wires formation_wizard community state to
+document_generator's real PDFs, stored in leg_documents. Admin-only
+generation, member-gated download, and a "keine Rechtsberatung"
+disclaimer pinned on the dashboard.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+import dashboard as dashboard_module
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+STATUS = {
+    "community_id": "c0ffee",
+    "name": "LEG Musterweg",
+    "status": "formation_started",
+    "distribution_model": "proportional",
+    "member_count": {"total": 3, "confirmed": 3, "invited": 0},
+    "members": [
+        {
+            "building_id": "b-admin",
+            "role": "admin",
+            "status": "confirmed",
+            "email": "a@example.ch",
+            "address": "Musterweg 1",
+        },
+        {
+            "building_id": "b-2",
+            "role": "member",
+            "status": "confirmed",
+            "email": "b@example.ch",
+            "address": "Musterweg 3",
+        },
+        {
+            "building_id": "b-3",
+            "role": "member",
+            "status": "invited",
+            "email": "c@example.ch",
+            "address": "Musterweg 5",
+        },
+    ],
+    "documents": None,
+    "next_steps": [],
+}
+
+
+def _patch(monkeypatch, pv_map=None):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    pv_map = pv_map or {"b-admin": 9.5}
+    monkeypatch.setattr(
+        dashboard_module.db,
+        "get_building_for_dashboard",
+        MagicMock(side_effect=lambda bid: {"potential_pv_kwp": pv_map.get(bid, 0)}),
+    )
+    mock_agreement = MagicMock(return_value=b"%PDF-agreement")
+    mock_contract = MagicMock(return_value=b"%PDF-contract")
+    monkeypatch.setattr(
+        dashboard_module.document_generator,
+        "generate_gemeinschaftsvereinbarung",
+        mock_agreement,
+    )
+    monkeypatch.setattr(
+        dashboard_module.document_generator,
+        "generate_teilnehmervertrag",
+        mock_contract,
+    )
+    mock_store = MagicMock(return_value=7)
+    monkeypatch.setattr(dashboard_module.db, "store_leg_document", mock_store)
+    mock_wizard_docs = MagicMock(return_value={"community_agreement": {}})
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard, "generate_documents", mock_wizard_docs
+    )
+    return mock_agreement, mock_contract, mock_store, mock_wizard_docs
+
+
+def test_generate_documents_requires_admin(monkeypatch):
+    mock_agreement, _, mock_store, _ = _patch(monkeypatch)
+    result = dashboard_module.leg_generate_documents("c0ffee", "b-2")
+    assert result["error"]
+    mock_agreement.assert_not_called()
+    mock_store.assert_not_called()
+
+
+def test_generate_documents_stores_agreement_and_contracts(monkeypatch):
+    mock_agreement, mock_contract, mock_store, mock_wizard = _patch(monkeypatch)
+    result = dashboard_module.leg_generate_documents("c0ffee", "b-admin")
+    assert result["error"] is None
+    # one agreement + one contract per CONFIRMED member (2 confirmed)
+    assert mock_agreement.call_count == 1
+    assert mock_contract.call_count == 2
+    assert mock_store.call_count == 3
+    # only confirmed members appear as participants
+    _, kwargs = mock_agreement.call_args
+    participants = kwargs["participants"]
+    assert len(participants) == 2
+    # the admin building has PV -> producer role
+    roles = {p["name"]: p["role"] for p in participants}
+    assert roles["a@example.ch"] == "producer"
+    assert roles["b@example.ch"] == "consumer"
+    # wizard status transition ran
+    mock_wizard.assert_called_once()
+
+
+def test_generate_documents_surfaces_generator_error(monkeypatch):
+    mock_agreement, _, mock_store, _ = _patch(monkeypatch, pv_map={})
+    mock_agreement.side_effect = ValueError(
+        "Eine LEG benötigt mindestens einen Produzent"
+    )
+    result = dashboard_module.leg_generate_documents("c0ffee", "b-admin")
+    assert "Produzent" in result["error"]
+    mock_store.assert_not_called()
+
+
+def test_document_download_gated_on_membership(monkeypatch):
+    monkeypatch.setattr(
+        dashboard_module.formation_wizard,
+        "get_community_status",
+        MagicMock(return_value=dict(STATUS)),
+    )
+    doc = {
+        "id": 7,
+        "community_id": "c0ffee",
+        "doc_type": "gemeinschaftsvereinbarung",
+        "filename": "vereinbarung.pdf",
+        "pdf_data": b"%PDF-agreement",
+    }
+    monkeypatch.setattr(
+        dashboard_module.db, "get_leg_document", MagicMock(return_value=doc)
+    )
+    ok = dashboard_module.leg_document_for_member(7, "b-2")
+    assert ok is not None
+    assert ok["pdf_data"] == b"%PDF-agreement"
+
+    denied = dashboard_module.leg_document_for_member(7, "b-stranger")
+    assert denied is None
+
+
+def test_document_routes_in_source():
+    with open(os.path.join(PROJECT_ROOT, "app.py"), encoding="utf-8") as handle:
+        source = handle.read()
+    assert '"/leg/community/<community_id>/documents"' in source
+    assert '"/leg/document/<int:doc_id>"' in source
+
+
+def test_dashboard_template_has_documents_section_with_disclaimer():
+    path = os.path.join(PROJECT_ROOT, "templates", "leg_dashboard.html")
+    with open(path, encoding="utf-8") as handle:
+        html = handle.read()
+    assert "/documents" in html
+    assert "keine Rechtsberatung" in html
+    assert "leg_documents" in html

--- a/tests/test_store_correspondence.py
+++ b/tests/test_store_correspondence.py
@@ -1,0 +1,127 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Interface tests for the correspondence ledger repository (store.correspondence).
+
+Phase 6 MVP of docs/leg-registry.md: one shared log per community of
+outgoing and incoming mail (email and physical post), manually logged.
+No external mail provider involved. Mirrors test_store_registry.py; the
+seam is the test surface.
+"""
+
+from contextlib import contextmanager
+import subprocess
+import sys
+
+import database
+from store import correspondence
+
+
+_REEXPORTED = (
+    "log_correspondence",
+    "list_correspondence",
+)
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None, rowcount=0):
+        self.rows = rows or []
+        self.one = one
+        self.rowcount = rowcount
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def test_database_reexports_are_identical_objects():
+    for name in _REEXPORTED:
+        assert getattr(database, name) is getattr(correspondence, name), name
+
+
+def test_store_correspondence_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.correspondence; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "ok"
+
+
+def test_log_correspondence_inserts_row(monkeypatch):
+    cur = _FakeCursor(one={"id": 3})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    entry_id = correspondence.log_correspondence(
+        community_id="c0ffee",
+        direction="out",
+        channel="post",
+        counterparty="Regionalwerke Baden AG",
+        subject="LEG Anmeldung",
+        notes="Per Einschreiben versendet",
+        logged_by="b-admin",
+    )
+    assert entry_id == 3
+    query, params = cur.executed[0]
+    assert "correspondence_log" in query
+    assert "c0ffee" in params
+    assert "out" in params
+    assert "post" in params
+
+
+def test_log_correspondence_rejects_bad_direction_or_channel(monkeypatch):
+    cur = _FakeCursor(one={"id": 3})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    assert (
+        correspondence.log_correspondence(
+            "c0ffee", "sideways", "post", "X", "Y", "", "b-admin"
+        )
+        is None
+    )
+    assert (
+        correspondence.log_correspondence(
+            "c0ffee", "out", "fax", "X", "Y", "", "b-admin"
+        )
+        is None
+    )
+    assert cur.executed == []
+
+
+def test_list_correspondence_scoped_to_community(monkeypatch):
+    cur = _FakeCursor(rows=[{"id": 1, "community_id": "c0ffee"}])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    rows = correspondence.list_correspondence("c0ffee")
+    assert rows == [{"id": 1, "community_id": "c0ffee"}]
+    query, params = cur.executed[0]
+    assert "community_id = %s" in query
+    assert params[0] == "c0ffee"


### PR DESCRIPTION
## Summary

The two carve-out phases of the LEG registry roadmap (`docs/leg-registry.md`), held together for one maintainer review. **Do not merge without reviewing the generated sample PDFs and disclaimer wording.**

### Phase 5 — contract builder (closes #178)
- `dashboard.leg_generate_documents` (admin-only): confirmed members → participants (producer when the building has PV potential); real PDFs from `document_generator.py` (Gemeinschaftsvereinbarung + one Teilnehmervertrag per confirmed member) stored in `leg_documents`; status transition via `formation_wizard.generate_documents`; generator validation errors surface honestly.
- Member-gated download (`GET /leg/document/<id>?bid=`); non-members 404.
- Dashboard "Dokumente" section with "keine Rechtsberatung" disclaimer pinned by test.
- DSO-Anmeldung deliberately not generated (metering points not tracked — an incomplete legal filing would be worse than none).

### Phase 6 — correspondence ledger MVP (closes #180)
- `store/correspondence.py` + `correspondence_log` table: shared per-community journal of in/out mail (email + post), manually logged, member-gated, direction/channel validated.
- Dashboard "Korrespondenz" section with journal table + logging form.
- Build-our-own by design — no external mail provider; hybrid-mail (e.g. Swiss Post) remains a separate business decision.

### Regression fixes found by driving the real app
- `database.store_leg_document` crashed under `RealDictCursor` (`row[0]` on dict rows → insert rolled back silently).
- `formation_wizard.generate_documents` passed a raw dict to the JSONB column ("can't adapt type 'dict'").
- Both pinned by regression tests.

## Test plan

- [x] All new code TDD-first (red confirmed for every slice).
- [x] `scripts/tdd_cycle.sh gate` green: 616 passed, 11 skipped.
- [x] End-to-end against local Postgres: generated 1 Vereinbarung + 3 Verträge, member downloaded a real PDF (`application/pdf`), stranger 404'd, community status advanced to `documents_generated`; correspondence entry logged by one member visible to another.
- [x] Sample PDFs sent to the maintainer for wording review.
