### PR TITLE
[codex] Deepen registration orchestration (#213)

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,8 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 # ruff: noqa: E402
 import os
-import time
-import uuid
 import math
 import json
 import hashlib
@@ -63,6 +61,8 @@ from email_utils import send_email
 import data_enricher
 import ml_models
 import security_utils
+import registration
+from registration import CONSENT_VERSION, parse_consents  # noqa: F401
 
 # --- PostgreSQL Database ---
 import database as db
@@ -230,33 +230,6 @@ def log_security_event(event_type, details, level="INFO"):
 def apply_basic_security_headers(response):
     response.headers["X-Content-Type-Options"] = "nosniff"
     return response
-
-
-# --- Consent Helpers ---
-CONSENT_VERSION = "2026-01-01"
-
-
-def _coerce_bool(value):
-    if isinstance(value, bool):
-        return value
-    if value is None:
-        return False
-    if isinstance(value, (int, float)):
-        return value != 0
-    if isinstance(value, str):
-        return value.strip().lower() in ("1", "true", "yes", "ja", "on")
-    return False
-
-
-def parse_consents(raw_consents):
-    consents = raw_consents or {}
-    return {
-        "share_with_neighbors": _coerce_bool(consents.get("share_with_neighbors")),
-        "share_with_utility": _coerce_bool(consents.get("share_with_utility")),
-        "updates_opt_in": _coerce_bool(consents.get("updates_opt_in")),
-        "consent_version": consents.get("consent_version") or CONSENT_VERSION,
-        "consent_timestamp": time.time(),
-    }
 
 
 # --- Anonymity ---
@@ -984,226 +957,44 @@ def api_check_potential():
 
 
 # --- Registration ---
-@app.route("/api/register_anonymous", methods=["POST"])
-@limiter.limit("5 per minute") if limiter else lambda f: f
-def api_register_anonymous():
+def _registration_response(user_type):
     if not request.json:
         return jsonify({"error": "Keine Daten empfangen."}), 400
     is_valid_size, size_error = security_utils.check_request_size(request)
     if not is_valid_size:
         return jsonify({"error": size_error}), 413
 
-    phone = (request.json.get("phone") or "").strip()
-    email = (request.json.get("email") or "").strip()
-    profile = request.json.get("profile")
-    referral_code = (request.json.get("referral_code") or "").strip()
-
-    referrer_id = None
-    if referral_code:
-        referrer = db.get_building_by_referral_code(referral_code)
-        if referrer:
-            referrer_id = referrer.get("building_id")
-
-    is_valid_email, normalized_email, email_error = (
-        security_utils.validate_email_address(email)
-    )
-    if not is_valid_email:
-        return jsonify({"error": email_error}), 400
-    email = normalized_email
-
-    if phone:
-        is_valid_phone, normalized_phone, phone_error = security_utils.validate_phone(
-            phone
-        )
-        if not is_valid_phone:
-            return jsonify({"error": phone_error}), 400
-        phone = normalized_phone
-
-    if not profile:
-        return jsonify({"error": "Profildaten fehlen."}), 400
-    building_id = profile.get("building_id")
-    is_valid_id, id_error = security_utils.validate_building_id(building_id)
-    if not is_valid_id:
-        return jsonify({"error": id_error}), 400
-
-    lat = profile.get("lat")
-    lon = profile.get("lon")
-    is_valid_coords, coords_error = security_utils.validate_coordinates(lat, lon)
-    if not is_valid_coords:
-        return jsonify({"error": coords_error}), 400
-
-    consents = parse_consents(request.json.get("consents"))
-    if not consents.get("share_with_neighbors") or not consents.get(
-        "share_with_utility"
-    ):
-        return jsonify({"error": "Bitte stimmen Sie der Datenweitergabe zu."}), 400
-
     city_id = g.tenant.get("territory", "zurich") if hasattr(g, "tenant") else "zurich"
-
-    # Save to PostgreSQL
-    db.save_building(
-        building_id=building_id,
-        email=email,
-        profile=profile,
-        consents=consents,
-        user_type="anonymous",
-        phone=phone,
-        referrer_id=referrer_id,
-        city_id=city_id,
+    deps = registration.RegistrationDeps(
+        db=db,
+        security=security_utils,
+        app_base_url=APP_BASE_URL,
+        thread=threading.Thread,
+        send_confirmation_email=send_confirmation_email,
+        run_full_ml_task=run_full_ml_task,
+        schedule_sequence_for_user=email_automation.schedule_sequence_for_user,
+        find_provisional_matches=find_provisional_matches,
+        collect_building_locations=collect_building_locations,
     )
-
-    # Create unsubscribe token
-    unsub_token = str(uuid.uuid4())
-    db.save_token(unsub_token, building_id, "unsubscribe")
-    unsubscribe_url = f"{APP_BASE_URL}/unsubscribe/{unsub_token}"
-
-    # Background tasks
-    threading.Thread(
-        target=send_confirmation_email,
-        args=(email, unsubscribe_url, building_id, profile.get("address", "")),
-        daemon=True,
-    ).start()
-    threading.Thread(
-        target=run_full_ml_task, args=(building_id, city_id), daemon=True
-    ).start()
-    threading.Thread(
-        target=email_automation.schedule_sequence_for_user,
-        args=(building_id, email),
-        daemon=True,
-    ).start()
-
-    db.track_event(
-        "registration", building_id, {"type": "anonymous", "city_id": city_id}
-    )
-
-    # Build response
-    cluster_info = find_provisional_matches(profile)
-    locations = collect_building_locations(
-        city_id=city_id, exclude_building_id=building_id
-    )
-    referral_link = None
-    ref_code = db.get_referral_code(building_id)
-    if ref_code:
-        referral_link = f"{APP_BASE_URL}/?ref={ref_code}"
-
-    payload = {
-        "buildings": locations,
-        "match_found": bool(cluster_info),
-        "verification_email_sent": True,
-        "referral_link": referral_link,
-    }
-    if cluster_info:
-        payload["cluster_info"] = cluster_info
+    try:
+        payload = registration.register(
+            request.json, city_id=city_id, user_type=user_type, deps=deps
+        )
+    except registration.RegistrationError as error:
+        return jsonify({"error": error.message}), error.status
     return jsonify(payload)
+
+
+@app.route("/api/register_anonymous", methods=["POST"])
+@limiter.limit("5 per minute") if limiter else lambda f: f
+def api_register_anonymous():
+    return _registration_response("anonymous")
 
 
 @app.route("/api/register_full", methods=["POST"])
 @limiter.limit("5 per minute") if limiter else lambda f: f
 def api_register_full():
-    if not request.json:
-        return jsonify({"error": "Keine Daten empfangen."}), 400
-    is_valid_size, size_error = security_utils.check_request_size(request)
-    if not is_valid_size:
-        return jsonify({"error": size_error}), 413
-
-    profile = request.json.get("profile")
-    email = (request.json.get("email") or "").strip()
-    phone = (request.json.get("phone") or "").strip()
-    referral_code = (request.json.get("referral_code") or "").strip()
-
-    referrer_id = None
-    if referral_code:
-        referrer = db.get_building_by_referral_code(referral_code)
-        if referrer:
-            referrer_id = referrer.get("building_id")
-
-    is_valid_email, normalized_email, email_error = (
-        security_utils.validate_email_address(email)
-    )
-    if not is_valid_email:
-        return jsonify({"error": email_error}), 400
-    email = normalized_email
-
-    if phone:
-        is_valid_phone, normalized_phone, phone_error = security_utils.validate_phone(
-            phone
-        )
-        if not is_valid_phone:
-            return jsonify({"error": phone_error}), 400
-        phone = normalized_phone
-
-    if not profile:
-        return jsonify({"error": "Profildaten fehlen."}), 400
-    building_id = profile.get("building_id")
-    is_valid_id, id_error = security_utils.validate_building_id(building_id)
-    if not is_valid_id:
-        return jsonify({"error": id_error}), 400
-
-    lat = profile.get("lat")
-    lon = profile.get("lon")
-    is_valid_coords, coords_error = security_utils.validate_coordinates(lat, lon)
-    if not is_valid_coords:
-        return jsonify({"error": coords_error}), 400
-
-    consents = parse_consents(request.json.get("consents"))
-    if not consents.get("share_with_neighbors") or not consents.get(
-        "share_with_utility"
-    ):
-        return jsonify({"error": "Bitte stimmen Sie der Datenweitergabe zu."}), 400
-
-    city_id = g.tenant.get("territory", "zurich") if hasattr(g, "tenant") else "zurich"
-
-    db.save_building(
-        building_id=building_id,
-        email=email,
-        profile=profile,
-        consents=consents,
-        user_type="registered",
-        phone=phone,
-        referrer_id=referrer_id,
-        city_id=city_id,
-    )
-
-    unsub_token = str(uuid.uuid4())
-    db.save_token(unsub_token, building_id, "unsubscribe")
-    unsubscribe_url = f"{APP_BASE_URL}/unsubscribe/{unsub_token}"
-
-    threading.Thread(
-        target=send_confirmation_email,
-        args=(email, unsubscribe_url, building_id, profile.get("address", "")),
-        daemon=True,
-    ).start()
-    threading.Thread(
-        target=run_full_ml_task, args=(building_id, city_id), daemon=True
-    ).start()
-    threading.Thread(
-        target=email_automation.schedule_sequence_for_user,
-        args=(building_id, email),
-        daemon=True,
-    ).start()
-
-    db.track_event(
-        "registration", building_id, {"type": "registered", "city_id": city_id}
-    )
-
-    cluster_info = find_provisional_matches(profile)
-    locations = collect_building_locations(
-        city_id=city_id, exclude_building_id=building_id
-    )
-    referral_link = None
-    ref_code = db.get_referral_code(building_id)
-    if ref_code:
-        referral_link = f"{APP_BASE_URL}/?ref={ref_code}"
-
-    payload = {
-        "buildings": locations,
-        "match_found": bool(cluster_info),
-        "verification_email_sent": True,
-        "referral_link": referral_link,
-    }
-    if cluster_info:
-        payload["cluster_info"] = cluster_info
-    return jsonify(payload)
+    return _registration_response("registered")
 
 
 # --- Meter Data Upload ---

--- a/registration.py
+++ b/registration.py
@@ -1,0 +1,154 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Registration validation and orchestration."""
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+CONSENT_VERSION = "2026-01-01"
+
+
+@dataclass(frozen=True, kw_only=True)
+class RegistrationDeps:
+    db: Any
+    security: Any
+    app_base_url: str
+    thread: Callable[..., Any] = threading.Thread
+    send_confirmation_email: Callable[..., Any]
+    run_full_ml_task: Callable[..., Any]
+    schedule_sequence_for_user: Callable[..., Any]
+    find_provisional_matches: Callable[..., Any]
+    collect_building_locations: Callable[..., Any]
+
+
+class RegistrationError(Exception):
+    def __init__(self, message, status=400):
+        super().__init__(message)
+        self.message = message
+        self.status = status
+
+
+def _coerce_bool(value):
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "ja", "on")
+    return False
+
+
+def parse_consents(raw_consents):
+    consents = raw_consents or {}
+    return {
+        "share_with_neighbors": _coerce_bool(consents.get("share_with_neighbors")),
+        "share_with_utility": _coerce_bool(consents.get("share_with_utility")),
+        "updates_opt_in": _coerce_bool(consents.get("updates_opt_in")),
+        "consent_version": consents.get("consent_version") or CONSENT_VERSION,
+        "consent_timestamp": time.time(),
+    }
+
+
+def register(data, *, city_id, user_type, deps: RegistrationDeps):
+    db = deps.db
+    security = deps.security
+    phone = (data.get("phone") or "").strip()
+    email = (data.get("email") or "").strip()
+    profile = data.get("profile")
+    referral_code = (data.get("referral_code") or "").strip()
+
+    referrer_id = None
+    if referral_code:
+        referrer = db.get_building_by_referral_code(referral_code)
+        if referrer:
+            referrer_id = referrer.get("building_id")
+
+    is_valid_email, normalized_email, email_error = security.validate_email_address(
+        email
+    )
+    if not is_valid_email:
+        raise RegistrationError(email_error)
+    email = normalized_email
+
+    if phone:
+        is_valid_phone, normalized_phone, phone_error = security.validate_phone(phone)
+        if not is_valid_phone:
+            raise RegistrationError(phone_error)
+        phone = normalized_phone
+
+    if not profile:
+        raise RegistrationError("Profildaten fehlen.")
+    building_id = profile.get("building_id")
+    is_valid_id, id_error = security.validate_building_id(building_id)
+    if not is_valid_id:
+        raise RegistrationError(id_error)
+
+    lat = profile.get("lat")
+    lon = profile.get("lon")
+    is_valid_coords, coords_error = security.validate_coordinates(lat, lon)
+    if not is_valid_coords:
+        raise RegistrationError(coords_error)
+
+    consents = parse_consents(data.get("consents"))
+    if not consents.get("share_with_neighbors") or not consents.get(
+        "share_with_utility"
+    ):
+        raise RegistrationError("Bitte stimmen Sie der Datenweitergabe zu.")
+
+    db.save_building(
+        building_id=building_id,
+        email=email,
+        profile=profile,
+        consents=consents,
+        user_type=user_type,
+        phone=phone,
+        referrer_id=referrer_id,
+        city_id=city_id,
+    )
+
+    unsub_token = str(uuid.uuid4())
+    db.save_token(unsub_token, building_id, "unsubscribe")
+    unsubscribe_url = f"{deps.app_base_url}/unsubscribe/{unsub_token}"
+
+    thread = deps.thread
+    thread(
+        target=deps.send_confirmation_email,
+        args=(email, unsubscribe_url, building_id, profile.get("address", "")),
+        daemon=True,
+    ).start()
+    thread(
+        target=deps.run_full_ml_task,
+        args=(building_id, city_id),
+        daemon=True,
+    ).start()
+    thread(
+        target=deps.schedule_sequence_for_user,
+        args=(building_id, email),
+        daemon=True,
+    ).start()
+
+    db.track_event("registration", building_id, {"type": user_type, "city_id": city_id})
+
+    cluster_info = deps.find_provisional_matches(profile)
+    locations = deps.collect_building_locations(
+        city_id=city_id, exclude_building_id=building_id
+    )
+    referral_link = None
+    ref_code = db.get_referral_code(building_id)
+    if ref_code:
+        referral_link = f"{deps.app_base_url}/?ref={ref_code}"
+
+    payload = {
+        "buildings": locations,
+        "match_found": bool(cluster_info),
+        "verification_email_sent": True,
+        "referral_link": referral_link,
+    }
+    if cluster_info:
+        payload["cluster_info"] = cluster_info
+    return payload

--- a/tests/test_registration_contract.py
+++ b/tests/test_registration_contract.py
@@ -1,0 +1,261 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""HTTP contract tests for both registration routes."""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(scope="module")
+def app_module():
+    with patch.dict(
+        os.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "CRON_SECRET": "test-cron-secret",
+            "APP_BASE_URL": "http://localhost:5003",
+        },
+    ):
+        with (
+            patch("database.is_db_available", return_value=True),
+            patch("database._connection_pool", MagicMock()),
+        ):
+            import app
+
+            app = importlib.reload(app)
+            if app.limiter:
+                app.limiter.enabled = False
+            hooks = list(app.app.before_request_funcs.get(None, []))
+            app.app.before_request_funcs[None] = [
+                hook
+                for hook in hooks
+                if not (
+                    getattr(hook, "__module__", "").startswith("flask_limiter")
+                    or getattr(hook, "__name__", "") == "_check_request_limit"
+                )
+            ]
+            yield app
+            app.app.before_request_funcs[None] = hooks
+
+
+@pytest.fixture
+def registration(app_module, monkeypatch):
+    threads = []
+
+    class FakeThread:
+        def __init__(self, *, target, args, daemon):
+            self.target = target
+            self.args = args
+            self.daemon = daemon
+            self.started = False
+            threads.append(self)
+
+        def start(self):
+            self.started = True
+
+    db = app_module.db
+    for name in (
+        "get_building_by_referral_code",
+        "save_building",
+        "save_token",
+        "track_event",
+        "get_referral_code",
+    ):
+        monkeypatch.setattr(db, name, MagicMock())
+    db.get_referral_code.return_value = "REFER"
+
+    monkeypatch.setattr(
+        app_module.security_utils,
+        "check_request_size",
+        MagicMock(return_value=(True, None)),
+    )
+    monkeypatch.setattr(
+        app_module.security_utils,
+        "validate_email_address",
+        MagicMock(return_value=(True, "user@example.ch", None)),
+    )
+    monkeypatch.setattr(
+        app_module.security_utils,
+        "validate_phone",
+        MagicMock(return_value=(True, "+41791234567", None)),
+    )
+    monkeypatch.setattr(
+        app_module.security_utils,
+        "validate_building_id",
+        MagicMock(return_value=(True, None)),
+    )
+    monkeypatch.setattr(
+        app_module.security_utils,
+        "validate_coordinates",
+        MagicMock(return_value=(True, None)),
+    )
+    monkeypatch.setattr(app_module.threading, "Thread", FakeThread)
+    monkeypatch.setattr(app_module, "send_confirmation_email", MagicMock())
+    monkeypatch.setattr(app_module, "run_full_ml_task", MagicMock())
+    monkeypatch.setattr(app_module, "find_provisional_matches", MagicMock())
+    app_module.find_provisional_matches.return_value = None
+    monkeypatch.setattr(
+        app_module,
+        "collect_building_locations",
+        MagicMock(return_value=[{"lat": 47.1, "lon": 8.1, "type": "anonymous"}]),
+    )
+    monkeypatch.setattr(
+        app_module.email_automation, "schedule_sequence_for_user", MagicMock()
+    )
+
+    return app_module.app.test_client(), db, threads
+
+
+def valid_data(**updates):
+    data = {
+        "email": " user@example.ch ",
+        "phone": " 079 123 45 67 ",
+        "profile": {
+            "building_id": "building-1",
+            "lat": 47.1,
+            "lon": 8.1,
+            "address": "Badenerstrasse 1",
+        },
+        "consents": {
+            "share_with_neighbors": True,
+            "share_with_utility": True,
+        },
+    }
+    data.update(updates)
+    return data
+
+
+@pytest.mark.parametrize("url", ["/api/register_anonymous", "/api/register_full"])
+def test_registration_empty_json_contract(registration, url):
+    client, _, _ = registration
+    response = client.post(url, json={})
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Keine Daten empfangen."}
+
+
+@pytest.mark.parametrize("url", ["/api/register_anonymous", "/api/register_full"])
+def test_registration_request_size_contract(registration, app_module, url):
+    client, _, _ = registration
+    app_module.security_utils.check_request_size.return_value = (False, "Zu gross.")
+    response = client.post(url, json=valid_data())
+    assert response.status_code == 413
+    assert response.get_json() == {"error": "Zu gross."}
+
+
+@pytest.mark.parametrize("url", ["/api/register_anonymous", "/api/register_full"])
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("email", "Ungültige E-Mail."),
+        ("phone", "Ungültige Telefonnummer."),
+        ("profile", "Profildaten fehlen."),
+        ("building_id", "Ungültige Gebäude-ID."),
+        ("coordinates", "Ungültige Koordinaten."),
+        ("consents", "Bitte stimmen Sie der Datenweitergabe zu."),
+    ],
+)
+def test_registration_400_contracts(registration, app_module, url, case, message):
+    client, _, _ = registration
+    data = valid_data()
+    if case == "email":
+        app_module.security_utils.validate_email_address.return_value = (
+            False,
+            None,
+            message,
+        )
+    elif case == "phone":
+        app_module.security_utils.validate_phone.return_value = (False, None, message)
+    elif case == "profile":
+        data["profile"] = None
+    elif case == "building_id":
+        app_module.security_utils.validate_building_id.return_value = (False, message)
+    elif case == "coordinates":
+        app_module.security_utils.validate_coordinates.return_value = (False, message)
+    else:
+        data["consents"]["share_with_utility"] = False
+
+    response = client.post(url, json=data)
+    assert response.status_code == 400
+    assert response.get_json() == {"error": message}
+
+
+@pytest.mark.parametrize(
+    ("url", "user_type"),
+    [
+        ("/api/register_anonymous", "anonymous"),
+        ("/api/register_full", "registered"),
+    ],
+)
+@pytest.mark.parametrize("matched", [False, True])
+def test_registration_happy_path_contract(
+    registration, app_module, url, user_type, matched
+):
+    client, db, threads = registration
+    cluster = {"community_id": 7} if matched else None
+    app_module.find_provisional_matches.return_value = cluster
+    db.get_building_by_referral_code.return_value = {"building_id": "referrer-1"}
+
+    response = client.post(url, json=valid_data(referral_code=" KNOWN "))
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert set(payload) == {
+        "buildings",
+        "match_found",
+        "verification_email_sent",
+        "referral_link",
+    } | ({"cluster_info"} if matched else set())
+    assert payload["match_found"] is matched
+    assert payload["referral_link"] == "http://localhost:5003/?ref=REFER"
+    assert payload.get("cluster_info") == cluster
+    db.get_building_by_referral_code.assert_called_once_with("KNOWN")
+    db.save_building.assert_called_once_with(
+        building_id="building-1",
+        email="user@example.ch",
+        profile=valid_data()["profile"],
+        consents=db.save_building.call_args.kwargs["consents"],
+        user_type=user_type,
+        phone="+41791234567",
+        referrer_id="referrer-1",
+        city_id="zurich",
+    )
+    db.track_event.assert_called_once_with(
+        "registration", "building-1", {"type": user_type, "city_id": "zurich"}
+    )
+    assert [
+        (thread.target, thread.args, thread.daemon, thread.started)
+        for thread in threads
+    ] == [
+        (
+            app_module.send_confirmation_email,
+            (
+                "user@example.ch",
+                db.save_token.call_args.args[0].join(
+                    ["http://localhost:5003/unsubscribe/", ""]
+                ),
+                "building-1",
+                "Badenerstrasse 1",
+            ),
+            True,
+            True,
+        ),
+        (app_module.run_full_ml_task, ("building-1", "zurich"), True, True),
+        (
+            app_module.email_automation.schedule_sequence_for_user,
+            ("building-1", "user@example.ch"),
+            True,
+            True,
+        ),
+    ]
+
+
+@pytest.mark.parametrize("url", ["/api/register_anonymous", "/api/register_full"])
+def test_registration_unknown_referral_is_ignored(registration, url):
+    client, db, _ = registration
+    db.get_building_by_referral_code.return_value = None
+    response = client.post(url, json=valid_data(referral_code="UNKNOWN"))
+    assert response.status_code == 200
+    assert db.save_building.call_args.kwargs["referrer_id"] is None


