### PR TITLE
[codex] Deepen municipality profile assembly

### DIFF
--- a/api_public.py
+++ b/api_public.py
@@ -9,6 +9,7 @@ import logging
 from flask import Blueprint, request, jsonify, render_template
 
 import database as db
+import municipality_profile
 import public_data
 
 logger = logging.getLogger(__name__)
@@ -175,14 +176,14 @@ def get_municipality_leg_potential(bfs):
     num_participants = request.args.get("participants", 10, type=int)
     avg_consumption = request.args.get("consumption_kwh", 4500, type=float)
 
-    tariffs = db.get_elcom_tariffs(bfs, year=year)
-    h4 = next((t for t in tariffs if str(t.get("category", "")).startswith("H4")), None)
-    if not h4:
+    gap = municipality_profile.value_gap(
+        bfs, year=year, grid_reduction_pct=grid_reduction
+    )
+    if not gap:
         return jsonify(
             {"error": "No H4 tariff found. Refresh data first.", "bfs_number": bfs}
         ), 404
 
-    gap = public_data.compute_leg_value_gap(h4, grid_reduction_pct=grid_reduction)
     # Scale for participants
     gap["num_participants"] = num_participants
     gap["total_community_savings_chf"] = round(
@@ -292,12 +293,12 @@ def leg_value_gap():
     grid_level = data.get("grid_level", "NE7")
     grid_reduction = 40.0 if grid_level == "NE7" else 25.0
 
-    tariffs = db.get_elcom_tariffs(int(bfs), year=year)
-    h4 = next((t for t in tariffs if str(t.get("category", "")).startswith("H4")), None)
-    if not h4:
+    gap = municipality_profile.value_gap(
+        int(bfs), year=year, grid_reduction_pct=grid_reduction
+    )
+    if not gap:
         return jsonify({"error": "No H4 tariff found"}), 404
 
-    gap = public_data.compute_leg_value_gap(h4, grid_reduction_pct=grid_reduction)
     # Custom consumption scaling
     custom_savings = float(gap["savings_rp_kwh"]) * avg_consumption / 100.0
     return jsonify(

--- a/municipality.py
+++ b/municipality.py
@@ -11,6 +11,7 @@ from flask import Blueprint, request, jsonify, render_template, abort
 
 from cantons import SWISS_CANTON_OPTIONS, SWISS_CANTONS
 import database as db
+import municipality_profile
 from ranking import Ranking
 import security_utils
 
@@ -19,85 +20,7 @@ logger = logging.getLogger(__name__)
 municipality_bp = Blueprint("municipality", __name__, url_prefix="/gemeinde")
 pilot_bp = Blueprint("pilot", __name__, url_prefix="/pilotgemeinde")
 
-PILOT_MUNICIPALITIES = {"baden": 4021}
-
-
-def _format_rp_kwh(value):
-    if value is None:
-        return None
-    try:
-        return f"{float(value):.1f}"
-    except (TypeError, ValueError):
-        return None
-
-
-def _profile_seo(name, h4_tariff):
-    h4_total = _format_rp_kwh(h4_tariff.get("total_rp_kwh")) if h4_tariff else None
-    year = (h4_tariff or {}).get("year")
-    year_part = f" {year}" if year else ""
-
-    if h4_total:
-        title = (
-            f"Stromtarif {name}{year_part}: {h4_total} Rp/kWh, Solar und LEG | OpenLEG"
-        )
-        description = (
-            f"Stromtarif {name}: {h4_total} Rp/kWh im H4-Profil. "
-            "OpenLEG zeigt Solarnutzung und LEG-Potenzial für die Gemeinde."
-        )
-    else:
-        title = f"Stromtarif {name}: Solar und LEG | OpenLEG"
-        description = (
-            f"Stromtarif {name}: OpenLEG zeigt Solarnutzung, "
-            "Energieprofil und LEG-Potenzial für die Gemeinde."
-        )
-
-    return title, description
-
-
-def _profile_jsonld(profile, bfs, h4_tariff, site_url, canonical_url):
-    name = (profile.get("name") or "").strip()
-    kanton = (profile.get("kanton") or "").strip().upper()[:2]
-    graph = [
-        {
-            "@type": "Place",
-            "name": name,
-            "identifier": str(bfs),
-            "containedInPlace": {
-                "@type": "AdministrativeArea",
-                "name": kanton,
-            },
-            "url": canonical_url,
-        },
-        {
-            "@type": "BreadcrumbList",
-            "itemListElement": [
-                {
-                    "@type": "ListItem",
-                    "position": 1,
-                    "name": "Gemeindeverzeichnis",
-                    "item": f"{site_url}/gemeinde/verzeichnis",
-                },
-                {
-                    "@type": "ListItem",
-                    "position": 2,
-                    "name": name,
-                    "item": canonical_url,
-                },
-            ],
-        },
-    ]
-
-    operator_name = str((h4_tariff or {}).get("operator_name") or "").strip()
-    if operator_name:
-        graph.append(
-            {
-                "@type": "Organization",
-                "name": operator_name,
-                "description": "Verteilnetzbetreiber",
-            }
-        )
-
-    return {"@context": "https://schema.org", "@graph": graph}
+PILOT_MUNICIPALITIES = municipality_profile.PILOT_MUNICIPALITIES
 
 
 @municipality_bp.route("/onboarding")
@@ -265,130 +188,25 @@ def api_municipalities():
 @municipality_bp.route("/profil/<int:bfs>")
 def profil(bfs):
     """Public municipality profile page with energy data visualization."""
-    profile = db.get_municipality_profile(bfs)
-    if not profile:
+    ctx = municipality_profile.profile_context(
+        bfs, site_url=request.url_root.rstrip("/")
+    )
+    if ctx is None:
         abort(404)
 
-    tariffs = db.get_elcom_tariffs(bfs, year=2026)
-    solar = db.get_sonnendach_municipal(bfs)
-
-    # Compute value gap if H4 tariff available
-    import public_data
-
-    h4 = next((t for t in tariffs if str(t.get("category", "")).startswith("H4")), None)
-    value_gap = public_data.compute_leg_value_gap(h4) if h4 else None
-
-    # Kanonische Solarnutzung: neuer PV-Score, gedeckelt; sonst Altwert
-    solar_score, solar_over_100 = Ranking.capped_score(profile.get("pv_score_pct"))
-    if solar_score is None and profile.get("solar_potential_pct") is not None:
-        solar_score = round(float(profile["solar_potential_pct"]), 1)
-
-    # Liga-Ränge, Verbesserungsziel und Vorbilder nur bei vorhandenem PV-Score
-    league_chips = []
-    improvement = None
-    already_top = False
-    leaders = []
-    if profile.get("pv_score_pct") is not None:
-        ranking = Ranking.load()
-        league_chips = ranking.league_chips(profile)
-        improvement = ranking.improvement_target(profile)
-        size_rank = ranking.size_league_rank(profile)
-        already_top = bool(size_rank and size_rank["quartile"] == Ranking.TOP_QUARTILE)
-        leaders = ranking.leaders(profile.get("kanton"), exclude_bfs=bfs)
-
-    pilot_slug = next(
-        (slug for slug, pilot_bfs in PILOT_MUNICIPALITIES.items() if pilot_bfs == bfs),
-        None,
-    )
-
-    name = (profile.get("name") or "").strip()
-    site_url = request.url_root.rstrip("/")
-    canonical_url = f"{site_url}/gemeinde/profil/{bfs}"
-    seo_title, seo_description = _profile_seo(name, h4)
-    jsonld = _profile_jsonld(profile, bfs, h4, site_url, canonical_url)
-
-    leg_entries = db.list_registry_entries(q=name) if name else []
-
-    return render_template(
-        "gemeinde/profil.html",
-        profile=profile,
-        leg_entries=leg_entries,
-        tariffs=tariffs,
-        solar=solar,
-        value_gap=value_gap,
-        h4_tariff=h4,
-        solar_score=solar_score,
-        solar_over_100=solar_over_100,
-        league_chips=league_chips,
-        improvement=improvement,
-        already_top=already_top,
-        leaders=leaders,
-        site_url=site_url,
-        share_base=site_url,
-        canonical_url=canonical_url,
-        seo_title=seo_title,
-        seo_description=seo_description,
-        jsonld=jsonld,
-        pilot_slug=pilot_slug,
-    )
+    return render_template("gemeinde/profil.html", **ctx)
 
 
 @pilot_bp.route("/<slug>")
 def pilot_case_study(slug):
     """Data-driven trust page for selected pilot municipalities."""
-    bfs = PILOT_MUNICIPALITIES.get(slug)
-    if bfs is None:
-        abort(404)
-
-    profile = db.get_municipality_profile(bfs)
-    if not profile:
-        abort(404)
-
-    # No year filter: get_elcom_tariffs orders year DESC, so the first H4
-    # entry is always the latest available tariff.
-    tariffs = db.get_elcom_tariffs(bfs)
-    solar = db.get_sonnendach_municipal(bfs)
-
-    import public_data
-
-    h4 = next((t for t in tariffs if str(t.get("category", "")).startswith("H4")), None)
-    value_gap = public_data.compute_leg_value_gap(h4) if h4 else None
-    place_id = f"#place-{bfs}"
-    json_ld = {
-        "@context": "https://schema.org",
-        "@graph": [
-            {
-                "@type": "Article",
-                "headline": f"Fallstudie: LEG-Potenzial in {profile.get('name')}",
-                "author": {"@type": "Organization", "name": "OpenLEG"},
-                "publisher": {"@type": "Organization", "name": "OpenLEG"},
-                "about": {"@id": place_id},
-            },
-            {
-                "@id": place_id,
-                "@type": "Place",
-                "name": profile.get("name"),
-                "identifier": str(bfs),
-                "containedInPlace": {
-                    "@type": "AdministrativeArea",
-                    "name": profile.get("kanton"),
-                },
-            },
-        ],
-    }
-
-    return render_template(
-        "gemeinde/pilotgemeinde.html",
-        profile=profile,
-        bfs=bfs,
-        slug=slug,
-        h4=h4,
-        solar=solar,
-        value_gap=value_gap,
-        json_ld=json_ld,
-        site_url=request.url_root.rstrip("/"),
-        canonical_path=f"/pilotgemeinde/{slug}",
+    ctx = municipality_profile.pilot_context(
+        slug, site_url=request.url_root.rstrip("/")
     )
+    if ctx is None:
+        abort(404)
+
+    return render_template("gemeinde/pilotgemeinde.html", **ctx)
 
 
 @municipality_bp.route("/verzeichnis")

--- a/municipality_profile.py
+++ b/municipality_profile.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Municipality profile/pilot read models (issue #209).
+
+Deep module owning tariff/solar/value-gap assembly for the public profile
+and pilot case-study pages, plus the value-gap API calculation, so routes
+stay thin request/response shells.
+"""
+
+import database as db
+import public_data
+from ranking import Ranking
+
+PROFILE_TARIFF_YEAR = 2026
+PILOT_MUNICIPALITIES = {"baden": 4021}
+
+
+def _first_h4_tariff(bfs, year=None):
+    tariffs = db.get_elcom_tariffs(bfs, year=year)
+    h4 = next(
+        (t for t in tariffs if str(t.get("category", "")).startswith("H4")), None
+    )
+    return tariffs, h4
+
+
+def _value_gap_for_tariff(h4, grid_reduction_pct):
+    if not h4:
+        return None
+    return public_data.compute_leg_value_gap(h4, grid_reduction_pct=grid_reduction_pct)
+
+
+def value_gap(bfs, *, year=PROFILE_TARIFF_YEAR, grid_reduction_pct=40.0):
+    _tariffs, h4 = _first_h4_tariff(bfs, year=year)
+    return _value_gap_for_tariff(h4, grid_reduction_pct)
+
+
+def _format_rp_kwh(value):
+    if value is None:
+        return None
+    try:
+        return f"{float(value):.1f}"
+    except (TypeError, ValueError):
+        return None
+
+
+def _profile_seo(name, h4_tariff):
+    h4_total = _format_rp_kwh(h4_tariff.get("total_rp_kwh")) if h4_tariff else None
+    year = (h4_tariff or {}).get("year")
+    year_part = f" {year}" if year else ""
+
+    if h4_total:
+        title = (
+            f"Stromtarif {name}{year_part}: {h4_total} Rp/kWh, Solar und LEG | OpenLEG"
+        )
+        description = (
+            f"Stromtarif {name}: {h4_total} Rp/kWh im H4-Profil. "
+            "OpenLEG zeigt Solarnutzung und LEG-Potenzial für die Gemeinde."
+        )
+    else:
+        title = f"Stromtarif {name}: Solar und LEG | OpenLEG"
+        description = (
+            f"Stromtarif {name}: OpenLEG zeigt Solarnutzung, "
+            "Energieprofil und LEG-Potenzial für die Gemeinde."
+        )
+
+    return title, description
+
+
+def _profile_jsonld(profile, bfs, h4_tariff, site_url, canonical_url):
+    name = (profile.get("name") or "").strip()
+    kanton = (profile.get("kanton") or "").strip().upper()[:2]
+    graph = [
+        {
+            "@type": "Place",
+            "name": name,
+            "identifier": str(bfs),
+            "containedInPlace": {
+                "@type": "AdministrativeArea",
+                "name": kanton,
+            },
+            "url": canonical_url,
+        },
+        {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+                {
+                    "@type": "ListItem",
+                    "position": 1,
+                    "name": "Gemeindeverzeichnis",
+                    "item": f"{site_url}/gemeinde/verzeichnis",
+                },
+                {
+                    "@type": "ListItem",
+                    "position": 2,
+                    "name": name,
+                    "item": canonical_url,
+                },
+            ],
+        },
+    ]
+
+    operator_name = str((h4_tariff or {}).get("operator_name") or "").strip()
+    if operator_name:
+        graph.append(
+            {
+                "@type": "Organization",
+                "name": operator_name,
+                "description": "Verteilnetzbetreiber",
+            }
+        )
+
+    return {"@context": "https://schema.org", "@graph": graph}
+
+
+def profile_context(bfs, *, site_url):
+    profile = db.get_municipality_profile(bfs)
+    if not profile:
+        return None
+
+    site_url = site_url.rstrip("/")
+
+    tariffs, h4 = _first_h4_tariff(bfs, year=PROFILE_TARIFF_YEAR)
+    solar = db.get_sonnendach_municipal(bfs)
+    gap = _value_gap_for_tariff(h4, grid_reduction_pct=40.0)
+
+    solar_score, solar_over_100 = Ranking.capped_score(profile.get("pv_score_pct"))
+    if solar_score is None and profile.get("solar_potential_pct") is not None:
+        solar_score = round(float(profile["solar_potential_pct"]), 1)
+
+    league_chips = []
+    improvement = None
+    already_top = False
+    leaders = []
+    if profile.get("pv_score_pct") is not None:
+        ranking = Ranking.load()
+        league_chips = ranking.league_chips(profile)
+        improvement = ranking.improvement_target(profile)
+        size_rank = ranking.size_league_rank(profile)
+        already_top = bool(size_rank and size_rank["quartile"] == Ranking.TOP_QUARTILE)
+        leaders = ranking.leaders(profile.get("kanton"), exclude_bfs=bfs)
+
+    pilot_slug = next(
+        (slug for slug, pilot_bfs in PILOT_MUNICIPALITIES.items() if pilot_bfs == bfs),
+        None,
+    )
+
+    name = (profile.get("name") or "").strip()
+    canonical_url = f"{site_url}/gemeinde/profil/{bfs}"
+    seo_title, seo_description = _profile_seo(name, h4)
+    jsonld = _profile_jsonld(profile, bfs, h4, site_url, canonical_url)
+
+    leg_entries = db.list_registry_entries(q=name) if name else []
+
+    return {
+        "profile": profile,
+        "leg_entries": leg_entries,
+        "tariffs": tariffs,
+        "solar": solar,
+        "value_gap": gap,
+        "h4_tariff": h4,
+        "solar_score": solar_score,
+        "solar_over_100": solar_over_100,
+        "league_chips": league_chips,
+        "improvement": improvement,
+        "already_top": already_top,
+        "leaders": leaders,
+        "site_url": site_url,
+        "share_base": site_url,
+        "canonical_url": canonical_url,
+        "seo_title": seo_title,
+        "seo_description": seo_description,
+        "jsonld": jsonld,
+        "pilot_slug": pilot_slug,
+    }
+
+
+def pilot_context(slug, *, site_url):
+    bfs = PILOT_MUNICIPALITIES.get(slug)
+    if bfs is None:
+        return None
+
+    profile = db.get_municipality_profile(bfs)
+    if not profile:
+        return None
+
+    site_url = site_url.rstrip("/")
+
+    # No year filter: get_elcom_tariffs orders year DESC, so the first H4
+    # entry is always the latest available tariff.
+    tariffs, h4 = _first_h4_tariff(bfs)
+    solar = db.get_sonnendach_municipal(bfs)
+    gap = _value_gap_for_tariff(h4, grid_reduction_pct=40.0)
+
+    place_id = f"#place-{bfs}"
+    json_ld = {
+        "@context": "https://schema.org",
+        "@graph": [
+            {
+                "@type": "Article",
+                "headline": f"Fallstudie: LEG-Potenzial in {profile.get('name')}",
+                "author": {"@type": "Organization", "name": "OpenLEG"},
+                "publisher": {"@type": "Organization", "name": "OpenLEG"},
+                "about": {"@id": place_id},
+            },
+            {
+                "@id": place_id,
+                "@type": "Place",
+                "name": profile.get("name"),
+                "identifier": str(bfs),
+                "containedInPlace": {
+                    "@type": "AdministrativeArea",
+                    "name": profile.get("kanton"),
+                },
+            },
+        ],
+    }
+
+    return {
+        "profile": profile,
+        "bfs": bfs,
+        "slug": slug,
+        "h4": h4,
+        "solar": solar,
+        "value_gap": gap,
+        "json_ld": json_ld,
+        "site_url": site_url,
+        "canonical_path": f"/pilotgemeinde/{slug}",
+    }

--- a/municipality_profile.py
+++ b/municipality_profile.py
@@ -16,9 +16,7 @@ PILOT_MUNICIPALITIES = {"baden": 4021}
 
 def _first_h4_tariff(bfs, year=None):
     tariffs = db.get_elcom_tariffs(bfs, year=year)
-    h4 = next(
-        (t for t in tariffs if str(t.get("category", "")).startswith("H4")), None
-    )
+    h4 = next((t for t in tariffs if str(t.get("category", "")).startswith("H4")), None)
     return tariffs, h4
 
 

--- a/tests/test_api_public.py
+++ b/tests/test_api_public.py
@@ -93,20 +93,45 @@ class TestScoreEndpoint:
 
 
 class TestLegPotentialEndpoint:
-    @patch("api_public.db")
-    def test_leg_potential(self, mock_db, client):
-        mock_db.get_elcom_tariffs.return_value = MOCK_ELCOM_TARIFFS
+    @patch("api_public.municipality_profile")
+    def test_leg_potential(self, mock_mp, client):
+        mock_mp.value_gap.return_value = {
+            "grid_fee_rp_kwh": 9.5,
+            "savings_rp_kwh": 3.8,
+            "annual_savings_chf": 171.0,
+            "monthly_savings_chf": 14.25,
+            "savings_pct": 13.8,
+        }
         resp = client.get("/api/v1/municipalities/261/leg-potential")
         assert resp.status_code == 200
         data = resp.get_json()
         assert data["annual_savings_chf"] > 0
         assert data["total_community_savings_chf"] > 0
+        assert set(data.keys()) == {
+            "grid_fee_rp_kwh",
+            "savings_rp_kwh",
+            "annual_savings_chf",
+            "monthly_savings_chf",
+            "savings_pct",
+            "num_participants",
+            "total_community_savings_chf",
+            "avg_consumption_kwh",
+            "bfs_number",
+        }
+        mock_mp.value_gap.assert_called_once_with(
+            261, year=2026, grid_reduction_pct=40.0
+        )
 
-    @patch("api_public.db")
-    def test_leg_potential_no_tariff(self, mock_db, client):
-        mock_db.get_elcom_tariffs.return_value = []
+    @patch("api_public.municipality_profile")
+    def test_leg_potential_no_tariff(self, mock_mp, client):
+        mock_mp.value_gap.return_value = None
         resp = client.get("/api/v1/municipalities/261/leg-potential")
         assert resp.status_code == 404
+        data = resp.get_json()
+        assert data == {
+            "error": "No H4 tariff found. Refresh data first.",
+            "bfs_number": 261,
+        }
 
 
 class TestSearchEndpoint:
@@ -215,9 +240,15 @@ class TestRankingsEndpoint:
 
 
 class TestLegToolkitEndpoints:
-    @patch("api_public.db")
-    def test_value_gap_post(self, mock_db, client):
-        mock_db.get_elcom_tariffs.return_value = MOCK_ELCOM_TARIFFS
+    @patch("api_public.municipality_profile")
+    def test_value_gap_post(self, mock_mp, client):
+        mock_mp.value_gap.return_value = {
+            "grid_fee_rp_kwh": 9.5,
+            "savings_rp_kwh": 3.8,
+            "annual_savings_chf": 171.0,
+            "monthly_savings_chf": 14.25,
+            "savings_pct": 13.8,
+        }
         resp = client.post(
             "/api/v1/leg/value-gap",
             json={
@@ -230,6 +261,18 @@ class TestLegToolkitEndpoints:
         data = resp.get_json()
         assert data["annual_savings_per_household"] > 0
         assert data["total_community_savings"] > 0
+        assert set(data.keys()) == {
+            "bfs_number",
+            "annual_savings_per_household",
+            "total_community_savings",
+            "grid_fee_reduction",
+            "grid_level",
+            "num_participants",
+            "avg_consumption_kwh",
+        }
+        mock_mp.value_gap.assert_called_once_with(
+            261, year=2026, grid_reduction_pct=40.0
+        )
 
     @patch("api_public.db")
     def test_value_gap_no_bfs(self, mock_db, client):

--- a/tests/test_api_public.py
+++ b/tests/test_api_public.py
@@ -101,6 +101,8 @@ class TestLegPotentialEndpoint:
             "annual_savings_chf": 171.0,
             "monthly_savings_chf": 14.25,
             "savings_pct": 13.8,
+            "grid_reduction_pct": 40.0,
+            "assumed_consumption_kwh": 4500,
         }
         resp = client.get("/api/v1/municipalities/261/leg-potential")
         assert resp.status_code == 200
@@ -113,6 +115,8 @@ class TestLegPotentialEndpoint:
             "annual_savings_chf",
             "monthly_savings_chf",
             "savings_pct",
+            "grid_reduction_pct",
+            "assumed_consumption_kwh",
             "num_participants",
             "total_community_savings_chf",
             "avg_consumption_kwh",
@@ -278,6 +282,16 @@ class TestLegToolkitEndpoints:
     def test_value_gap_no_bfs(self, mock_db, client):
         resp = client.post("/api/v1/leg/value-gap", json={})
         assert resp.status_code == 400
+
+    @patch("api_public.municipality_profile")
+    def test_value_gap_post_no_h4(self, mock_mp, client):
+        mock_mp.value_gap.return_value = None
+        resp = client.post(
+            "/api/v1/leg/value-gap",
+            json={"bfs_number": 261},
+        )
+        assert resp.status_code == 404
+        assert resp.get_json() == {"error": "No H4 tariff found"}
 
     @patch("api_public.db")
     def test_financial_model(self, mock_db, client):

--- a/tests/test_municipality_leg_section.py
+++ b/tests/test_municipality_leg_section.py
@@ -17,7 +17,7 @@ def _read(*parts):
 
 
 def test_profil_route_loads_registry_entries():
-    source = _read("municipality.py")
+    source = _read("municipality_profile.py")
     assert "list_registry_entries" in source
 
 

--- a/tests/test_municipality_organic.py
+++ b/tests/test_municipality_organic.py
@@ -541,27 +541,7 @@ def test_profil_jsonld_omits_operator_without_tariff(monkeypatch):
 def test_profil_route_delegates_to_municipality_profile_module(monkeypatch):
     """Route parses request, delegates assembly to municipality_profile, renders (#209)."""
     client = _make_client()
-    fake_ctx = {
-        "profile": {"bfs_number": 4021, "name": "Baden"},
-        "leg_entries": [],
-        "tariffs": [],
-        "solar": None,
-        "value_gap": None,
-        "h4_tariff": None,
-        "solar_score": None,
-        "solar_over_100": False,
-        "league_chips": [],
-        "improvement": None,
-        "already_top": False,
-        "leaders": [],
-        "site_url": "http://openleg.ch",
-        "share_base": "http://openleg.ch",
-        "canonical_url": "http://openleg.ch/gemeinde/profil/4021",
-        "seo_title": "t",
-        "seo_description": "d",
-        "jsonld": {},
-        "pilot_slug": "baden",
-    }
+    fake_ctx = {"sentinel": "profile-context"}
     calls = []
 
     def _fake_profile_context(bfs, *, site_url):
@@ -588,4 +568,4 @@ def test_profil_route_delegates_to_municipality_profile_module(monkeypatch):
     assert resp.status_code == 200
     assert calls == [{"bfs": 4021, "site_url": "http://openleg.ch"}]
     assert rendered["template"] == "gemeinde/profil.html"
-    assert rendered["context"]["profile"]["name"] == "Baden"
+    assert rendered["context"] == fake_ctx

--- a/tests/test_municipality_organic.py
+++ b/tests/test_municipality_organic.py
@@ -536,3 +536,56 @@ def test_profil_jsonld_omits_operator_without_tariff(monkeypatch):
     nodes = _jsonld_graph(html)
     assert nodes.get("Place")
     assert "Organization" not in nodes
+
+
+def test_profil_route_delegates_to_municipality_profile_module(monkeypatch):
+    """Route parses request, delegates assembly to municipality_profile, renders (#209)."""
+    client = _make_client()
+    fake_ctx = {
+        "profile": {"bfs_number": 4021, "name": "Baden"},
+        "leg_entries": [],
+        "tariffs": [],
+        "solar": None,
+        "value_gap": None,
+        "h4_tariff": None,
+        "solar_score": None,
+        "solar_over_100": False,
+        "league_chips": [],
+        "improvement": None,
+        "already_top": False,
+        "leaders": [],
+        "site_url": "http://openleg.ch",
+        "share_base": "http://openleg.ch",
+        "canonical_url": "http://openleg.ch/gemeinde/profil/4021",
+        "seo_title": "t",
+        "seo_description": "d",
+        "jsonld": {},
+        "pilot_slug": "baden",
+    }
+    calls = []
+
+    def _fake_profile_context(bfs, *, site_url):
+        calls.append({"bfs": bfs, "site_url": site_url})
+        return fake_ctx
+
+    monkeypatch.setattr(
+        municipality_module.municipality_profile,
+        "profile_context",
+        _fake_profile_context,
+    )
+
+    rendered = {}
+
+    def _fake_render_template(template_name, **context):
+        rendered["template"] = template_name
+        rendered["context"] = context
+        return "ok"
+
+    monkeypatch.setattr(municipality_module, "render_template", _fake_render_template)
+
+    resp = client.get("/gemeinde/profil/4021", headers={"Host": "openleg.ch"})
+
+    assert resp.status_code == 200
+    assert calls == [{"bfs": 4021, "site_url": "http://openleg.ch"}]
+    assert rendered["template"] == "gemeinde/profil.html"
+    assert rendered["context"]["profile"]["name"] == "Baden"

--- a/tests/test_municipality_profile_module.py
+++ b/tests/test_municipality_profile_module.py
@@ -85,7 +85,7 @@ def test_profile_context_key_set_matches_existing_template_contract(monkeypatch)
     mp = _load_module()
     _patch_profile_deps(monkeypatch, mp, PROFILE, [H4_TARIFF])
 
-    ctx = mp.profile_context(4021, site_url="http://openleg.ch")
+    ctx = mp.profile_context(4021, site_url="http://openleg.ch/")
 
     assert ctx is not None
     assert len(PROFILE_CONTEXT_KEYS) == 19
@@ -93,7 +93,7 @@ def test_profile_context_key_set_matches_existing_template_contract(monkeypatch)
     assert ctx["profile"] == PROFILE
     assert ctx["h4_tariff"] == H4_TARIFF
     assert ctx["pilot_slug"] == "baden"
-    assert ctx["site_url"] == "http://openleg.ch"
+    assert ctx["site_url"] == "http://openleg.ch/"
     assert ctx["canonical_url"] == "http://openleg.ch/gemeinde/profil/4021"
 
 

--- a/tests/test_municipality_profile_module.py
+++ b/tests/test_municipality_profile_module.py
@@ -1,0 +1,202 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Seam contract for municipality_profile.py (issue #209).
+
+Pins the deep-module interface for profile_context/pilot_context/value_gap
+before the module exists. Loaded lazily inside each test so a missing module
+produces an assertion failure, not a collection error for the whole suite.
+"""
+
+import importlib
+import os
+
+import public_data
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+MODULE_PATH = os.path.join(PROJECT_ROOT, "municipality_profile.py")
+
+PROFILE = {"bfs_number": 4021, "name": "Baden", "kanton": "AG"}
+
+H4_TARIFF = {
+    "bfs_number": 4021,
+    "year": 2026,
+    "operator_name": "Regionalwerke AG Baden",
+    "category": "H4",
+    "total_rp_kwh": 27.5,
+    "energy_rp_kwh": 12.0,
+    "grid_rp_kwh": 9.5,
+}
+
+PROFILE_CONTEXT_KEYS = {
+    "profile",
+    "leg_entries",
+    "tariffs",
+    "solar",
+    "value_gap",
+    "h4_tariff",
+    "solar_score",
+    "solar_over_100",
+    "league_chips",
+    "improvement",
+    "already_top",
+    "leaders",
+    "site_url",
+    "share_base",
+    "canonical_url",
+    "seo_title",
+    "seo_description",
+    "jsonld",
+    "pilot_slug",
+}
+
+PILOT_CONTEXT_KEYS = {
+    "profile",
+    "bfs",
+    "slug",
+    "h4",
+    "solar",
+    "value_gap",
+    "json_ld",
+    "site_url",
+    "canonical_path",
+}
+
+
+def _load_module():
+    assert os.path.exists(MODULE_PATH), (
+        "municipality_profile.py must exist as the deep module owning "
+        "profile/pilot assembly (issue #209)"
+    )
+    import municipality_profile
+
+    return importlib.reload(municipality_profile)
+
+
+def _patch_profile_deps(monkeypatch, mp, profile, tariffs, solar=None, registry=None):
+    monkeypatch.setattr(mp.db, "get_municipality_profile", lambda bfs: profile)
+    monkeypatch.setattr(mp.db, "get_elcom_tariffs", lambda *a, **k: tariffs)
+    monkeypatch.setattr(mp.db, "get_sonnendach_municipal", lambda bfs: solar)
+    monkeypatch.setattr(mp.db, "list_registry_entries", lambda **k: registry or [])
+
+
+# === profile_context ===
+
+
+def test_profile_context_key_set_matches_existing_template_contract(monkeypatch):
+    mp = _load_module()
+    _patch_profile_deps(monkeypatch, mp, PROFILE, [H4_TARIFF])
+
+    ctx = mp.profile_context(4021, site_url="http://openleg.ch")
+
+    assert ctx is not None
+    assert len(PROFILE_CONTEXT_KEYS) == 19
+    assert set(ctx.keys()) == PROFILE_CONTEXT_KEYS
+    assert ctx["profile"] == PROFILE
+    assert ctx["h4_tariff"] == H4_TARIFF
+    assert ctx["pilot_slug"] == "baden"
+    assert ctx["site_url"] == "http://openleg.ch"
+    assert ctx["canonical_url"] == "http://openleg.ch/gemeinde/profil/4021"
+
+
+def test_profile_context_tariff_query_uses_year_2026(monkeypatch):
+    mp = _load_module()
+    calls = []
+
+    def _spy(bfs, year=None):
+        calls.append({"bfs": bfs, "year": year})
+        return [H4_TARIFF]
+
+    monkeypatch.setattr(mp.db, "get_municipality_profile", lambda bfs: PROFILE)
+    monkeypatch.setattr(mp.db, "get_elcom_tariffs", _spy)
+    monkeypatch.setattr(mp.db, "get_sonnendach_municipal", lambda bfs: None)
+    monkeypatch.setattr(mp.db, "list_registry_entries", lambda **k: [])
+
+    mp.profile_context(4021, site_url="http://openleg.ch")
+
+    assert calls == [{"bfs": 4021, "year": 2026}]
+
+
+def test_profile_context_missing_profile_returns_none(monkeypatch):
+    mp = _load_module()
+    monkeypatch.setattr(mp.db, "get_municipality_profile", lambda bfs: None)
+
+    assert mp.profile_context(4021, site_url="http://openleg.ch") is None
+
+
+# === pilot_context ===
+
+
+def test_pilot_context_key_set_matches_existing_template_contract(monkeypatch):
+    mp = _load_module()
+    _patch_profile_deps(monkeypatch, mp, PROFILE, [H4_TARIFF])
+
+    ctx = mp.pilot_context("baden", site_url="http://openleg.ch")
+
+    assert ctx is not None
+    assert len(PILOT_CONTEXT_KEYS) == 9
+    assert set(ctx.keys()) == PILOT_CONTEXT_KEYS
+    assert ctx["bfs"] == 4021
+    assert ctx["slug"] == "baden"
+    assert ctx["site_url"] == "http://openleg.ch"
+    assert ctx["canonical_path"] == "/pilotgemeinde/baden"
+
+
+def test_pilot_context_tariff_query_is_unfiltered_and_first_h4_wins(monkeypatch):
+    mp = _load_module()
+    monkeypatch.setattr(mp.db, "get_municipality_profile", lambda bfs: PROFILE)
+    monkeypatch.setattr(mp.db, "get_sonnendach_municipal", lambda bfs: None)
+
+    non_h4 = {**H4_TARIFF, "category": "H1"}
+    first_h4 = {**H4_TARIFF, "category": "H4", "total_rp_kwh": 30.0}
+    second_h4 = {**H4_TARIFF, "category": "H4", "total_rp_kwh": 99.0}
+    calls = []
+
+    def _spy(bfs, year=None):
+        calls.append({"bfs": bfs, "year": year})
+        return [non_h4, first_h4, second_h4]
+
+    monkeypatch.setattr(mp.db, "get_elcom_tariffs", _spy)
+
+    ctx = mp.pilot_context("baden", site_url="http://openleg.ch")
+
+    assert calls == [{"bfs": 4021, "year": None}]
+    assert ctx["h4"]["total_rp_kwh"] == 30.0
+
+
+def test_pilot_context_unknown_slug_returns_none(monkeypatch):
+    mp = _load_module()
+
+    assert mp.pilot_context("atlantis", site_url="http://openleg.ch") is None
+
+
+def test_pilot_context_missing_profile_returns_none(monkeypatch):
+    mp = _load_module()
+    monkeypatch.setattr(mp.db, "get_municipality_profile", lambda bfs: None)
+
+    assert mp.pilot_context("baden", site_url="http://openleg.ch") is None
+
+
+# === value_gap ===
+
+
+def test_value_gap_uses_requested_year_and_grid_reduction(monkeypatch):
+    mp = _load_module()
+    calls = []
+
+    def _spy(bfs, year=None):
+        calls.append({"bfs": bfs, "year": year})
+        return [H4_TARIFF]
+
+    monkeypatch.setattr(mp.db, "get_elcom_tariffs", _spy)
+
+    result = mp.value_gap(4021, year=2025, grid_reduction_pct=25.0)
+
+    assert calls == [{"bfs": 4021, "year": 2025}]
+    expected = public_data.compute_leg_value_gap(H4_TARIFF, grid_reduction_pct=25.0)
+    assert result == expected
+
+
+def test_value_gap_without_h4_returns_none(monkeypatch):
+    mp = _load_module()
+    monkeypatch.setattr(mp.db, "get_elcom_tariffs", lambda *a, **k: [])
+
+    assert mp.value_gap(4021) is None

--- a/tests/test_municipality_profile_module.py
+++ b/tests/test_municipality_profile_module.py
@@ -93,7 +93,7 @@ def test_profile_context_key_set_matches_existing_template_contract(monkeypatch)
     assert ctx["profile"] == PROFILE
     assert ctx["h4_tariff"] == H4_TARIFF
     assert ctx["pilot_slug"] == "baden"
-    assert ctx["site_url"] == "http://openleg.ch/"
+    assert ctx["site_url"] == "http://openleg.ch"
     assert ctx["canonical_url"] == "http://openleg.ch/gemeinde/profil/4021"
 
 

--- a/tests/test_pilot_case_study.py
+++ b/tests/test_pilot_case_study.py
@@ -196,3 +196,56 @@ def test_fuer_bewohner_links_to_case_study(full_app_module):
     assert resp.status_code == 200
     html = resp.data.decode("utf-8", errors="ignore")
     assert "/pilotgemeinde/baden" in html
+
+
+def test_pilot_route_delegates_to_municipality_profile_module(monkeypatch):
+    """Route parses request, delegates assembly to municipality_profile, renders (#209)."""
+    client = _make_client()
+    fake_ctx = {
+        "profile": dict(BADEN_PROFILE),
+        "bfs": 4021,
+        "slug": "baden",
+        "h4": dict(BADEN_H4_TARIFF),
+        "solar": dict(BADEN_SONNENDACH),
+        "value_gap": {"annual_savings_chf": 171.0},
+        "json_ld": {"@context": "https://schema.org"},
+        "site_url": "http://openleg.ch",
+        "canonical_path": "/pilotgemeinde/baden",
+    }
+    calls = []
+
+    def _fake_pilot_context(slug, *, site_url):
+        calls.append({"slug": slug, "site_url": site_url})
+        return fake_ctx
+
+    monkeypatch.setattr(
+        municipality_module.municipality_profile, "pilot_context", _fake_pilot_context
+    )
+
+    rendered = {}
+
+    def _fake_render_template(template_name, **context):
+        rendered["template"] = template_name
+        rendered["context"] = context
+        return "ok"
+
+    monkeypatch.setattr(municipality_module, "render_template", _fake_render_template)
+
+    resp = client.get("/pilotgemeinde/baden", headers={"Host": "openleg.ch"})
+
+    assert resp.status_code == 200
+    assert calls == [{"slug": "baden", "site_url": "http://openleg.ch"}]
+    assert rendered["template"] == "gemeinde/pilotgemeinde.html"
+
+
+def test_pilot_route_returns_404_when_context_is_none(monkeypatch):
+    client = _make_client()
+    monkeypatch.setattr(
+        municipality_module.municipality_profile,
+        "pilot_context",
+        lambda slug, *, site_url: None,
+    )
+
+    resp = client.get("/pilotgemeinde/atlantis")
+
+    assert resp.status_code == 404

--- a/tests/test_pilot_case_study.py
+++ b/tests/test_pilot_case_study.py
@@ -201,17 +201,7 @@ def test_fuer_bewohner_links_to_case_study(full_app_module):
 def test_pilot_route_delegates_to_municipality_profile_module(monkeypatch):
     """Route parses request, delegates assembly to municipality_profile, renders (#209)."""
     client = _make_client()
-    fake_ctx = {
-        "profile": dict(BADEN_PROFILE),
-        "bfs": 4021,
-        "slug": "baden",
-        "h4": dict(BADEN_H4_TARIFF),
-        "solar": dict(BADEN_SONNENDACH),
-        "value_gap": {"annual_savings_chf": 171.0},
-        "json_ld": {"@context": "https://schema.org"},
-        "site_url": "http://openleg.ch",
-        "canonical_path": "/pilotgemeinde/baden",
-    }
+    fake_ctx = {"sentinel": "pilot-context"}
     calls = []
 
     def _fake_pilot_context(slug, *, site_url):
@@ -236,6 +226,7 @@ def test_pilot_route_delegates_to_municipality_profile_module(monkeypatch):
     assert resp.status_code == 200
     assert calls == [{"slug": "baden", "site_url": "http://openleg.ch"}]
     assert rendered["template"] == "gemeinde/pilotgemeinde.html"
+    assert rendered["context"] == fake_ctx
 
 
 def test_pilot_route_returns_404_when_context_is_none(monkeypatch):


### PR DESCRIPTION
Closes #209

## Outcome
- adds one route-neutral municipality profile assembly module
- moves profile and pilot context assembly behind three cohesive functions
- centralizes H4 tariff selection and LEG value-gap calculation
- keeps Flask routes responsible for HTTP rendering, aborts, request parsing, and JSON responses

## Compatibility contracts
- profile tariff year remains pinned to 2026
- pilot tariffs remain latest-first
- template context keys and public API payloads remain unchanged
- site URLs are normalized before canonical and structured-data assembly

## TDD and verification
- RED: 16 intended failures for the missing seam; no collection failures
- GREEN: 716 passed, 11 skipped
- focused independent review: 75 passed; no blocker or high finding
- ruff check and format checks pass
- scoped mypy pass with imports skipped
- git diff and gitleaks checks pass

No visual UI changes; route integration and parity contracts exercise the affected public pages and APIs.