### PR TITLE
[codex] Add auditable draft billing periods

### DIFF
--- a/billing_engine.py
+++ b/billing_engine.py
@@ -21,6 +21,10 @@ def _money(value):
     return Decimal(str(value)).quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
 
 
+def _priced_amount(quantity, unit_price):
+    return _money(Decimal(str(quantity)) * Decimal(str(unit_price)))
+
+
 def allocate_energy(production, consumption, model="proportional"):
     """Allocate solar production to consumers per 15-min interval.
 
@@ -170,7 +174,9 @@ def generate_billing_summary(
                     "item_type": "consumer_charge",
                     "quantity_kwh": quantity,
                     "unit_price_chf_per_kwh": internal_price_per_kwh,
-                    "amount_chf": float(_money(quantity * internal_price_per_kwh)),
+                    "amount_chf": float(
+                        _priced_amount(quantity, internal_price_per_kwh)
+                    ),
                 }
             )
 
@@ -185,7 +191,7 @@ def generate_billing_summary(
         producer_ids = list(credited.index)
         for producer_id in producer_ids:
             quantity = round(float(credited[producer_id]), 6)
-            amount = _money(quantity * internal_price_per_kwh)
+            amount = _priced_amount(quantity, internal_price_per_kwh)
             credited_total += amount
             line_items.append(
                 {

--- a/billing_engine.py
+++ b/billing_engine.py
@@ -8,7 +8,9 @@ Implements Art. 17d/17e StromVG allocation models:
 """
 
 from decimal import ROUND_HALF_UP, Decimal
+from math import isfinite
 
+import numpy as np
 import pandas as pd
 
 DISCOUNT_SAME_LEVEL = 0.40
