### PR TITLE
W5: registry federation publish API + box client

### DIFF
--- a/federation.py
+++ b/federation.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""A self-hosted OpenLEG box publishes its LEG to a central registry."""
+
+import time
+
+import requests
+
+
+def publish_leg(base_url: str, entry: dict, timeout: int = 10) -> dict:
+    url = base_url.rstrip("/") + "/api/registry/publish"
+    for attempt in range(3):
+        try:
+            response = requests.post(url, json=entry, timeout=timeout)
+            response.raise_for_status()
+            return response.json()
+        except (requests.exceptions.ConnectionError, requests.exceptions.Timeout):
+            if attempt == 2:
+                raise
+            time.sleep(0.1 * (attempt + 1))
+
+    raise RuntimeError("unreachable")

--- a/leg_registry.py
+++ b/leg_registry.py
@@ -10,7 +10,7 @@ import logging
 import re
 import secrets
 
-from flask import Blueprint, abort, render_template, request
+from flask import Blueprint, abort, jsonify, render_template, request
 
 import database as db
 import email_utils
@@ -175,6 +175,58 @@ def eintragen():
         form=None,
         submitted=True,
     )
+
+
+@registry_bp.route("/api/registry/publish", methods=["POST"])
+def api_registry_publish():
+    data = request.get_json(silent=True) or {}
+    name = (data.get("name") or "").strip()
+    contact_email = (data.get("contact_email") or "").strip()
+
+    if not name or not contact_email:
+        return jsonify({"error": "name und contact_email erforderlich."}), 400
+
+    is_valid, normalized_email, email_error = security_utils.validate_email_address(
+        contact_email
+    )
+    if not is_valid:
+        return jsonify({"error": email_error}), 400
+
+    leg_status = (data.get("leg_status") or "planung").strip()
+    if leg_status not in {code for code, _ in LEG_STATUS_OPTIONS if code}:
+        leg_status = "planung"
+
+    member_count_estimate = None
+    try:
+        member_count = int(data["member_count_estimate"])
+        if member_count > 0:
+            member_count_estimate = member_count
+    except (KeyError, TypeError, ValueError):
+        pass
+
+    kanton = (data.get("kanton") or "").strip().upper()
+    slug = _unique_slug(name)
+    saved = db.save_registry_entry(
+        slug=slug,
+        name=name,
+        contact_email=normalized_email,
+        kanton=kanton,
+        plz=(data.get("plz") or "").strip(),
+        ort=(data.get("ort") or "").strip(),
+        vnb_name=(data.get("vnb_name") or "").strip(),
+        member_count_estimate=member_count_estimate,
+        leg_status=leg_status,
+        description=(data.get("description") or "").strip(),
+        website_url=(data.get("website_url") or "").strip(),
+        source="self_hosted",
+    )
+    if not saved:
+        return jsonify({"error": "Eintrag konnte nicht gespeichert werden."}), 500
+
+    db.track_event(
+        "registry_entry_published", data={"slug": slug, "source": "self_hosted"}
+    )
+    return jsonify({"slug": slug, "moderation_status": "pending"}), 201
 
 
 def _eintragen_error(message, form, status):

--- a/tests/test_registry_federation.py
+++ b/tests/test_registry_federation.py
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Registry federation (Program 9 W5): self-hosted boxes feed the public registry.
+
+A self-hosted OpenLEG instance publishes its LEG to the central registry over a
+JSON API. Entries land as source="self_hosted" and stay moderation pending, the
+same human-moderated, honesty-bounded path as a web submission. This is the
+loop the incumbent cannot run: self-host distribution -> public registry -> SEO.
+"""
+
+import os
+from unittest.mock import MagicMock
+
+from flask import Flask
+
+import leg_registry as leg_registry_module
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+VALID = {
+    "name": "LEG Sonnenhof",
+    "contact_email": "kontakt@sonnenhof.example.ch",
+    "kanton": "zh",
+    "plz": "8000",
+    "ort": "Zürich",
+    "leg_status": "aktiv",
+    "vnb_name": "EKZ",
+}
+
+
+def _client(monkeypatch, saved=1):
+    monkeypatch.setattr(
+        leg_registry_module, "_unique_slug", lambda name: "leg-sonnenhof"
+    )
+    save = MagicMock(return_value=saved)
+    monkeypatch.setattr(leg_registry_module.db, "save_registry_entry", save)
+    monkeypatch.setattr(leg_registry_module.db, "track_event", MagicMock())
+    app = Flask(__name__)
+    app.register_blueprint(leg_registry_module.registry_bp)
+    return app.test_client(), save
+
+
+class TestPublishEndpoint:
+    def test_creates_pending_self_hosted_entry(self, monkeypatch):
+        client, save = _client(monkeypatch)
+        resp = client.post("/api/registry/publish", json=VALID)
+        assert resp.status_code == 201
+        body = resp.get_json()
+        assert body["slug"] == "leg-sonnenhof"
+        assert body["moderation_status"] == "pending"
+        _, kwargs = save.call_args
+        assert kwargs["source"] == "self_hosted"
+        assert kwargs["name"] == "LEG Sonnenhof"
+
+    def test_requires_name_and_email(self, monkeypatch):
+        client, save = _client(monkeypatch)
+        resp = client.post("/api/registry/publish", json={"name": "Nur Name"})
+        assert resp.status_code == 400
+        save.assert_not_called()
+
+    def test_rejects_invalid_email(self, monkeypatch):
+        client, save = _client(monkeypatch)
+        bad = dict(VALID, contact_email="not-an-email")
+        resp = client.post("/api/registry/publish", json=bad)
+        assert resp.status_code == 400
+        save.assert_not_called()
+
+
+class TestBoxClient:
+    def test_publish_leg_posts_to_central(self, monkeypatch):
+        import federation
+
+        captured = {}
+
+        class _Resp:
+            def raise_for_status(self):
+                return None
+
+            def json(self):
+                return {"slug": "leg-sonnenhof", "moderation_status": "pending"}
+
+        def fake_post(url, json=None, timeout=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+        monkeypatch.setattr(federation.requests, "post", fake_post)
+        result = federation.publish_leg("https://openleg.ch", VALID)
+        assert captured["url"] == "https://openleg.ch/api/registry/publish"
+        assert captured["json"] == VALID
+        assert result["moderation_status"] == "pending"
+
+
+def test_publish_route_in_source():
+    with open(
+        os.path.join(PROJECT_ROOT, "leg_registry.py"), encoding="utf-8"
+    ) as handle:
+        assert '"/api/registry/publish"' in handle.read()


### PR DESCRIPTION
## What

The federation flywheel: self-hosted instances feed the public registry, an SEO loop the utility-gated incumbent structurally cannot run.

- **`POST /api/registry/publish`** — a self-hosted box announces its LEG to the central registry over JSON. It mirrors the web submission's validation and lands the entry as `source="self_hosted"`, `moderation_status="pending"` — same human-moderated, honesty-bounded path, no auto-publish, no eligibility claims.
- **`federation.publish_leg`** — the box-side client (POST + `raise_for_status`), with a small retry on connection/timeout errors.

## Tests

- `tests/test_registry_federation.py`: endpoint creates a pending `self_hosted` entry, rejects missing name/email and invalid email, and the box client posts to the right URL and returns the parsed result.
- Full local gate: 661 passed, 11 skipped, ruff clean.

## Follow-ups (noted, not in this slice)

- A consent-gated "publish my LEG" action in the box UI.
- Populating the same-instance `leg_registry.community_id` link for `openleg_formed` entries (the FK is currently declared but unused).

Closes #194

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_