### PR TITLE
W2: download-first /self-host landing + README inversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,15 @@ OpenLEG serves four audiences. Pick the one that matches you.
 | Municipality | `/fuer-gemeinden` | Compare solar usage, claim a free `<gemeinde>.openleg.ch` page. |
 | Developer / self-host | this repo | Read the code, use the free API, run your own instance (below). |
 
-Most users do not self-host: the hosted platform gives every municipality and
-LEG its own subdomain at no cost. Self-hosting is for teams who want full data
-sovereignty on their own infrastructure.
+Self-hosting is the sovereign default: your LEG runs OpenLEG on its own
+infrastructure and keeps control of its data. Start with one command:
+
+```bash
+curl -fsSL https://openleg.ch/install.sh | bash
+```
+
+The hosted platform remains the no-maintenance alternative for municipalities
+and LEGs that do not want to operate their own instance.
 
 ### Live examples
 
@@ -74,6 +80,7 @@ See:
 - `/rangliste` and `/gemeinde/profil/<bfs>` solar utilization ranking
 - `/fuer-gemeinden` municipality onboarding overview
 - `/open-source` codebase and self-hosting explainer
+- `/self-host` one-command sovereign self-hosting on-ramp
 - `/api/v1/docs` public API documentation
 - `/health` and `/livez` runtime health checks
 

--- a/app.py
+++ b/app.py
@@ -579,6 +579,7 @@ def sitemap_xml():
         ("/leg-kalkulator", "0.9", "weekly", current_date),
         ("/pricing", "0.7", "monthly", current_date),
         ("/open-source", "0.8", "weekly", current_date),
+        ("/self-host", "0.8", "weekly", current_date),
         ("/gemeinde/verzeichnis", "0.9", "weekly", current_date),
         ("/leg-verzeichnis", "0.9", "weekly", current_date),
         ("/leg-check", "0.9", "weekly", current_date),

--- a/self_host.py
+++ b/self_host.py
@@ -3,19 +3,24 @@
 
 Serves the one-command installer verbatim from ``scripts/install.sh`` so the
 piped-to-shell command can never drift from the audited file a cautious host
