### PR TITLE
W0: canonical test harness (scripts/test.sh) run on every build/deploy/debug

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,4 +43,4 @@ jobs:
       - name: Run tests
         env:
           DATABASE_URL: postgresql://openleg:testpass@localhost:5432/openleg
-        run: pytest tests/ -q
+        run: bash scripts/test.sh full

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,10 @@ python_files = ["test_*.py"]
 python_classes = ["Test*"]
 python_functions = ["test_*"]
 addopts = "-v --tb=short"
+markers = [
+    "unit: fast isolated unit test, needs no external services",
+    "integration: needs a real database or redis",
+    "smoke: drives the running application end to end",
+    "deploy: validates deployment artifacts (compose, Caddyfile, Dockerfile)",
+    "contract: pins a repository boundary or policy invariant",
+]

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# OpenLEG canonical test harness.
+#
+# One command we run on every build, deploy, and debug:
+#
+#   scripts/test.sh [fast|full|gate]
+#
+#   fast  quick inner loop for TDD: unit + contract layers, no services needed
+#   full  the whole suite (integration/smoke layers run when services exist)
+#   gate  what a pull request must pass: full pytest + ruff lint + format check
+#
+# Default mode is gate, so a bare `scripts/test.sh` is the pre-PR check.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+MODE="${1:-gate}"
+
+case "$MODE" in
+  fast)
+    pytest tests/ -q -m "not integration and not smoke"
+    ;;
+  full)
+    pytest tests/ -q
+    ;;
+  gate)
+    pytest tests/ -q
+    ruff check .
+    ruff format --check .
+    ;;
+  *)
+    echo "usage: scripts/test.sh [fast|full|gate]" >&2
+    exit 2
+    ;;
+esac

--- a/tests/test_test_harness.py
+++ b/tests/test_test_harness.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract for the canonical test harness (Program 9 W0).
+
+One command, `scripts/test.sh`, is what we run on every build, deploy, and
+debug. It has layered modes and its `gate` mode mirrors the required CI checks,
+so a green gate locally means a green PR.
+"""
+
+import stat
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEST_SH = ROOT / "scripts" / "test.sh"
+
+
+def test_harness_script_exists_and_is_executable():
+    assert TEST_SH.is_file()
+    assert TEST_SH.stat().st_mode & stat.S_IXUSR
+
+
+def test_harness_has_strict_mode_and_layered_modes():
+    content = TEST_SH.read_text(encoding="utf-8")
+    assert "set -euo pipefail" in content
+    for mode in ("fast", "full", "gate"):
+        assert mode in content
+
+
+def test_gate_mode_mirrors_required_checks():
+    # gate == what a PR must pass: full pytest + ruff lint + ruff format check.
+    content = TEST_SH.read_text(encoding="utf-8")
+    assert "pytest" in content
+    assert "ruff check" in content
+    assert "ruff format --check" in content
+
+
+def test_pytest_markers_registered():
+    pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    for marker in ("unit", "integration", "smoke", "deploy", "contract"):
+        assert marker in pyproject
+
+
+def test_ci_test_job_uses_canonical_harness():
+    deploy = (ROOT / ".github" / "workflows" / "deploy.yml").read_text(encoding="utf-8")
+    assert "scripts/test.sh" in deploy


### PR DESCRIPTION
## What

Adds `scripts/test.sh`, one command with layered modes as the single suite we run on every build, deploy, and debug:

- `fast` — quick TDD inner loop (`pytest -m "not integration and not smoke"`), no services needed
- `full` — the whole suite
- `gate` — what a PR must pass: full pytest + `ruff check` + `ruff format --check` (default mode)

Registers pytest markers (`unit`/`integration`/`smoke`/`deploy`/`contract`) and points the `ci/test` job at `scripts/test.sh full`, so a green local gate means a green PR. No new gating workflow — the exactly-three-checks contract is preserved.

## Why

First ticket of Program 9. The user asked for a comprehensive, Bun-style suite run every time we build, deploy, or debug. This becomes the gate for every later slice.

## Tests

- New `tests/test_test_harness.py` pins the harness contract (modes, strict mode, gate mirrors required checks, markers registered, CI wired).
- `tests/test_ci_contract.py` and `tests/test_deployment.py` still pass.
- Full suite: 621 passed, 11 skipped locally.

Closes #184

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_