### PR DESCRIPTION
Closes #213.

Moves registration validation and orchestration out of `app.py` into a new `registration.py`, with no HTTP contract change.

## Before

`/api/register_anonymous` and `/api/register_full` were two near-identical 110-line routes. They differed in exactly two places: the `user_type` handed to `db.save_building` and the `type` field in the tracked event. Everything else, roughly 100 lines of validation, persistence, token creation, background tasks and response assembly, was duplicated verbatim.

## After

`registration.register(data, city_id=..., user_type=..., deps=...)` owns steps 3 through 17 of the old routes: referral resolution, email and phone validation, profile and coordinate checks, consent parsing and enforcement, `save_building`, unsubscribe token creation, the three background threads, event tracking and response assembly. One path, parameterised by `user_type`.

Both routes are now thin wrappers that do only what belongs in Flask: the empty-JSON check, the request size check, resolving `city_id` from the tenant, building the dependency bundle, and mapping the result to `jsonify`. The rate limit decorators stay on the routes.

Failures raise `RegistrationError(message, status)`, which the route catches and maps. Success returns a plain payload dict, so the module has no Flask dependency at all.

`CONSENT_VERSION`, `parse_consents` and `_coerce_bool` moved into the module. `app.py` re-exports the first two so existing importers keep working.

## Avoiding the import cycle

`send_confirmation_email`, `run_full_ml_task`, `find_provisional_matches` and `collect_building_locations` live in `app.py`, so `registration.py` must never import `app`. They are injected instead, through a frozen `RegistrationDeps` dataclass built by the route at call time. Resolving at call time keeps every existing test that patches these on the `app` module working untouched. `threading.Thread` is injected the same way with a real default, which is what makes the background tasks assertable without running them.

A typed dataclass rather than a dict: nine loosely-keyed strings in a bag is a seam that fails at runtime on a typo.

## Tests

22 mocked contract cases in `tests/test_registration_contract.py`, written and made green against the ORIGINAL `app.py` first, then re-run unchanged after the refactor. They pin every 400 message, the 413 path, the happy-path payload keys, `cluster_info` appearing only on a match, the differing `user_type` and event type between the two routes, referral resolution including the unknown-code case, and that all three background tasks start with the right arguments.

No existing test needed editing. That was the acceptance bar for this move.

`scripts/tdd_cycle.sh gate`: 759 passed, 11 skipped; ruff check and ruff format clean.

Net effect on `app.py`: 235 lines removed, 26 added.