### PR TITLE
chore(deps): bump scipy to 1.17.1 (Python 3.11 compatible)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==3.1.3
 pandas==3.0.3
-numpy==1.26.2
-scipy==1.11.4
+numpy==1.26.4
+scipy==1.17.1
 scikit-learn==1.9.0
 
 # Security dependencies


### PR DESCRIPTION
Replaces dependabot PR #147, which could never merge.

## Why #147 failed

Dependabot proposed `scipy==1.18.0`. That release requires Python >=3.12, and this project targets 3.11 (`.github/workflows/lint.yml` and `deploy.yml` both pin `python-version: "3.11"`). CI failed at install:

```
ERROR: Ignored the following versions that require a different python version: 1.18.0 Requires-Python >=3.12
ERROR: No matching distribution found for scipy==1.18.0
```

Dependabot will keep proposing 1.18 until scipy is on a version it considers current, so this bumps to the newest release that actually supports 3.11.

## This PR

- `scipy` 1.11.4 to 1.17.1, the newest release declaring `Requires-Python: >=3.11`
- `numpy` 1.26.2 to 1.26.4, because scipy 1.17.1 requires `numpy>=1.26.4`. Patch-level bump, no API change.

`pip install --dry-run -r requirements.txt` resolves cleanly with `pandas==3.0.3` unchanged.

scipy is used in one optional place: the `ConvexHull` fallback for cluster polygons in `app.py`, guarded by `HAS_SCIPY`, with a bounding-box fallback when it is absent.

`scripts/tdd_cycle.sh gate`: 804 passed, 11 skipped; ruff check and ruff format clean.