### PR TITLE
W8 Tier A: OpenLEG private network (compose profile + operator CLI + docs)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,5 +162,8 @@ openclaw/config/openclaw.json
 openclaw/config/cron/
 openclaw/config/workspace/
 
+# Local private-network (Headscale) runtime config
+headscale/config.yaml
+
 # Throwaway logo exploration
 logo-explore/

--- a/docker-compose.net.yml
+++ b/docker-compose.net.yml
@@ -1,0 +1,29 @@
+# OpenLEG private network, Tier A (self-hosted, open).
+#
+# An optional Headscale control server (the open, self-hostable Tailscale control
+# plane) on an audited WireGuard data plane. LEG members join with a one-time code
+# and reach the box over the private network with no ports opened on the home
+# router. Nothing OpenLEG operates is in the loop.
+#
+# Copy headscale/config.example.yaml to headscale/config.yaml, set server_url to an
+# endpoint your members can reach, then start with:
+#   docker compose -f docker-compose.yml -f docker-compose.net.yml --profile net up -d
+# or:  scripts/openleg net up
+services:
+  headscale:
+    image: headscale/headscale:0.23.0
+    container_name: openleg-headscale
+    profiles: ["net"]
+    restart: unless-stopped
+    command: serve
+    volumes:
+      - headscale_data:/var/lib/headscale
+      - ./headscale/config.yaml:/etc/headscale/config.yaml:ro
+    networks:
+      - web
+
+volumes:
+  headscale_data:
+
+networks:
+  web:

--- a/docs/private-network.md
+++ b/docs/private-network.md
@@ -1,0 +1,56 @@
+# The OpenLEG private network (Tier A, self-hosted)
+
+How LEG members reach a self-hosted OpenLEG box from their own homes without the host
+opening any ports on the home router, and without any OpenLEG-operated service in the loop.
+
+## What it is
+
+An optional Headscale control server (the open, self-hostable Tailscale control plane) on an
+audited WireGuard data plane. The host runs it as a compose profile on the same box:
+
+    scripts/openleg net up
+
+Members install the standard Tailscale/WireGuard client and join with a one-time code the
+host mints:
+
+    scripts/openleg net invite      # prints a join code (a preauth key, valid 24h)
+    scripts/openleg net status      # lists joined members
+
+The data plane is WireGuard, encrypted peer to peer. Members reach the box over the private
+network; nothing is exposed to the public internet.
+
+## Why this shape
+
+We own the control plane and the enrolment experience, but we do not invent a VPN protocol
+or write transport crypto. Building a novel secure transport (key exchange, NAT traversal, a
+relay for CGNAT, rekeying, replay protection) is a multi-year, security-critical effort where
+any bug is a citizen-data breach. WireGuard plus a self-hosted control server gives the same
+"data stays in the LEG, no open ports" outcome with a decade of audited crypto. Full
+reasoning: `docs/self-host-appliance.md`.
+
+## Honesty invariants
+
+- **No open ports.** WireGuard is outbound UDP; the home router needs no port forwarding for
+  members to reach the box.
+- **Reachability caveat.** The self-hosted coordinator itself must be reachable by the members
+  joining it: run it on a small VPS, or on a home box whose coordinator endpoint is reachable.
+  Homes behind carrier-grade NAT cannot expose a coordinator; those LEGs need the
+  OpenLEG-operated network (Tier B), which is not part of this self-hosted profile.
+- **Metadata, not payloads.** A coordinator (self-hosted here, or OpenLEG-operated in Tier B)
+  handles key distribution and NAT coordination. It sees connection metadata (which member
+  joined, when) but never the peer-to-peer-encrypted smart-meter payloads.
+
+## Tiers
+
+- **Tier A (this doc):** fully self-hosted, open, no OpenLEG service in the loop.
+- **Tier B (not built here):** an OpenLEG-operated coordinator and relay as a subscription or
+  grant-sponsored service, for LEGs that will not run their own. A business decision that
+  lives partly in `openleg-ops`.
+
+## Setup
+
+1. `cp headscale/config.example.yaml headscale/config.yaml` and set `server_url` to an
+   endpoint your members can reach.
+2. `scripts/openleg net up`
+3. Create the Headscale user once (`headscale users create openleg`), then
+   `scripts/openleg net invite` to mint join codes for your neighbours.

