### PR TITLE
W7: honest distribution ladder + revenue model on /pricing

### DIFF
--- a/templates/pricing.html
+++ b/templates/pricing.html
@@ -108,6 +108,42 @@
       </div>
     </div>
 
+    <div class="mt-12 bg-white rounded-xl border border-slate-200 p-6">
+      <h2 class="text-2xl font-bold mb-2">Wie Sie OpenLEG betreiben</h2>
+      <p class="text-sm text-ink-muted mb-6">Von voller Datenhoheit bis ohne eigenen Aufwand. Dieselbe Open-Source-Software läuft auf jeder Stufe, und Sie wechseln jederzeit. Wir verkaufen Komfort, Hardware und Betrieb, niemals Ihre Daten.</p>
+      <div class="grid md:grid-cols-2 gap-4">
+        <div class="border border-slate-200 rounded-lg p-5">
+          <div class="flex items-center justify-between mb-1">
+            <h3 class="font-bold">Selbst betreiben</h3>
+            <span class="text-xs font-semibold text-green-700">Verfügbar</span>
+          </div>
+          <p class="text-sm text-ink-muted mb-3">Auf eigener Hardware, ein Befehl. Ihre LEG besitzt Box und Daten. Kostenlos und offen.</p>
+          <a href="/self-host" class="text-brand font-semibold text-sm underline">Zum Schnellstart</a>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-5">
+          <div class="flex items-center justify-between mb-1">
+            <h3 class="font-bold">Gehostet auf openleg.ch</h3>
+            <span class="text-xs font-semibold text-green-700">Verfügbar</span>
+          </div>
+          <p class="text-sm text-ink-muted">Ohne eigenen Betrieb, wir übernehmen Wartung und Verfügbarkeit. Kostenlos für Bewohner und Gemeinden.</p>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-5">
+          <div class="flex items-center justify-between mb-1">
+            <h3 class="font-bold">OpenLEG-Box oder Schweizer VPS in Ihrer Nähe</h3>
+            <span class="text-xs font-semibold text-slate-500">In Vorbereitung</span>
+          </div>
+          <p class="text-sm text-ink-muted">Vorkonfigurierte Hardware bei Ihnen im Quartier oder ein Server in der Schweiz, nahe an Ihrer Nachbarschaft. Auf Anfrage.</p>
+        </div>
+        <div class="border border-slate-200 rounded-lg p-5">
+          <div class="flex items-center justify-between mb-1">
+            <h3 class="font-bold">OpenLEG-Netzwerk</h3>
+            <span class="text-xs font-semibold text-slate-500">In Vorbereitung</span>
+          </div>
+          <p class="text-sm text-ink-muted">Ein privates Netzwerk, damit Nachbarn die Box ohne offene Ports erreichen. Selbst gehostet oder als Abo, für berechtigte LEG gesponsert. Der Koordinator sieht Verbindungsdaten, nie Ihre Messdaten.</p>
+        </div>
+      </div>
+    </div>
+
     <div class="mt-8 text-center">
       <p class="text-ink-muted mb-4">Fragen zu Betrieb, Finanzierung oder Self-Hosting?</p>
       <div class="flex flex-col sm:flex-row gap-3 justify-center">

--- a/tests/test_distribution_ladder.py
+++ b/tests/test_distribution_ladder.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Distribution ladder + honest revenue model on /pricing (Program 9 W7).
+
+Presents the ways to run OpenLEG from DIY self-host to managed options, and
+states the revenue model honestly: sell convenience, hardware and operation,
+never citizen data. Managed offerings that do not exist yet are marked as
+planned, not advertised as purchasable today.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PRICING = ROOT / "templates" / "pricing.html"
+
+
+def _html():
+    return PRICING.read_text(encoding="utf-8")
+
+
+def test_shows_run_options_ladder():
+    html = _html()
+    assert "Selbst betreiben" in html
+    assert "Gehostet" in html
+    assert "OpenLEG-Box" in html
+    assert "OpenLEG-Netzwerk" in html
+
+
+def test_managed_options_marked_as_planned():
+    # Honesty: do not advertise a box / VPS / network you can buy today.
+    html = _html().lower()
+    assert "vorbereitung" in html or "anfrage" in html
+
+
+def test_revenue_model_never_sells_data():
+    html = _html()
+    assert "niemals" in html or "kein Datenverkauf" in html
+    assert "Komfort" in html or "Hardware" in html
+
+
+def test_links_to_self_host():
+    assert "/self-host" in _html()
+
+
+def test_swiss_hochdeutsch_rules():
+    html = _html()
+    assert "ß" not in html
+    assert "—" not in html  # em dash
+    assert "–" not in html  # en dash
+
+
+def test_keeps_free_positioning():
+    # An existing route test asserts the page still contains "Kostenlos".
+    assert "Kostenlos" in _html()


### PR DESCRIPTION
## What

A "Wie Sie OpenLEG betreiben" section on `/pricing` presenting the sovereignty ladder and the revenue model, honestly:

- **Selbst betreiben** (Verfügbar, CHF 0) → links to `/self-host`
- **Gehostet auf openleg.ch** (Verfügbar, CHF 0)
- **OpenLEG-Box oder Schweizer VPS in Ihrer Nähe** (In Vorbereitung)
- **OpenLEG-Netzwerk** — private network, self-hosted or subscription/sponsored (In Vorbereitung)

The revenue model is stated plainly: sell convenience, hardware, and operation, **never citizen data**. The same open-source software runs on every rung and a LEG can move down to full self-host any time.

## Honesty

Managed offerings that don't exist yet are badged **In Vorbereitung**, not advertised as purchasable today. The hosted private network explicitly states it sees connection metadata but never meter data. No grid-topology eligibility claims. Schweizer Hochdeutsch throughout.

## Tests

- `tests/test_distribution_ladder.py`: the ladder rungs, the planned-marker on managed tiers, the never-sell-data revenue statement, the `/self-host` link, the Swiss-Hochdeutsch char rules, and that the free positioning is preserved.
- Full local gate: 667 passed, 11 skipped, ruff clean.

Closes #196

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_