### PR TITLE
W9: surface the one-line installer + refresh self-host copy

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -394,6 +394,7 @@
           <p class="text-ink-muted mt-3">OpenLEG ist freie Software. Der gesamte Code ist öffentlich einsehbar, jede Gemeinde kann die Plattform selbst betreiben, und niemand kontrolliert Ihre Energiedaten.</p>
           <ul class="mt-4 space-y-2 text-ink-muted list-disc list-inside">
             <li>Gesamter Code auf GitHub, AGPL-3.0 Lizenz</li>
+            <li>In einer Zeile selbst installieren, auf einem Raspberry Pi oder Mini-PC</li>
             <li>Freie API für Schweizer Energiedaten (ElCom Tarife, Sonnendach, Energie Reporter)</li>
             <li>Keine Anbieterbindung: jederzeit selbst hosten oder migrieren</li>
             <li>Community-Beiträge willkommen</li>
@@ -404,6 +405,12 @@
           </div>
         </div>
         <div class="space-y-4">
+          <div class="rounded-xl border border-slate-200 bg-ink p-5">
+            <div class="font-semibold text-white">In einer Zeile selbst betreiben</div>
+            <p class="text-sm text-slate-300 mt-1 mb-3">Auf einem Raspberry Pi, Mini-PC oder NAS. Ihre LEG besitzt Box und Daten.</p>
+            <pre class="text-slate-100 text-sm overflow-x-auto"><code>curl -fsSL https://openleg.ch/install.sh | bash</code></pre>
+            <a href="/self-host" class="inline-block mt-3 text-sm text-white font-semibold underline">Zum Schnellstart</a>
+          </div>
           <div class="rounded-xl border border-slate-200 bg-[#f6f4ef] p-5">
             <div class="font-semibold">Freie Energiedaten API</div>
             <p class="text-sm text-ink-muted mt-1">ElCom Tarife, Solarpotenzial und Gemeinde-Profile aus öffentlichen Datenquellen. Kein API-Key nötig.</p>

--- a/templates/open_source.html
+++ b/templates/open_source.html
@@ -36,7 +36,8 @@
       <h1 class="text-4xl font-bold mb-4">Freie Energieinfrastruktur, die man prüfen und selbst betreiben kann.</h1>
       <p class="text-lg text-ink-muted">OpenLEG ist das öffentliche App-Repo für Schweizer Lokale Elektrizitätsgemeinschaften. Der Code ist offen, die Datenquellen sind nachvollziehbar, und produktive Secrets bleiben ausserhalb des öffentlichen Repos.</p>
       <div class="mt-6 flex flex-col sm:flex-row gap-3">
-        <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">GitHub öffnen</a>
+        <a href="/self-host" class="bg-brand text-white px-6 py-3 rounded-lg font-semibold hover:bg-brand-dark text-center">Selbst betreiben</a>
+        <a href="https://github.com/Open-LEG-ch/openleg" target="_blank" rel="noopener" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">GitHub öffnen</a>
         <a href="/api/v1/docs" class="border border-ink/20 text-ink px-6 py-3 rounded-lg font-semibold hover:bg-white text-center">API ansehen</a>
       </div>
     </header>
@@ -99,12 +100,15 @@
       </div>
       <div class="bg-white border border-slate-200 rounded-xl p-6">
         <h2 class="text-xl font-bold mb-3">Selbst betreiben</h2>
-        <p class="text-ink-muted mb-4">Die lokale Entwicklung braucht Python, Docker und eine `.env` aus der öffentlichen Vorlage.</p>
+        <p class="text-ink-muted mb-3">Ein Befehl auf Ihrer eigenen Hardware. Docker genügt, ein Raspberry Pi reicht für den Anfang.</p>
+        <pre class="bg-ink text-slate-100 rounded-lg p-4 text-sm overflow-x-auto"><code>curl -fsSL https://openleg.ch/install.sh | bash</code></pre>
+        <p class="text-ink-muted mt-4 text-sm">Danach verwalten Sie die Box mit einem Befehl, importieren Ihre Messdaten lokal und verbinden Nachbarn über ein privates Netzwerk ohne offene Ports.</p>
+        <p class="text-ink-muted mt-4 mb-2 text-sm font-semibold">Oder manuell aus dem Quellcode:</p>
         <pre class="bg-ink text-slate-300 rounded-lg p-4 text-sm overflow-x-auto"><code>git clone https://github.com/Open-LEG-ch/openleg.git
 cd openleg
 cp .env.example .env
 docker compose up -d</code></pre>
-        <p class="mt-4"><a href="/self-host" class="text-brand font-semibold underline">Zum Schnellstart für den eigenen Betrieb</a></p>
+        <p class="mt-3"><a href="/self-host" class="text-brand font-semibold underline">Schnellstart, manuelle Installation und privates Netzwerk</a></p>
       </div>
     </section>
 

--- a/tests/test_install_surfacing.py
+++ b/tests/test_install_surfacing.py
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Website copy reflects the shipped self-host appliance (Program 9 W9).
+
+The one-line installer is surfaced on the homepage and the open-source page, both
+point to /self-host, and the updated pages stay in Schweizer Hochdeutsch.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+TEMPLATES = ROOT / "templates"
+ONE_COMMAND = "curl -fsSL https://openleg.ch/install.sh | bash"
+
+
+def _html(name):
+    return (TEMPLATES / name).read_text(encoding="utf-8")
+
+
+def test_homepage_surfaces_one_line_installer():
+    html = _html("index.html")
+    assert ONE_COMMAND in html
+    assert "/self-host" in html
+
+
+def test_open_source_leads_with_one_line_installer():
+    html = _html("open_source.html")
+    assert ONE_COMMAND in html
+    assert "/self-host" in html
+
+
+def test_updated_pages_stay_swiss_hochdeutsch():
+    for name in ("index.html", "open_source.html"):
+        html = _html(name)
+        assert "ß" not in html
+        assert "—" not in html  # em dash
+        assert "–" not in html  # en dash


### PR DESCRIPTION
## What

Brings the website copy in line with what Program 9 actually shipped, and surfaces the one-line installer where self-hosters land.

- **Homepage** (`index.html`): a download-first installer card in the Open Source section — `curl -fsSL https://openleg.ch/install.sh | bash`, "runs on a Raspberry Pi / mini-PC / NAS, your LEG owns box and data" — plus a matching bullet, and a "Zum Schnellstart" link to `/self-host`.
- **`/open-source`**: the "Selbst betreiben" card now **leads with the one command**, names the shipped capabilities (operator CLI, local meter import, private network without open ports), keeps the manual `git clone` path below it, and makes **"Selbst betreiben"** the primary header CTA.
- Schweizer Hochdeutsch throughout.

## Tests

- `tests/test_install_surfacing.py`: the one command is present on the homepage and `/open-source`, both link to `/self-host`, and both pages stay free of ß / em / en dashes.
- Existing `test_open_source_page_explains_codebase` still passes (manual `git clone` retained).
- Full local gate: 676 passed, 11 skipped, ruff clean.

Closes #200

---
_Generated by [Claude Code](https://claude.ai/code/session_01YVoijcSk2hE8C8jpT9e6DA)_