--- a/headscale/config.example.yaml
+++ b/headscale/config.example.yaml
@@ -1,0 +1,37 @@
+# Example Headscale config for the OpenLEG private network (Tier A, self-hosted).
+#
+# Copy this file to headscale/config.yaml (gitignored) and set server_url to a URL
+# your LEG members can reach:
+#   - a small VPS hostname, or
+#   - your home box's port-forwarded HTTPS endpoint.
+# A self-hosted coordinator must be reachable by the members joining it. Homes behind
+# carrier-grade NAT cannot expose one; those LEGs need the OpenLEG-operated network
+# (Tier B), which is not part of this self-hosted profile.
+#
+# Full reference: https://headscale.net/stable/ref/configuration/
+
+server_url: https://leg.example.ch:8080
+listen_addr: 0.0.0.0:8080
+metrics_listen_addr: 127.0.0.1:9090
+
+private_key_path: /var/lib/headscale/private.key
+noise:
+  private_key_path: /var/lib/headscale/noise_private.key
+
+# WireGuard address ranges handed to members.
+prefixes:
+  v4: 100.64.0.0/10
+  v6: fd7a:115c:a1e0::/48
+
+database:
+  type: sqlite
+  sqlite:
+    path: /var/lib/headscale/db.sqlite
+
+# Keep DNS simple for a small LEG network.
+dns:
+  magic_dns: false
+  base_domain: leg.internal
+
+log:
+  level: info

--- a/scripts/openleg
+++ b/scripts/openleg
@@ -33,8 +33,29 @@ case "${1:-}" in
   stop)
     $COMPOSE stop
     ;;
+  net)
+    # OpenLEG private network (Tier A, self-hosted Headscale). Members join over
+    # WireGuard with a one-time code and reach the box with no ports opened.
+    COMPOSE_NET="docker compose -f docker-compose.yml -f docker-compose.net.yml"
+    case "${2:-}" in
+      up)
+        $COMPOSE_NET --profile net up -d headscale
+        ;;
+      invite)
+        # Mint a one-time join code (a preauth key), valid 24h.
+        $COMPOSE_NET exec headscale headscale preauthkeys create --user openleg --expiration 24h
+        ;;
+      status)
+        $COMPOSE_NET exec headscale headscale nodes list
+        ;;
+      *)
+        echo "Usage: scripts/openleg net {up|invite|status}" >&2
+        exit 2
+        ;;
+    esac
+    ;;
   *)
-    echo "Usage: scripts/openleg {status|logs|update|backup|restore|stop}" >&2
+    echo "Usage: scripts/openleg {status|logs|update|backup|restore|stop|net}" >&2
     exit 2
     ;;
 esac

--- a/templates/self_host.html
+++ b/templates/self_host.html
@@ -47,6 +47,12 @@ docker compose up -d</code></pre>
       <p class="text-ink-muted">Ihre LEG betreibt die Box, und Ihre Daten bleiben in der LEG. Dafür übernimmt Ihr Team Updates, Backups und die Verfügbarkeit. Wenn Sie keine Wartung übernehmen möchten, nutzen Sie die <a href="/" class="text-brand font-semibold underline">gehostete Plattform</a> als Alternative ohne eigenen Betriebsaufwand.</p>
     </section>
 
+    <section class="bg-white border border-slate-200 rounded-xl p-6 mb-10">
+      <h2 class="text-2xl font-bold mb-3">Privates Netzwerk für Ihre Nachbarn</h2>
+      <p class="text-ink-muted mb-3">Ihre Mitglieder erreichen die Box von zu Hause über ein privates Netzwerk, ganz ohne offene Ports am Router. Es baut auf WireGuard und einem selbst gehosteten Headscale-Server auf. Nachbarn treten mit einem einmaligen Code bei.</p>
+      <p class="text-sm text-ink-muted">Der Koordinator sieht Verbindungsdaten, nie Ihre Messdaten. <a href="https://github.com/Open-LEG-ch/openleg/blob/main/docs/private-network.md" class="text-brand font-semibold underline">Anleitung zum privaten Netzwerk</a>.</p>
+    </section>
+
     <section class="text-center">
       <h2 class="text-2xl font-bold mb-3">Offen und nachvollziehbar</h2>
       <p class="text-ink-muted mb-5">Prüfen Sie den Code, passen Sie Ihre Installation an und behalten Sie die Kontrolle über den Betrieb.</p>

