### PR TITLE
[codex] Finish the Ranking seam (#210)

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,7 +67,7 @@ import security_utils
 # --- PostgreSQL Database ---
 import database as db
 import dashboard as dashboard_module
-import pv_ranking
+from ranking import Ranking
 
 USE_POSTGRES = db.is_db_available()
 if not USE_POSTGRES:
@@ -459,7 +459,7 @@ def _ranking_extremes(n=3):
     Gibt (vorbilder, chancen, total) zurück. Leer, wenn zu wenige Daten.
     """
     try:
-        ranked = pv_ranking.assign_ranks(db.get_pv_profiles())
+        ranked = Ranking.load().national()
     except Exception:
         logger.exception("ranking preview failed")
         return [], [], 0
@@ -469,13 +469,12 @@ def _ranking_extremes(n=3):
         return [], [], total
 
     def shape(row):
-        score, _ = pv_ranking.capped_score(row.get("pv_score_pct"))
         return {
             "rank": row.get("rank"),
             "name": row.get("name"),
             "kanton": row.get("kanton"),
             "bfs_number": row.get("bfs_number"),
-            "score": score,
+            "score": row.get("display_score"),
         }
 
     best = [shape(r) for r in scored[:n]]

--- a/rangliste.py
+++ b/rangliste.py
@@ -10,7 +10,6 @@ import logging
 from flask import Blueprint, Response, render_template, request
 
 import database as db
-import pv_ranking
 from cantons import SWISS_CANTON_OPTIONS
 from ranking import Ranking
 
@@ -121,7 +120,7 @@ def vergleich():
         profile = db.get_municipality_profile(bfs)
         if not profile:
             return None
-        score, over_100 = pv_ranking.capped_score(profile.get("pv_score_pct"))
+        score, over_100 = ranking.capped_score(profile.get("pv_score_pct"))
         return {
             **profile,
             "display_score": score,
@@ -172,9 +171,8 @@ def movers():
         limit = 100
 
     ranking = Ranking([])
-    rows = ranking.movers()
-    league = pv_ranking.filter_league(
-        rows, kanton=kanton.upper() if kanton else None, size=size, density=density
+    league = ranking.movers(
+        kanton=kanton.upper() if kanton else None, size=size, density=density
     )
     latest_year = league[0]["year"] if league else None
 

--- a/ranking.py
+++ b/ranking.py
@@ -97,14 +97,20 @@ class Ranking:
         canton_profiles = pv_ranking.filter_league(self._profiles, kanton=kanton)
         return pv_ranking.league_leaders(canton_profiles, exclude_bfs=exclude_bfs)
 
-    def movers(self, mover_rows: Optional[List[Dict]] = None) -> List[Dict]:
+    def movers(
+        self,
+        mover_rows: Optional[List[Dict]] = None,
+        kanton: Optional[str] = None,
+        size: Optional[str] = None,
+        density: Optional[str] = None,
+    ) -> List[Dict]:
         """Gemeinden mit dem grössten Score-Delta.
 
         Nutzt injizierte Zeilen, falls vorhanden, sonst ``store_ranking.get_pv_movers``.
+        Wendet anschliessend dieselben Liga-Filter wie ``standings`` an.
         """
-        if mover_rows is not None:
-            return mover_rows
-        return store_ranking.get_pv_movers()
+        rows = mover_rows if mover_rows is not None else store_ranking.get_pv_movers()
+        return pv_ranking.filter_league(rows, kanton=kanton, size=size, density=density)
 
     def _rank_for_bfs(self, bfs: int) -> Optional[int]:
         for row in pv_ranking.assign_ranks(self._profiles):

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 import public_data
+from ranking import Ranking
 
 
 def _disable_rate_limit_hooks(flask_app):
@@ -244,3 +245,58 @@ def test_backfill_elcom_processes_batch_and_returns_summary(
     assert data["processed"] == 2
     assert data["saved"] == 2
     assert data["errors"] == []
+
+
+# === Issue #210: homepage ranking preview routed through the Ranking facade ===
+
+_RANKING_EXTREMES_PROFILES = [
+    {"bfs_number": 1, "name": "Overcap", "kanton": "ZH", "pv_score_pct": 140},
+    {"bfs_number": 2, "name": "G2", "kanton": "ZH", "pv_score_pct": 95},
+    {"bfs_number": 3, "name": "G3", "kanton": "ZH", "pv_score_pct": 90},
+    {"bfs_number": 4, "name": "G4", "kanton": "ZH", "pv_score_pct": 85},
+    {"bfs_number": 5, "name": "G5", "kanton": "ZH", "pv_score_pct": 80},
+    {"bfs_number": 6, "name": "G6", "kanton": "ZH", "pv_score_pct": 75},
+    {"bfs_number": 7, "name": "G7", "kanton": "ZH", "pv_score_pct": 70},
+    {"bfs_number": 8, "name": "Unscored", "kanton": "ZH", "pv_score_pct": None},
+]
+
+
+def test_ranking_extremes_uses_facade(full_app_module, monkeypatch):
+    mock_load = MagicMock(return_value=Ranking(_RANKING_EXTREMES_PROFILES))
+    monkeypatch.setattr(full_app_module.Ranking, "load", mock_load)
+
+    best, worst, total = full_app_module._ranking_extremes(n=3)
+
+    mock_load.assert_called_once_with()
+    assert total == 7  # bfs 8 has no score and is excluded
+    assert best == [
+        {"rank": 1, "name": "Overcap", "kanton": "ZH", "bfs_number": 1, "score": 100.0},
+        {"rank": 2, "name": "G2", "kanton": "ZH", "bfs_number": 2, "score": 95.0},
+        {"rank": 3, "name": "G3", "kanton": "ZH", "bfs_number": 3, "score": 90.0},
+    ]
+    assert worst == [
+        {"rank": 7, "name": "G7", "kanton": "ZH", "bfs_number": 7, "score": 70.0},
+        {"rank": 6, "name": "G6", "kanton": "ZH", "bfs_number": 6, "score": 75.0},
+        {"rank": 5, "name": "G5", "kanton": "ZH", "bfs_number": 5, "score": 80.0},
+    ]
+
+
+def test_ranking_extremes_empty_when_too_few_scored(full_app_module, monkeypatch):
+    profiles = _RANKING_EXTREMES_PROFILES[:2]
+    mock_load = MagicMock(return_value=Ranking(profiles))
+    monkeypatch.setattr(full_app_module.Ranking, "load", mock_load)
+
+    best, worst, total = full_app_module._ranking_extremes(n=3)
+
+    assert (best, worst, total) == ([], [], 2)
+
+
+def test_ranking_extremes_falls_back_on_load_failure(full_app_module, monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("db down")
+
+    monkeypatch.setattr(full_app_module.Ranking, "load", _boom)
+
+    best, worst, total = full_app_module._ranking_extremes(n=3)
+
+    assert (best, worst, total) == ([], [], 0)

--- a/tests/test_rangliste.py
+++ b/tests/test_rangliste.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock
 
 from flask import Flask
 
+import pv_ranking
 import rangliste as rangliste_module
 from ranking import Ranking
 
@@ -137,7 +138,11 @@ MOVERS = [
 def _make_movers_client(monkeypatch, rows=MOVERS):
     mock_ranking = MagicMock()
     instance = mock_ranking.return_value
-    instance.movers.return_value = rows
+    instance.movers.side_effect = (
+        lambda mover_rows=None, kanton=None, size=None, density=None: pv_ranking.filter_league(
+            rows, kanton=kanton, size=size, density=density
+        )
+    )
     monkeypatch.setattr(rangliste_module, "Ranking", mock_ranking)
     app = Flask(__name__, template_folder=os.path.join(PROJECT_ROOT, "templates"))
     app.config["TESTING"] = True
@@ -150,7 +155,7 @@ def test_movers_tab_renders_delta(monkeypatch):
     resp = client.get("/rangliste/fortschritte")
     assert resp.status_code == 200
     mock_ranking.assert_called_once_with([])
-    instance.movers.assert_called_once_with()
+    instance.movers.assert_called_once_with(kanton=None, size=None, density=None)
     html = resp.data.decode("utf-8", errors="ignore")
     assert "Grösste Fortschritte" in html
     assert "+8.50 Pkt" in html

--- a/tests/test_rangliste.py
+++ b/tests/test_rangliste.py
@@ -139,8 +139,8 @@ def _make_movers_client(monkeypatch, rows=MOVERS):
     mock_ranking = MagicMock()
     instance = mock_ranking.return_value
     instance.movers.side_effect = (
-        lambda mover_rows=None, kanton=None, size=None, density=None: pv_ranking.filter_league(
-            rows, kanton=kanton, size=size, density=density
+        lambda mover_rows=None, kanton=None, size=None, density=None: (
+            pv_ranking.filter_league(rows, kanton=kanton, size=size, density=density)
         )
     )
     monkeypatch.setattr(rangliste_module, "Ranking", mock_ranking)

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -4,11 +4,19 @@
 Pure unit tests: no Flask app, no real database.
 """
 
+import os
 from unittest.mock import patch
 
 import pv_ranking
 import ranking
 from store import ranking as store_ranking
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _read_source(name):
+    with open(os.path.join(PROJECT_ROOT, name), encoding="utf-8") as handle:
+        return handle.read()
 
 
 class TestRanking:
@@ -298,6 +306,37 @@ class TestRankingMovers:
         injected = [{"bfs_number": 2, "delta": 3.0}]
         assert r.movers(mover_rows=injected) is injected
 
+    def test_movers_applies_kanton_filter(self):
+        rows = [
+            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
+            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+        ]
+        r = ranking.Ranking([])
+        result = r.movers(mover_rows=rows, kanton="ZH")
+        assert result == [rows[1]]
+
+    def test_movers_applies_size_and_density_filters(self):
+        rows = [
+            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
+            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+        ]
+        r = ranking.Ranking([])
+        assert r.movers(mover_rows=rows, size="large") == [rows[1]]
+        assert r.movers(mover_rows=rows, density="low") == [rows[0]]
+
+    def test_movers_filters_store_backed_rows_too(self):
+        rows = [
+            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
+            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+        ]
+        with patch.object(store_ranking, "get_pv_movers") as mock_get:
+            mock_get.return_value = rows
+            r = ranking.Ranking([])
+            result = r.movers(kanton="ZH")
+
+            mock_get.assert_called_once_with()
+            assert result == [rows[1]]
+
 
 class TestRankingBadgeSvg:
     def test_badge_svg_delegates_to_pv_badge(self):
@@ -359,3 +398,13 @@ class TestRankingOgCardSvg:
 
             mock_og.assert_called_once_with("A", "AG", None, None, None)
             assert result == "<svg>og</svg>"
+
+
+class TestRankingSeamBoundary:
+    """Issue #210: app.py und rangliste.py duerfen pv_ranking nicht mehr direkt nutzen."""
+
+    def test_app_does_not_import_pv_ranking(self):
+        assert "import pv_ranking" not in _read_source("app.py")
+
+    def test_rangliste_does_not_import_pv_ranking(self):
+        assert "import pv_ranking" not in _read_source("rangliste.py")

--- a/tests/test_ranking.py
+++ b/tests/test_ranking.py
@@ -308,8 +308,18 @@ class TestRankingMovers:
 
     def test_movers_applies_kanton_filter(self):
         rows = [
-            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
-            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+            {
+                "bfs_number": 1,
+                "kanton": "AG",
+                "population": 3000,
+                "density_per_km2": 200,
+            },
+            {
+                "bfs_number": 2,
+                "kanton": "ZH",
+                "population": 30000,
+                "density_per_km2": 1500,
+            },
         ]
         r = ranking.Ranking([])
         result = r.movers(mover_rows=rows, kanton="ZH")
@@ -317,8 +327,18 @@ class TestRankingMovers:
 
     def test_movers_applies_size_and_density_filters(self):
         rows = [
-            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
-            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+            {
+                "bfs_number": 1,
+                "kanton": "AG",
+                "population": 3000,
+                "density_per_km2": 200,
+            },
+            {
+                "bfs_number": 2,
+                "kanton": "ZH",
+                "population": 30000,
+                "density_per_km2": 1500,
+            },
         ]
         r = ranking.Ranking([])
         assert r.movers(mover_rows=rows, size="large") == [rows[1]]
@@ -326,8 +346,18 @@ class TestRankingMovers:
 
     def test_movers_filters_store_backed_rows_too(self):
         rows = [
-            {"bfs_number": 1, "kanton": "AG", "population": 3000, "density_per_km2": 200},
-            {"bfs_number": 2, "kanton": "ZH", "population": 30000, "density_per_km2": 1500},
+            {
+                "bfs_number": 1,
+                "kanton": "AG",
+                "population": 3000,
+                "density_per_km2": 200,
+            },
+            {
+                "bfs_number": 2,
+                "kanton": "ZH",
+                "population": 30000,
+                "density_per_km2": 1500,
+            },
         ]
         with patch.object(store_ranking, "get_pv_movers") as mock_get:
             mock_get.return_value = rows


### PR DESCRIPTION
Closes #210.

Routes the remaining homepage, comparison and mover calculations through the `Ranking` facade and deletes the direct `pv_ranking` bypasses.

## Changes

- `app.py::_ranking_extremes` uses `Ranking.load().national()` and reads the facade's `display_score` instead of calling `pv_ranking.assign_ranks` / `capped_score`. Presentational shaping stays in the view. Fallback logging preserved.
- `rangliste.py::vergleich` uses `ranking.capped_score(...)`.
- `rangliste.py::movers` passes kanton/size/density into `Ranking.movers()`; the standalone `filter_league` call is gone.
- `Ranking.movers()` gains `kanton`/`size`/`density` and applies `filter_league` itself, matching `standings`.
- `import pv_ranking` removed from `app.py` and `rangliste.py`. `pv_ranking` stays an internal collaborator of `ranking.py` only.

No new module, no new helper class, no second ranking abstraction.

## Tests

Parity tests added first (red), then implementation:

- `tests/test_ranking.py::TestRankingMovers::test_movers_applies_kanton_filter`
- `::test_movers_applies_size_and_density_filters`
- `::test_movers_filters_store_backed_rows_too`
- `tests/test_ranking.py::TestRankingSeamBoundary::test_app_does_not_import_pv_ranking`
- `::test_rangliste_does_not_import_pv_ranking`
- `tests/test_app_organic_routes.py::test_ranking_extremes_uses_facade`
- `::test_ranking_extremes_empty_when_too_few_scored`
- `::test_ranking_extremes_falls_back_on_load_failure`

Ordering, ties, score caps and displayed values unchanged.

`scripts/tdd_cycle.sh gate`: 724 passed, 11 skipped; ruff check and ruff format clean.