@@ -106,15 +108,18 @@ def generate_billing_summary(
         dict with total_production_kwh, total_allocated_kwh,
         total_network_discount_chf, participants (list of per-participant summaries)
     """
-    if grid_fee_per_kwh < 0 or internal_price_per_kwh < 0:
-        raise ValueError("Billing prices must not be negative")
+    if not all(
+        isfinite(price) and price >= 0
+        for price in (grid_fee_per_kwh, internal_price_per_kwh)
+    ):
+        raise ValueError("Billing prices must be finite and non-negative")
     if network_level not in {"same", "cross"}:
         raise ValueError("network_level must be 'same' or 'cross'")
     if distribution_model not in {"proportional", "einfach"}:
         raise ValueError("Unsupported distribution model")
     if (
-        pd.isna(production).to_numpy().any()
-        or pd.isna(consumption).to_numpy().any()
+        not np.isfinite(production.to_numpy()).all()
+        or not np.isfinite(consumption.to_numpy()).all()
         or (production < 0).to_numpy().any()
         or (consumption < 0).to_numpy().any()
     ):

--- a/billing_engine.py
+++ b/billing_engine.py
@@ -163,13 +163,14 @@ def generate_billing_summary(
             }
         )
         if producer_production is not None:
+            quantity = round(alloc_kwh, 6)
             line_items.append(
                 {
                     "participant_id": col,
                     "item_type": "consumer_charge",
-                    "quantity_kwh": round(alloc_kwh, 6),
+                    "quantity_kwh": quantity,
                     "unit_price_chf_per_kwh": internal_price_per_kwh,
-                    "amount_chf": float(_money(alloc_kwh * internal_price_per_kwh)),
+                    "amount_chf": float(_money(quantity * internal_price_per_kwh)),
                 }
             )
 
@@ -182,19 +183,29 @@ def generate_billing_summary(
         charge_total = sum(_money(item["amount_chf"]) for item in line_items)
         credited_total = Decimal(0)
         producer_ids = list(credited.index)
-        for position, producer_id in enumerate(producer_ids):
-            quantity = float(credited[producer_id])
+        for producer_id in producer_ids:
+            quantity = round(float(credited[producer_id]), 6)
             amount = _money(quantity * internal_price_per_kwh)
-            if position == len(producer_ids) - 1:
-                amount = charge_total - credited_total
             credited_total += amount
             line_items.append(
                 {
                     "participant_id": producer_id,
                     "item_type": "producer_credit",
-                    "quantity_kwh": round(quantity, 6),
+                    "quantity_kwh": quantity,
                     "unit_price_chf_per_kwh": internal_price_per_kwh,
                     "amount_chf": -float(amount),
+                }
+            )
+
+        rounding_difference = charge_total - credited_total
+        if producer_ids and rounding_difference:
+            line_items.append(
+                {
+                    "participant_id": producer_ids[-1],
+                    "item_type": "rounding_adjustment",
+                    "quantity_kwh": None,
+                    "unit_price_chf_per_kwh": None,
+                    "amount_chf": -float(rounding_difference),
                 }
             )
 

--- a/billing_engine.py
+++ b/billing_engine.py
@@ -25,6 +25,10 @@ def _priced_amount(quantity, unit_price):
     return _money(Decimal(str(quantity)) * Decimal(str(unit_price)))
 
 
+def _currency(value):
+    return float(value.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP))
+
+
 def allocate_energy(production, consumption, model="proportional"):
     """Allocate solar production to consumers per 15-min interval.
 
@@ -112,6 +116,11 @@ def generate_billing_summary(
         dict with total_production_kwh, total_allocated_kwh,
         total_network_discount_chf, participants (list of per-participant summaries)
     """
+    try:
+        grid_fee_per_kwh = float(grid_fee_per_kwh)
+        internal_price_per_kwh = float(internal_price_per_kwh)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Billing prices must be finite and non-negative") from exc
     if not all(
         isfinite(price) and price >= 0
         for price in (grid_fee_per_kwh, internal_price_per_kwh)
@@ -121,6 +130,11 @@ def generate_billing_summary(
         raise ValueError("network_level must be 'same' or 'cross'")
     if distribution_model not in {"proportional", "einfach"}:
         raise ValueError("Unsupported distribution model")
+    try:
+        production = production.astype(float)
+        consumption = consumption.astype(float)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Billing readings must be finite and non-negative") from exc
     if (
         not np.isfinite(production.to_numpy()).all()
         or not np.isfinite(consumption.to_numpy()).all()
@@ -150,9 +164,10 @@ def generate_billing_summary(
     line_items = []
     for col in allocation.columns:
         alloc_kwh = float(allocation[col].sum())
+        priced_quantity = round(alloc_kwh, 6)
         cons_kwh = float(consumption[col].sum())
         discount = compute_network_discount(alloc_kwh, grid_fee_per_kwh, network_level)
-        cost = alloc_kwh * internal_price_per_kwh
+        cost = _priced_amount(priced_quantity, internal_price_per_kwh)
 
         participants.append(
             {
@@ -162,20 +177,19 @@ def generate_billing_summary(
                 "self_supply_ratio": round(alloc_kwh / cons_kwh, 4)
                 if cons_kwh > 0
                 else 0,
-                "internal_cost_chf": round(cost, 2),
-                "network_discount_chf": round(discount, 2),
+                "internal_cost_chf": _currency(cost),
+                "network_discount_chf": _currency(_money(discount)),
             }
         )
         if producer_production is not None:
-            quantity = round(alloc_kwh, 6)
             line_items.append(
                 {
                     "participant_id": col,
                     "item_type": "consumer_charge",
-                    "quantity_kwh": quantity,
+                    "quantity_kwh": priced_quantity,
                     "unit_price_chf_per_kwh": internal_price_per_kwh,
                     "amount_chf": float(
-                        _priced_amount(quantity, internal_price_per_kwh)
+                        _priced_amount(priced_quantity, internal_price_per_kwh)
                     ),
                 }
             )
@@ -207,7 +221,7 @@ def generate_billing_summary(
         if producer_ids and rounding_difference:
             line_items.append(
                 {
-                    "participant_id": producer_ids[-1],
+                    "participant_id": min(producer_ids, key=str),
                     "item_type": "rounding_adjustment",
                     "quantity_kwh": None,
                     "unit_price_chf_per_kwh": None,
@@ -219,7 +233,7 @@ def generate_billing_summary(
         "total_production_kwh": round(total_production, 2),
         "total_allocated_kwh": round(total_allocated, 2),
         "total_surplus_kwh": round(max(0, total_production - total_allocated), 2),
-        "total_network_discount_chf": round(total_discount, 2),
+        "total_network_discount_chf": _currency(_money(total_discount)),
         "internal_price_chf_per_kwh": internal_price_per_kwh,
         "grid_fee_chf_per_kwh": grid_fee_per_kwh,
         "distribution_model": distribution_model,

--- a/billing_engine.py
+++ b/billing_engine.py
@@ -7,10 +7,16 @@ Implements Art. 17d/17e StromVG allocation models:
 - Network discount: 40% same level, 20% cross level
 """
 
+from decimal import ROUND_HALF_UP, Decimal
+
 import pandas as pd
 
 DISCOUNT_SAME_LEVEL = 0.40
 DISCOUNT_CROSS_LEVEL = 0.20
+
+
+def _money(value):
+    return Decimal(str(value)).quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
 
 
 def allocate_energy(production, consumption, model="proportional"):
@@ -100,15 +106,39 @@ def generate_billing_summary(
         dict with total_production_kwh, total_allocated_kwh,
         total_network_discount_chf, participants (list of per-participant summaries)
     """
-    allocation = allocate_energy(production, consumption, model=distribution_model)
+    if grid_fee_per_kwh < 0 or internal_price_per_kwh < 0:
+        raise ValueError("Billing prices must not be negative")
+    if network_level not in {"same", "cross"}:
+        raise ValueError("network_level must be 'same' or 'cross'")
+    if distribution_model not in {"proportional", "einfach"}:
+        raise ValueError("Unsupported distribution model")
+    if (
+        pd.isna(production).to_numpy().any()
+        or pd.isna(consumption).to_numpy().any()
+        or (production < 0).to_numpy().any()
+        or (consumption < 0).to_numpy().any()
+    ):
+        raise ValueError("Billing readings must be finite and non-negative")
 
-    total_production = float(production.sum())
+    producer_production = production if isinstance(production, pd.DataFrame) else None
+    total_production_series = (
+        production.sum(axis=1) if producer_production is not None else production
+    )
+    if not total_production_series.index.equals(consumption.index):
+        raise ValueError("Production and consumption intervals must match")
+
+    allocation = allocate_energy(
+        total_production_series, consumption, model=distribution_model
+    )
+
+    total_production = float(total_production_series.sum())
     total_allocated = float(allocation.values.sum())
     total_discount = compute_network_discount(
         total_allocated, grid_fee_per_kwh, network_level
     )
 
     participants = []
+    line_items = []
     for col in allocation.columns:
         alloc_kwh = float(allocation[col].sum())
         cons_kwh = float(consumption[col].sum())
@@ -127,11 +157,51 @@ def generate_billing_summary(
                 "network_discount_chf": round(discount, 2),
             }
         )
+        if producer_production is not None:
+            line_items.append(
+                {
+                    "participant_id": col,
+                    "item_type": "consumer_charge",
+                    "quantity_kwh": round(alloc_kwh, 6),
+                    "unit_price_chf_per_kwh": internal_price_per_kwh,
+                    "amount_chf": float(_money(alloc_kwh * internal_price_per_kwh)),
+                }
+            )
+
+    if producer_production is not None:
+        allocated_by_interval = allocation.sum(axis=1)
+        shares = producer_production.div(
+            total_production_series.replace(0, float("nan")), axis=0
+        ).fillna(0)
+        credited = shares.mul(allocated_by_interval, axis=0).sum(axis=0)
+        charge_total = sum(_money(item["amount_chf"]) for item in line_items)
+        credited_total = Decimal(0)
+        producer_ids = list(credited.index)
+        for position, producer_id in enumerate(producer_ids):
+            quantity = float(credited[producer_id])
+            amount = _money(quantity * internal_price_per_kwh)
+            if position == len(producer_ids) - 1:
+                amount = charge_total - credited_total
+            credited_total += amount
+            line_items.append(
+                {
+                    "participant_id": producer_id,
+                    "item_type": "producer_credit",
+                    "quantity_kwh": round(quantity, 6),
+                    "unit_price_chf_per_kwh": internal_price_per_kwh,
+                    "amount_chf": -float(amount),
+                }
+            )
 
     return {
         "total_production_kwh": round(total_production, 2),
         "total_allocated_kwh": round(total_allocated, 2),
         "total_surplus_kwh": round(max(0, total_production - total_allocated), 2),
         "total_network_discount_chf": round(total_discount, 2),
+        "internal_price_chf_per_kwh": internal_price_per_kwh,
+        "grid_fee_chf_per_kwh": grid_fee_per_kwh,
+        "distribution_model": distribution_model,
+        "network_level": network_level,
         "participants": participants,
+        "line_items": line_items,
     }

--- a/database.py
+++ b/database.py
@@ -522,6 +522,9 @@ def _create_tables():
                     total_network_discount_chf DECIMAL(10, 2) DEFAULT 0,
                     distribution_model VARCHAR(32) DEFAULT 'proportional',
                     network_level VARCHAR(16) DEFAULT 'same',
+                    internal_price_chf_per_kwh DECIMAL(12, 6),
+                    grid_fee_chf_per_kwh DECIMAL(12, 6),
+                    timezone VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich',
                     status VARCHAR(32) DEFAULT 'draft',
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
@@ -532,6 +535,10 @@ def _create_tables():
                     id SERIAL PRIMARY KEY,
                     billing_period_id INTEGER REFERENCES billing_periods(id),
                     participant_id VARCHAR(64) NOT NULL,
+                    item_type VARCHAR(32),
+                    quantity_kwh DECIMAL(12, 6),
+                    unit_price_chf_per_kwh DECIMAL(12, 6),
+                    amount_chf DECIMAL(12, 6),
                     consumption_kwh DECIMAL(12, 4) DEFAULT 0,
                     allocated_kwh DECIMAL(12, 4) DEFAULT 0,
                     self_supply_ratio DECIMAL(5, 4) DEFAULT 0,
@@ -539,6 +546,21 @@ def _create_tables():
                     network_discount_chf DECIMAL(10, 2) DEFAULT 0,
                     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
                 )
+            """)
+
+            cur.execute("""
+                ALTER TABLE billing_periods
+                    ADD COLUMN IF NOT EXISTS internal_price_chf_per_kwh DECIMAL(12, 6),
+                    ADD COLUMN IF NOT EXISTS grid_fee_chf_per_kwh DECIMAL(12, 6),
+                    ADD COLUMN IF NOT EXISTS timezone VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich'
+            """)
+
+            cur.execute("""
+                ALTER TABLE billing_line_items
+                    ADD COLUMN IF NOT EXISTS item_type VARCHAR(32),
+                    ADD COLUMN IF NOT EXISTS quantity_kwh DECIMAL(12, 6),
+                    ADD COLUMN IF NOT EXISTS unit_price_chf_per_kwh DECIMAL(12, 6),
+                    ADD COLUMN IF NOT EXISTS amount_chf DECIMAL(12, 6)
             """)
 
             cur.execute("""

--- a/store/billing.py
+++ b/store/billing.py
@@ -75,24 +75,25 @@ def save_billing_period(
                         ),
                     )
 
-                for p in [] if line_items else summary.get("participants", []):
-                    cur.execute(
-                        """
-                        INSERT INTO billing_line_items
-                        (billing_period_id, participant_id, consumption_kwh, allocated_kwh,
-                         self_supply_ratio, internal_cost_chf, network_discount_chf)
-                        VALUES (%s, %s, %s, %s, %s, %s, %s)
-                    """,
-                        (
-                            period_id,
-                            p["id"],
-                            p["consumption_kwh"],
-                            p["allocated_kwh"],
-                            p["self_supply_ratio"],
-                            p["internal_cost_chf"],
-                            p["network_discount_chf"],
-                        ),
-                    )
+                if not line_items:
+                    for p in summary.get("participants", []):
+                        cur.execute(
+                            """
+                            INSERT INTO billing_line_items
+                            (billing_period_id, participant_id, consumption_kwh, allocated_kwh,
+                             self_supply_ratio, internal_cost_chf, network_discount_chf)
+                            VALUES (%s, %s, %s, %s, %s, %s, %s)
+                        """,
+                            (
+                                period_id,
+                                p["id"],
+                                p["consumption_kwh"],
+                                p["allocated_kwh"],
+                                p["self_supply_ratio"],
+                                p["internal_cost_chf"],
+                                p["network_discount_chf"],
+                            ),
+                        )
 
                 return period_id
     except Exception as e:

--- a/store/billing.py
+++ b/store/billing.py
@@ -33,8 +33,11 @@ def save_billing_period(
                     """
                     INSERT INTO billing_periods
                     (community_id, period_start, period_end, total_production_kwh, total_allocated_kwh,
-                     total_surplus_kwh, total_network_discount_chf, status)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, 'final') RETURNING id
+                     total_surplus_kwh, total_network_discount_chf, distribution_model,
+                     network_level, internal_price_chf_per_kwh, grid_fee_chf_per_kwh,
+                     timezone, status)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'draft')
+                    RETURNING id
                 """,
                     (
                         community_id,
@@ -44,11 +47,35 @@ def save_billing_period(
                         summary["total_allocated_kwh"],
                         summary.get("total_surplus_kwh", 0),
                         summary["total_network_discount_chf"],
+                        summary.get("distribution_model", "proportional"),
+                        summary.get("network_level", "same"),
+                        summary["internal_price_chf_per_kwh"],
+                        summary["grid_fee_chf_per_kwh"],
+                        summary.get("timezone", "Europe/Zurich"),
                     ),
                 )
                 period_id = cur.fetchone()[0]
 
-                for p in summary.get("participants", []):
+                line_items = summary.get("line_items", [])
+                for item in line_items:
+                    cur.execute(
+                        """
+                        INSERT INTO billing_line_items
+                        (billing_period_id, participant_id, item_type, quantity_kwh,
+                         unit_price_chf_per_kwh, amount_chf)
+                        VALUES (%s, %s, %s, %s, %s, %s)
+                    """,
+                        (
+                            period_id,
+                            item["participant_id"],
+                            item["item_type"],
+                            item["quantity_kwh"],
+                            item["unit_price_chf_per_kwh"],
+                            item["amount_chf"],
+                        ),
+                    )
+
+                for p in [] if line_items else summary.get("participants", []):
                     cur.execute(
                         """
                         INSERT INTO billing_line_items