-reads first. The ``/self-host`` landing page joins this blueprint in a later
-slice.
+reads first. The blueprint also serves the sovereign self-host landing page.
 """
 
 import os
 
-from flask import Blueprint, Response
+from flask import Blueprint, Response, render_template
 
 self_host_bp = Blueprint("self_host", __name__)
 
 _INSTALLER_PATH = os.path.join(
     os.path.dirname(os.path.abspath(__file__)), "scripts", "install.sh"
 )
+
+
+@self_host_bp.route("/self-host")
+def self_host_page():
+    """Show the download-first self-host on-ramp."""
+    return render_template("self_host.html")
 
 
 @self_host_bp.route("/install.sh")

--- a/templates/leg_gruenden.html
+++ b/templates/leg_gruenden.html
@@ -469,6 +469,7 @@
         OpenLEG nimmt Ihnen nicht die Gründung ab, aber es räumt viel Kleinarbeit weg:
         Abrechnung, Dokumente, Vorlagen und ein sauberer Einstieg für neue Mitglieder.
       </p>
+      <p class="text-white/90 mb-6">Sie möchten die Plattform in Ihrer LEG betreiben? <a href="/self-host" class="font-semibold underline">OpenLEG selbst installieren</a>.</p>
       <div class="flex flex-col sm:flex-row gap-4 justify-center">
         <a href="/leg-kalkulator" class="inline-block bg-white text-brand px-8 py-3 rounded-lg font-bold hover:bg-slate-100">
           Sparpotenzial berechnen

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -104,6 +104,7 @@
 cd openleg
 cp .env.example .env
 docker compose up -d</code></pre>
+        <p class="mt-4"><a href="/self-host" class="text-brand font-semibold underline">Zum Schnellstart für den eigenen Betrieb</a></p>
       </div>
     </section>
 

--- a/templates/self_host.html
+++ b/templates/self_host.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+{% from "partials/page_meta.html" import page_meta with context %}
+
+{% block meta %}
+{{ page_meta(
+  title="Selbst betreiben | OpenLEG",
+  description="OpenLEG auf eigener Infrastruktur betreiben: souveräner Schnellstart mit einem Befehl oder manuelle Installation mit voller Kontrolle.",
+  path="/self-host",
+  og_title="OpenLEG selbst betreiben",
+  og_description="Die souveräne OpenLEG-Installation für Ihre LEG, mit einem Befehl auf eigener Hardware.",
+  site_url=site_url,
+) }}
+{% endblock %}
+
+{% block content %}
+  <main class="max-w-6xl mx-auto px-4 py-12">
+    <header class="max-w-3xl mb-10">
+      <p class="text-sm font-semibold text-brand mb-2">Selbst betreiben</p>
+      <h1 class="text-4xl font-bold mb-4">Ihre LEG, Ihre Infrastruktur, Ihre Daten.</h1>
+      <p class="text-lg text-ink-muted mb-6">OpenLEG läuft auf Ihrer eigenen Hardware. Docker und eine Zeile genügen für den Einstieg.</p>
+      <div class="bg-ink rounded-xl p-5 shadow-lg">
+        <p class="text-sm font-semibold text-slate-300 mb-3">Schnellstart</p>
+        <pre class="text-slate-100 text-sm overflow-x-auto"><code>curl -fsSL https://openleg.ch/install.sh | bash</code></pre>
+      </div>
+    </header>
+
+    <section class="grid md:grid-cols-2 gap-6 mb-10">
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-2xl font-bold mb-3">Schnellstart</h2>
+        <p class="text-ink-muted mb-4">Der Installer richtet OpenLEG mit Docker in einer Zeile ein. Ein Raspberry Pi, Mini-PC oder NAS genügt für den Anfang.</p>
+        <pre class="bg-ink text-slate-100 rounded-lg p-4 text-sm overflow-x-auto"><code>curl -fsSL https://openleg.ch/install.sh | bash</code></pre>
+        <p class="text-sm text-ink-muted mt-4">Sie können das Installationsskript vor dem Ausführen öffnen und prüfen.</p>
+      </div>
+
+      <div class="bg-white border border-slate-200 rounded-xl p-6">
+        <h2 class="text-2xl font-bold mb-3">Fortgeschritten</h2>
+        <p class="text-ink-muted mb-4">Klonen Sie das Repository und verwalten Sie Konfiguration, Updates und Betrieb selbst, wenn Sie volle Kontrolle wünschen.</p>
+        <pre class="bg-ink text-slate-100 rounded-lg p-4 text-sm overflow-x-auto"><code>git clone https://github.com/Open-LEG-ch/openleg.git
+cd openleg
+cp .env.example .env
+docker compose up -d</code></pre>
+      </div>
+    </section>
+
+    <section class="bg-brand/5 border border-brand/20 rounded-xl p-6 mb-10">
+      <h2 class="text-2xl font-bold mb-3">Die souveräne Wahl</h2>
+      <p class="text-ink-muted">Ihre LEG betreibt die Box, und Ihre Daten bleiben in der LEG. Dafür übernimmt Ihr Team Updates, Backups und die Verfügbarkeit. Wenn Sie keine Wartung übernehmen möchten, nutzen Sie die <a href="/" class="text-brand font-semibold underline">gehostete Plattform</a> als Alternative ohne eigenen Betriebsaufwand.</p>
+    </section>
+
+    <section class="text-center">
+      <h2 class="text-2xl font-bold mb-3">Offen und nachvollziehbar</h2>
+      <p class="text-ink-muted mb-5">Prüfen Sie den Code, passen Sie Ihre Installation an und behalten Sie die Kontrolle über den Betrieb.</p>
+      <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="inline-block border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white">Quellcode auf GitHub</a>
+    </section>
+  </main>
+{% endblock %}

--- a/tests/test_self_host_page.py
+++ b/tests/test_self_host_page.py
@@ -1,0 +1,70 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for the download-first self-host landing (Program 9 W2).
+
+The page inverts the on-ramp: self-host is the sovereign default, hosted is the
+fallback. It leads with the one command, keeps the manual (Advanced) path, and
+holds the Schweizer Hochdeutsch rules and the honesty framing.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES = ROOT / "templates"
+SELF_HOST_TEMPLATE = TEMPLATES / "self_host.html"
+
+ONE_COMMAND = "curl -fsSL https://openleg.ch/install.sh | bash"
+
+
+def _client():
+    from flask import Flask
+
+    import self_host
+
+    app = Flask(__name__, template_folder=str(TEMPLATES))
+    app.register_blueprint(self_host.self_host_bp)
+    return app.test_client()
+
+
+class TestSelfHostPage:
+    def test_route_ok(self):
+        assert _client().get("/self-host").status_code == 200
+
+    def test_leads_with_one_command(self):
+        html = _client().get("/self-host").data.decode("utf-8")
+        assert ONE_COMMAND in html
+
+    def test_quickstart_and_advanced_both_present(self):
+        html = _client().get("/self-host").data.decode("utf-8")
+        assert "Schnellstart" in html
+        assert "Fortgeschritten" in html
+
+    def test_sovereign_default_and_honesty(self):
+        html = _client().get("/self-host").data.decode("utf-8")
+        assert "Ihre Daten" in html or "Datenhoheit" in html
+
+    def test_swiss_hochdeutsch_rules(self):
+        html = SELF_HOST_TEMPLATE.read_text(encoding="utf-8")
+        assert "ß" not in html
+        assert "—" not in html  # em dash
+        assert "–" not in html  # en dash
+
+    def test_uses_shared_base(self):
+        html = SELF_HOST_TEMPLATE.read_text(encoding="utf-8")
+        assert 'extends "base.html"' in html
+
+
+def test_sitemap_includes_self_host():
+    source = (ROOT / "app.py").read_text(encoding="utf-8")
+    assert '"/self-host"' in source
+
+
+def test_funnel_links_to_self_host():
+    for name in ("open_source.html", "leg_gruenden.html"):
+        html = (TEMPLATES / name).read_text(encoding="utf-8")
+        assert "/self-host" in html
+
+
+def test_readme_reframes_self_host_as_default():
+    readme = (ROOT / "README.md").read_text(encoding="utf-8")
+    assert "most users do not self-host" not in readme.lower()
+    assert "install.sh" in readme


### PR DESCRIPTION
## What

Inverts the self-host on-ramp into the sovereign default (openclaw.ai-style, download-first).

- **`templates/self_host.html`** + **`/self-host`** route: leads with the one command, splits **Schnellstart** (the one line, "runs on a Raspberry Pi / mini-PC / NAS") vs **Fortgeschritten** (the manual `git clone` path, preserved), and states the honest tradeoff — your LEG runs the box and your data stays in the LEG, in exchange your team owns updates/backups/availability; the hosted platform is the no-maintenance alternative. No grid-topology eligibility claims.
- **README** reframed from "most users do not self-host" to the sovereign default with the one-command on-ramp.
- Funnel links from `/open-source` and `/leg-gruenden`; `/self-host` added to the sitemap.
- Schweizer Hochdeutsch throughout (real umlauts, ss, no em/en dash).

## Tests

- `tests/test_self_host_page.py` pins the route, the one command, both paths, the honesty/sovereign framing, the Swiss-Hochdeutsch char rules, the sitemap entry, funnel links, and the README reframing.
- Full local gate: 643 passed, 11 skipped, ruff clean.

Closes #188

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_