--- a/tests/test_private_network.py
+++ b/tests/test_private_network.py
@@ -1,0 +1,37 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""OpenLEG private network, Tier A (Program 9 W8): self-hosted WireGuard control plane.
+
+An optional Headscale control server lets LEG members reach the box over a private
+WireGuard network with no ports opened on the home router. It ships as a compose
+profile so the base 4-service stack is unchanged and only starts on request.
+"""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load(name):
+    with open(ROOT / name) as handle:
+        return yaml.safe_load(handle)
+
+
+def test_net_override_defines_headscale_behind_profile():
+    hs = _load("docker-compose.net.yml")["services"]["headscale"]
+    assert "net" in hs["profiles"]  # optional; not started by default
+    assert "headscale" in hs["image"]
+    assert ":" in hs["image"]  # version-pinned, not :latest floating
+    assert "latest" not in hs["image"]
+    assert "web" in hs["networks"]
+
+
+def test_base_compose_stays_four_services():
+    base = _load("docker-compose.yml")
+    assert len(base["services"]) == 4
+    assert "headscale" not in base["services"]
+
+
+def test_headscale_config_example_present():
+    assert (ROOT / "headscale" / "config.example.yaml").is_file()

--- a/tests/test_private_network.py
+++ b/tests/test_private_network.py
@@ -37,6 +37,20 @@ def test_headscale_config_example_present():
     assert (ROOT / "headscale" / "config.example.yaml").is_file()
 
 
+def test_private_network_doc_present_and_honest():
+    doc = (ROOT / "docs" / "private-network.md").read_text(encoding="utf-8")
+    assert "WireGuard" in doc
+    assert "Headscale" in doc
+    for honesty in ("no open ports", "metadata", "carrier-grade nat"):
+        assert honesty in doc.lower()
+
+
+def test_self_host_page_links_private_network():
+    html = (ROOT / "templates" / "self_host.html").read_text(encoding="utf-8")
+    assert "private-network.md" in html
+    assert "Netzwerk" in html
+
+
 def test_operator_cli_has_net_subcommand():
     cli = (ROOT / "scripts" / "openleg").read_text(encoding="utf-8")
     # net dispatch present and uses the net compose override, not the base stack

--- a/tests/test_private_network.py
+++ b/tests/test_private_network.py
@@ -35,3 +35,15 @@ def test_base_compose_stays_four_services():
 
 def test_headscale_config_example_present():
     assert (ROOT / "headscale" / "config.example.yaml").is_file()
+
+
+def test_operator_cli_has_net_subcommand():
+    cli = (ROOT / "scripts" / "openleg").read_text(encoding="utf-8")
+    # net dispatch present and uses the net compose override, not the base stack
+    assert "net)" in cli
+    assert "docker-compose.net.yml" in cli
+    # net up starts only the profile; invite mints a one-time preauth key;
+    # status lists the joined nodes
+    assert "--profile net" in cli
+    assert "preauthkeys" in cli
+    assert "nodes" in cli


### PR DESCRIPTION
## What

W8 **Tier A** of the OpenLEG private network — fully self-hosted, open, no OpenLEG-operated service in the loop. You approved building Tier A now; **Tier B** (OpenLEG-operated subscription/sponsored) stays held for a business decision. Three thin commits:

- **W8a — `docker-compose.net.yml`**: an optional **Headscale** control server (the open, self-hostable Tailscale control plane, on an audited WireGuard data plane) behind a compose **`profiles: [net]`**, so the base 4-service stack is untouched and the network only starts on request. `headscale/config.example.yaml` ships as the template (host copies to a gitignored `config.yaml`).
- **W8b — `scripts/openleg net`**: `net up` starts only the profile, `net invite` mints a one-time join code (a preauth key, valid 24h), `net status` lists joined members.
- **W8c — `docs/private-network.md` + `/self-host` link**: documents no-open-ports, the WireGuard data plane, one-time-code enrolment, and the honesty invariants.

## Honesty invariants (documented, not hidden)

- **No open ports** — WireGuard is outbound UDP; the home router needs no port forwarding.
- **Reachability caveat** — a self-hosted coordinator must itself be reachable by joining members (a small VPS, or a reachable home endpoint); carrier-grade-NAT-only homes need Tier B's relay, which is not built here.
- **Metadata, not payloads** — the coordinator sees connection metadata, never the peer-to-peer-encrypted meter payloads.

## Design

Per `docs/self-host-appliance.md`: own the control plane + enrolment UX on an audited WireGuard data plane; do not invent a protocol.

## Tests

- `tests/test_private_network.py`: headscale behind the `net` profile + image pinned + base compose still 4 services + config example; the `net` CLI subcommands; the doc's honesty strings; the `/self-host` link.
- Full local gate: 673 passed, 11 skipped, ruff clean.

Closes #198