--- a/store/billing.py
+++ b/store/billing.py
@@ -49,21 +49,28 @@ def save_billing_period(
                         summary["total_network_discount_chf"],
                         summary.get("distribution_model", "proportional"),
                         summary.get("network_level", "same"),
-                        summary["internal_price_chf_per_kwh"],
-                        summary["grid_fee_chf_per_kwh"],
+                        summary.get("internal_price_chf_per_kwh"),
+                        summary.get("grid_fee_chf_per_kwh"),
                         summary.get("timezone", "Europe/Zurich"),
                     ),
                 )
                 period_id = cur.fetchone()[0]
 
                 line_items = summary.get("line_items", [])
+                participants = {
+                    participant["id"]: participant
+                    for participant in summary.get("participants", [])
+                }
                 for item in line_items:
+                    participant = participants.get(item["participant_id"], {})
                     cur.execute(
                         """
                         INSERT INTO billing_line_items
                         (billing_period_id, participant_id, item_type, quantity_kwh,
-                         unit_price_chf_per_kwh, amount_chf)
-                        VALUES (%s, %s, %s, %s, %s, %s)
+                         unit_price_chf_per_kwh, amount_chf, consumption_kwh,
+                         allocated_kwh, self_supply_ratio, internal_cost_chf,
+                         network_discount_chf)
+                        VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     """,
                         (
                             period_id,
@@ -72,6 +79,11 @@ def save_billing_period(
                             item["quantity_kwh"],
                             item["unit_price_chf_per_kwh"],
                             item["amount_chf"],
+                            participant.get("consumption_kwh", 0),
+                            participant.get("allocated_kwh", 0),
+                            participant.get("self_supply_ratio", 0),
+                            participant.get("internal_cost_chf", 0),
+                            participant.get("network_discount_chf", 0),
                         ),
                     )
 

--- a/store/billing.py
+++ b/store/billing.py
@@ -62,7 +62,11 @@ def save_billing_period(
                     for participant in summary.get("participants", [])
                 }
                 for item in line_items:
-                    participant = participants.get(item["participant_id"], {})
+                    participant = (
+                        participants.get(item["participant_id"], {})
+                        if item["item_type"] == "consumer_charge"
+                        else {}
+                    )
                     cur.execute(
                         """
                         INSERT INTO billing_line_items
@@ -79,11 +83,11 @@ def save_billing_period(
                             item["quantity_kwh"],
                             item["unit_price_chf_per_kwh"],
                             item["amount_chf"],
-                            participant.get("consumption_kwh", 0),
-                            participant.get("allocated_kwh", 0),
-                            participant.get("self_supply_ratio", 0),
-                            participant.get("internal_cost_chf", 0),
-                            participant.get("network_discount_chf", 0),
+                            participant.get("consumption_kwh"),
+                            participant.get("allocated_kwh"),
+                            participant.get("self_supply_ratio"),
+                            participant.get("internal_cost_chf"),
+                            participant.get("network_discount_chf"),
                         ),
                     )
 

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -93,7 +93,7 @@ def test_persisted_quantities_recompute_to_amounts_with_explicit_rounding_item()
         production=pd.DataFrame({"producer-a": [0.000008]}),
         consumption=pd.DataFrame({"consumer-a": [0.000004], "consumer-b": [0.000004]}),
         grid_fee_per_kwh=0.10,
-        internal_price_per_kwh=0.15,
+        internal_price_per_kwh=0.625,
         network_level="same",
     )
 
@@ -103,7 +103,10 @@ def test_persisted_quantities_recompute_to_amounts_with_explicit_rounding_item()
         if item["item_type"] in {"consumer_charge", "producer_credit"}
     ]
     for item in priced_items:
-        expected = _money(item["quantity_kwh"] * item["unit_price_chf_per_kwh"])
+        expected = _money(
+            Decimal(str(item["quantity_kwh"]))
+            * Decimal(str(item["unit_price_chf_per_kwh"]))
+        )
         assert _money(abs(item["amount_chf"])) == expected
 
     adjustment = [

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -102,6 +102,11 @@ def test_anonymous_aggregate_production_does_not_emit_unbalanced_ledger():
             pd.DataFrame({"consumer-a": [1.0]}),
             "unknown",
         ),
+        (
+            pd.DataFrame({"producer-a": [float("inf")]}),
+            pd.DataFrame({"consumer-a": [1.0]}),
+            "proportional",
+        ),
     ],
 )
 def test_invalid_billing_inputs_are_rejected(production, consumption, model):
@@ -113,6 +118,18 @@ def test_invalid_billing_inputs_are_rejected(production, consumption, model):
             internal_price_per_kwh=0.15,
             network_level="same",
             distribution_model=model,
+        )
+
+
+@pytest.mark.parametrize("price", [float("nan"), float("inf")])
+def test_non_finite_billing_prices_are_rejected(price):
+    with pytest.raises(ValueError):
+        billing_engine.generate_billing_summary(
+            production=pd.DataFrame({"producer-a": [1.0]}),
+            consumption=pd.DataFrame({"consumer-a": [1.0]}),
+            grid_fee_per_kwh=0.10,
+            internal_price_per_kwh=price,
+            network_level="same",
         )
 
 

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -294,7 +294,7 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
                 "amount_chf": 0.15,
             },
             {
-                "participant_id": "producer-a",
+                "participant_id": "consumer-a",
                 "item_type": "producer_credit",
                 "quantity_kwh": 1,
                 "unit_price_chf_per_kwh": 0.15,
@@ -317,6 +317,7 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
     assert "network_discount_chf" in item_queries[0][0]
     assert item_queries[0][1][-5:] == (1, 1, 1, 0.15, 0.04)
     assert item_queries[1][1][5] == -0.15
+    assert item_queries[1][1][-5:] == (None, None, None, None, None)
 
 
 def test_legacy_summary_still_saves_without_price_snapshot(monkeypatch):

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -1,7 +1,9 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 """TDD contract for auditable draft billing periods."""
 
+import re
 from contextlib import contextmanager
+from decimal import ROUND_HALF_UP, Decimal
 from pathlib import Path
 
 import pandas as pd
@@ -12,6 +14,20 @@ import database
 from store import billing
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _money(value):
+    return Decimal(str(value)).quantize(Decimal("0.000001"), rounding=ROUND_HALF_UP)
+
+
+def _create_table_block(source, table):
+    match = re.search(
+        rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\)\s*\"\"\"",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match, f"CREATE TABLE {table} block not found"
+    return match.group(1)
 
 
 class _Cursor:
@@ -70,6 +86,36 @@ def test_summary_emits_balanced_consumer_charges_and_producer_credits():
     assert all(item["amount_chf"] > 0 for item in charges)
     assert all(item["amount_chf"] < 0 for item in credits)
     assert round(sum(item["amount_chf"] for item in summary["line_items"]), 6) == 0
+
+
+def test_persisted_quantities_recompute_to_amounts_with_explicit_rounding_item():
+    summary = billing_engine.generate_billing_summary(
+        production=pd.DataFrame({"producer-a": [0.000008]}),
+        consumption=pd.DataFrame({"consumer-a": [0.000004], "consumer-b": [0.000004]}),
+        grid_fee_per_kwh=0.10,
+        internal_price_per_kwh=0.15,
+        network_level="same",
+    )
+
+    priced_items = [
+        item
+        for item in summary["line_items"]
+        if item["item_type"] in {"consumer_charge", "producer_credit"}
+    ]
+    for item in priced_items:
+        expected = _money(item["quantity_kwh"] * item["unit_price_chf_per_kwh"])
+        assert _money(abs(item["amount_chf"])) == expected
+
+    adjustment = [
+        item
+        for item in summary["line_items"]
+        if item["item_type"] == "rounding_adjustment"
+    ]
+    assert len(adjustment) == 1
+    assert adjustment[0]["participant_id"] == "producer-a"
+    assert adjustment[0]["quantity_kwh"] is None
+    assert adjustment[0]["unit_price_chf_per_kwh"] is None
+    assert _money(sum(item["amount_chf"] for item in summary["line_items"])) == 0
 
 
 def test_anonymous_aggregate_production_does_not_emit_unbalanced_ledger():
@@ -179,13 +225,10 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
 
 def test_schema_keeps_prices_and_signed_line_items_with_the_period():
     schema = (PROJECT_ROOT / "database.py").read_text(encoding="utf-8")
+    period_block = _create_table_block(schema, "billing_periods")
+    line_item_block = _create_table_block(schema, "billing_line_items")
 
-    for column in (
-        "internal_price_chf_per_kwh",
-        "grid_fee_chf_per_kwh",
-        "item_type",
-        "quantity_kwh",
-        "unit_price_chf_per_kwh",
-        "amount_chf",
-    ):
-        assert column in schema
+    for column in ("internal_price_chf_per_kwh", "grid_fee_chf_per_kwh"):
+        assert column in period_block
+    for column in ("item_type", "quantity_kwh", "unit_price_chf_per_kwh", "amount_chf"):
+        assert column in line_item_block

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -298,7 +298,14 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
                 "item_type": "producer_credit",
                 "quantity_kwh": 1,
                 "unit_price_chf_per_kwh": 0.15,
-                "amount_chf": -0.15,
+                "amount_chf": -0.149999,
+            },
+            {
+                "participant_id": "consumer-a",
+                "item_type": "rounding_adjustment",
+                "quantity_kwh": None,
+                "unit_price_chf_per_kwh": None,
+                "amount_chf": -0.000001,
             },
         ],
     }
@@ -312,12 +319,13 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
     assert "'draft'" in period_query
     assert period_params[9:11] == (0.15, 0.10)
     item_queries = cursor.executed[1:]
-    assert len(item_queries) == 2
+    assert len(item_queries) == 3
     assert all("item_type" in query for query, _ in item_queries)
     assert "network_discount_chf" in item_queries[0][0]
     assert item_queries[0][1][-5:] == (1, 1, 1, 0.15, 0.04)
-    assert item_queries[1][1][5] == -0.15
-    assert item_queries[1][1][-5:] == (None, None, None, None, None)
+    assert item_queries[1][1][5] == -0.149999
+    for _, params in item_queries[1:]:
+        assert params[-5:] == (None, None, None, None, None)
 
 
 def test_legacy_summary_still_saves_without_price_snapshot(monkeypatch):

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""TDD contract for auditable draft billing periods."""
+
+from contextlib import contextmanager
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+import billing_engine
+import database
+from store import billing
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
+
+class _Cursor:
+    def __init__(self):
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchone(self):
+        return (42,)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _Connection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _connection_factory(cursor):
+    @contextmanager
+    def factory():
+        yield _Connection(cursor)
+
+    return factory
+
+
+def test_summary_emits_balanced_consumer_charges_and_producer_credits():
+    production = pd.DataFrame({"producer-a": [6.0], "producer-b": [4.0]})
+    consumption = pd.DataFrame({"consumer-a": [7.0], "consumer-b": [3.0]})
+
+    summary = billing_engine.generate_billing_summary(
+        production=production,
+        consumption=consumption,
+        grid_fee_per_kwh=0.10,
+        internal_price_per_kwh=0.15,
+        network_level="same",
+    )
+
+    charges = [
+        item for item in summary["line_items"] if item["item_type"] == "consumer_charge"
+    ]
+    credits = [
+        item for item in summary["line_items"] if item["item_type"] == "producer_credit"
+    ]
+    assert {item["participant_id"] for item in charges} == {"consumer-a", "consumer-b"}
+    assert {item["participant_id"] for item in credits} == {"producer-a", "producer-b"}
+    assert all(item["amount_chf"] > 0 for item in charges)
+    assert all(item["amount_chf"] < 0 for item in credits)
+    assert round(sum(item["amount_chf"] for item in summary["line_items"]), 6) == 0
+
+
+def test_anonymous_aggregate_production_does_not_emit_unbalanced_ledger():
+    summary = billing_engine.generate_billing_summary(
+        production=pd.Series([1.0]),
+        consumption=pd.DataFrame({"consumer-a": [1.0]}),
+        grid_fee_per_kwh=0.10,
+        internal_price_per_kwh=0.15,
+        network_level="same",
+    )
+
+    assert summary["line_items"] == []
+
+
+@pytest.mark.parametrize(
+    ("production", "consumption", "model"),
+    [
+        (
+            pd.DataFrame({"producer-a": [-1.0]}),
+            pd.DataFrame({"consumer-a": [1.0]}),
+            "proportional",
+        ),
+        (
+            pd.DataFrame({"producer-a": [1.0]}),
+            pd.DataFrame({"consumer-a": [-1.0]}),
+            "proportional",
+        ),
+        (
+            pd.DataFrame({"producer-a": [1.0]}),
+            pd.DataFrame({"consumer-a": [1.0]}),
+            "unknown",
+        ),
+    ],
+)
+def test_invalid_billing_inputs_are_rejected(production, consumption, model):
+    with pytest.raises(ValueError):
+        billing_engine.generate_billing_summary(
+            production=production,
+            consumption=consumption,
+            grid_fee_per_kwh=0.10,
+            internal_price_per_kwh=0.15,
+            network_level="same",
+            distribution_model=model,
+        )
+
+
+def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch):
+    cursor = _Cursor()
+    monkeypatch.setattr(database, "get_connection", _connection_factory(cursor))
+    summary = {
+        "total_production_kwh": 1,
+        "total_allocated_kwh": 1,
+        "total_surplus_kwh": 0,
+        "total_network_discount_chf": 0.04,
+        "internal_price_chf_per_kwh": 0.15,
+        "grid_fee_chf_per_kwh": 0.10,
+        "distribution_model": "proportional",
+        "network_level": "same",
+        "line_items": [
+            {
+                "participant_id": "consumer-a",
+                "item_type": "consumer_charge",
+                "quantity_kwh": 1,
+                "unit_price_chf_per_kwh": 0.15,
+                "amount_chf": 0.15,
+            },
+            {
+                "participant_id": "producer-a",
+                "item_type": "producer_credit",
+                "quantity_kwh": 1,
+                "unit_price_chf_per_kwh": 0.15,
+                "amount_chf": -0.15,
+            },
+        ],
+    }
+
+    period_id = billing.save_billing_period("community-a", "start", "end", summary)
+
+    assert period_id == 42
+    period_query, period_params = cursor.executed[0]
+    assert "internal_price_chf_per_kwh" in period_query
+    assert "grid_fee_chf_per_kwh" in period_query
+    assert "'draft'" in period_query
+    assert 0.15 in period_params
+    item_queries = cursor.executed[1:]
+    assert len(item_queries) == 2
+    assert all("item_type" in query for query, _ in item_queries)
+    assert item_queries[1][1][-1] == -0.15
+
+
+def test_schema_keeps_prices_and_signed_line_items_with_the_period():
+    schema = (PROJECT_ROOT / "database.py").read_text(encoding="utf-8")
+
+    for column in (
+        "internal_price_chf_per_kwh",
+        "grid_fee_chf_per_kwh",
+        "item_type",
+        "quantity_kwh",
+        "unit_price_chf_per_kwh",
+        "amount_chf",
+    ):
+        assert column in schema

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -30,6 +30,16 @@ def _create_table_block(source, table):
     return match.group(1)
 
 
+def _alter_table_block(source, table):
+    match = re.search(
+        rf"ALTER TABLE {table}\s+(.*?)\s*\"\"\"",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match, f"ALTER TABLE {table} block not found"
+    return match.group(1)
+
+
 class _Cursor:
     def __init__(self):
         self.executed = []
@@ -121,6 +131,29 @@ def test_persisted_quantities_recompute_to_amounts_with_explicit_rounding_item()
     assert _money(sum(item["amount_chf"] for item in summary["line_items"])) == 0
 
 
+def test_rounding_adjustment_owner_is_independent_of_producer_column_order():
+    def adjustment_owner(columns):
+        production = pd.DataFrame({key: [value] for key, value in columns})
+        summary = billing_engine.generate_billing_summary(
+            production=production,
+            consumption=pd.DataFrame(
+                {"consumer-a": [0.000004], "consumer-b": [0.000004]}
+            ),
+            grid_fee_per_kwh=0.10,
+            internal_price_per_kwh=0.625,
+            network_level="same",
+        )
+        return next(
+            item["participant_id"]
+            for item in summary["line_items"]
+            if item["item_type"] == "rounding_adjustment"
+        )
+
+    assert adjustment_owner(
+        [("producer-a", 0.000002), ("producer-b", 0.000006)]
+    ) == adjustment_owner([("producer-b", 0.000006), ("producer-a", 0.000002)])
+
+
 def test_anonymous_aggregate_production_does_not_emit_unbalanced_ledger():
     summary = billing_engine.generate_billing_summary(
         production=pd.Series([1.0]),
@@ -170,7 +203,7 @@ def test_invalid_billing_inputs_are_rejected(production, consumption, model):
         )
 
 
-@pytest.mark.parametrize("price", [float("nan"), float("inf")])
+@pytest.mark.parametrize("price", [float("nan"), float("inf"), None])
 def test_non_finite_billing_prices_are_rejected(price):
     with pytest.raises(ValueError):
         billing_engine.generate_billing_summary(
@@ -180,6 +213,54 @@ def test_non_finite_billing_prices_are_rejected(price):
             internal_price_per_kwh=price,
             network_level="same",
         )
+
+
+def test_decimal_readings_are_accepted_and_normalized():
+    summary = billing_engine.generate_billing_summary(
+        production=pd.DataFrame({"producer-a": [Decimal("1.0")]}),
+        consumption=pd.DataFrame({"consumer-a": [Decimal("1.0")]}),
+        grid_fee_per_kwh=Decimal("0.10"),
+        internal_price_per_kwh=Decimal("0.15"),
+        network_level="same",
+    )
+
+    assert summary["line_items"][0]["amount_chf"] == 0.15
+
+
+def test_non_numeric_readings_raise_value_error():
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        billing_engine.generate_billing_summary(
+            production=pd.DataFrame({"producer-a": [None]}),
+            consumption=pd.DataFrame({"consumer-a": [1.0]}),
+            grid_fee_per_kwh=0.10,
+            internal_price_per_kwh=0.15,
+            network_level="same",
+        )
+
+
+def test_participant_cost_uses_half_up_rounding():
+    summary = billing_engine.generate_billing_summary(
+        production=pd.DataFrame({"producer-a": [1.5]}),
+        consumption=pd.DataFrame({"consumer-a": [1.5]}),
+        grid_fee_per_kwh=0.10,
+        internal_price_per_kwh=0.15,
+        network_level="same",
+    )
+
+    assert summary["participants"][0]["internal_cost_chf"] == 0.23
+
+
+def test_network_discount_uses_half_up_rounding():
+    summary = billing_engine.generate_billing_summary(
+        production=pd.DataFrame({"producer-a": [1.0]}),
+        consumption=pd.DataFrame({"consumer-a": [1.0]}),
+        grid_fee_per_kwh=0.0375,
+        internal_price_per_kwh=0.15,
+        network_level="same",
+    )
+
+    assert summary["participants"][0]["network_discount_chf"] == 0.02
+    assert summary["total_network_discount_chf"] == 0.02
 
 
 def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch):
@@ -194,6 +275,16 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
         "grid_fee_chf_per_kwh": 0.10,
         "distribution_model": "proportional",
         "network_level": "same",
+        "participants": [
+            {
+                "id": "consumer-a",
+                "consumption_kwh": 1,
+                "allocated_kwh": 1,
+                "self_supply_ratio": 1,
+                "internal_cost_chf": 0.15,
+                "network_discount_chf": 0.04,
+            }
+        ],
         "line_items": [
             {
                 "participant_id": "consumer-a",
@@ -219,11 +310,38 @@ def test_saved_period_is_draft_with_price_snapshot_and_signed_items(monkeypatch)
     assert "internal_price_chf_per_kwh" in period_query
     assert "grid_fee_chf_per_kwh" in period_query
     assert "'draft'" in period_query
-    assert 0.15 in period_params
+    assert period_params[9:11] == (0.15, 0.10)
     item_queries = cursor.executed[1:]
     assert len(item_queries) == 2
     assert all("item_type" in query for query, _ in item_queries)
-    assert item_queries[1][1][-1] == -0.15
+    assert "network_discount_chf" in item_queries[0][0]
+    assert item_queries[0][1][-5:] == (1, 1, 1, 0.15, 0.04)
+    assert item_queries[1][1][5] == -0.15
+
+
+def test_legacy_summary_still_saves_without_price_snapshot(monkeypatch):
+    cursor = _Cursor()
+    monkeypatch.setattr(database, "get_connection", _connection_factory(cursor))
+    summary = {
+        "total_production_kwh": 1,
+        "total_allocated_kwh": 1,
+        "total_network_discount_chf": 0.04,
+        "participants": [
+            {
+                "id": "consumer-a",
+                "consumption_kwh": 1,
+                "allocated_kwh": 1,
+                "self_supply_ratio": 1,
+                "internal_cost_chf": 0.15,
+                "network_discount_chf": 0.04,
+            }
+        ],
+    }
+
+    assert billing.save_billing_period("community-a", "start", "end", summary) == 42
+    assert cursor.executed[0][1][9:11] == (None, None)
+    assert len(cursor.executed) == 2
+    assert "consumption_kwh" in cursor.executed[1][0]
 
 
 def test_schema_keeps_prices_and_signed_line_items_with_the_period():
@@ -235,3 +353,23 @@ def test_schema_keeps_prices_and_signed_line_items_with_the_period():
         assert column in period_block
     for column in ("item_type", "quantity_kwh", "unit_price_chf_per_kwh", "amount_chf"):
         assert column in line_item_block
+
+
+def test_existing_billing_tables_receive_all_new_columns_additively():
+    schema = (PROJECT_ROOT / "database.py").read_text(encoding="utf-8")
+    period_migration = _alter_table_block(schema, "billing_periods")
+    line_item_migration = _alter_table_block(schema, "billing_line_items")
+
+    for column in (
+        "internal_price_chf_per_kwh",
+        "grid_fee_chf_per_kwh",
+        "timezone",
+    ):
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in period_migration
+    for column in (
+        "item_type",
+        "quantity_kwh",
+        "unit_price_chf_per_kwh",
+        "amount_chf",
+    ):
+        assert f"ADD COLUMN IF NOT EXISTS {column}" in line_item_migration


### PR DESCRIPTION
## Summary
- snapshot internal and grid prices on each billing period
- keep generated periods in draft state
- emit signed consumer charges and producer credits from identified interval series
- keep persisted quantities and priced amounts exactly recomputable
- record micro-CHF balancing differences as explicit, deterministic rounding adjustments
- preserve consumer audit fields including self-supply and network discount
- accept Decimal readings while rejecting invalid and non-finite inputs
- use commercial half-up rounding for CHF summaries
- preserve legacy summary persistence without inventing producer credits
- migrate existing billing tables additively

## Validation
- strict red-green-refactor tests
- Claude Code review and follow-up fixes
- scripts/tdd_cycle.sh gate
- 844 passed, 11 skipped
- Ruff 0.16.1 check and format clean

## Deliberately out of scope
- SDAT table adapter and metering-point/member mapping: #261
- finalization before SDAT quality validation
- invoice PDFs, sending, cron activation, and production deployment
- Guby cutover