### PR TITLE
feat(billing): bridge SDAT-E66 metering readings into the billing core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,12 @@ headscale/config.yaml
 
 # Throwaway logo exploration
 logo-explore/
+
+# Local VNB exports and LEG participant lists: real citizen data
+# (names, addresses, metering point IDs). Never commit to a public repo.
+# data/public/ stays tracked: it holds published PV/ElCom datasets only.
+/data/*
+!/data/public/
+
+# Local throwaway scripts: seeding, bootstrapping, one-off utilities
+scratch/

--- a/billing_readings.py
+++ b/billing_readings.py
@@ -1,0 +1,347 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Adapter from SDAT metering readings to billing engine frames.
+
+``billing_engine.generate_billing_summary`` wants two pandas frames with an
+identical interval index and one column per participant. ``store.metering``
+holds point-keyed rows in UTC. This module is the only place that translation
+happens, which makes it the right place for the data-quality gate: a period
+that cannot be billed fails here, naming the offending metering point, instead
+of producing a plausible but wrong invoice.
+
+Two deliberate choices:
+
+* Participants are keyed on ``building_id``, not on the metering point. A member
+  with a separate production meter is one participant with two points, and
+  ``billing_line_items.participant_id`` already speaks building ids.
+* The engine reallocates production itself. The VNB already allocated in the
+  E66 file (the ``community_kwh`` channel), so the two numbers can disagree.
+  ``reconcile_with_vnb`` reports that gap rather than hiding it.
+"""
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+import database as db
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TIMEZONE = "Europe/Zurich"
+RESOLUTION_MINUTES = 15
+CONFIRMED_STATUS = "confirmed"
+
+_MAX_REPORTED = 5
+
+
+class PeriodDataError(ValueError):
+    """A period cannot be billed. ``problems`` lists every defect found."""
+
+    def __init__(self, problems):
+        self.problems = list(problems)
+        super().__init__(_describe(self.problems))
+
+
+@dataclass(frozen=True)
+class PeriodFrames:
+    """Engine-ready frames plus the provenance needed to audit them."""
+
+    consumption: pd.DataFrame
+    production: pd.DataFrame
+    participants: tuple
+    vnb_reference: dict
+    provenance: dict
+
+
+def _describe(problems):
+    by_kind = {}
+    for problem in problems:
+        by_kind.setdefault(problem["kind"], []).append(problem["detail"])
+    parts = []
+    for kind, details in sorted(by_kind.items()):
+        shown = details[:_MAX_REPORTED]
+        suffix = (
+            f" (+{len(details) - len(shown)} more)" if len(details) > len(shown) else ""
+        )
+        parts.append(f"{kind}: {'; '.join(shown)}{suffix}")
+    return " | ".join(parts)
+
+
+def _problem(kind, detail, metering_point_id=None):
+    return {"kind": kind, "detail": detail, "metering_point_id": metering_point_id}
+
+
+def _localise(moment, tzinfo):
+    """Naive boundaries are read in the period timezone, not in UTC."""
+    if moment.tzinfo is None:
+        return moment.replace(tzinfo=tzinfo)
+    return moment
+
+
+def _expected_index(period_start, period_end, tzinfo):
+    return pd.date_range(
+        start=period_start,
+        end=period_end - timedelta(minutes=RESOLUTION_MINUTES),
+        freq=f"{RESOLUTION_MINUTES}min",
+        tz=tzinfo,
+    )
+
+
+def _participant_map(points, problems):
+    """metering_point_id -> building_id, rejecting anything unbillable."""
+    mapping = {}
+    for point in points:
+        point_id = point.get("metering_point_id")
+        building_id = point.get("building_id")
+        status = point.get("member_status")
+        if not building_id:
+            problems.append(
+                _problem(
+                    "unmapped_point",
+                    f"{point_id} is not assigned to a building",
+                    point_id,
+                )
+            )
+            continue
+        if status != CONFIRMED_STATUS:
+            problems.append(
+                _problem(
+                    "unconfirmed_member",
+                    f"{point_id} belongs to building {building_id} "
+                    f"with membership status {status or 'missing'}",
+                    point_id,
+                )
+            )
+            continue
+        mapping[point_id] = building_id
+    return mapping
+
+
+def _check_rows(readings, mapping, expected_index, problems):
+    """Reject unknown points, mixed resolutions, negatives and duplicates."""
+    seen = set()
+    grid = {moment.to_pydatetime() for moment in expected_index}
+    for row in readings:
+        point_id = row.get("metering_point_id")
+        direction = row.get("direction")
+        measured_at = row.get("measured_at")
+
+        if point_id not in mapping:
+            problems.append(
+                _problem(
+                    "unknown_point",
+                    f"{point_id} has readings but is not a billable point of "
+                    "this community",
+                    point_id,
+                )
+            )
+            continue
+
+        resolution = row.get("resolution_minutes")
+        if resolution != RESOLUTION_MINUTES:
+            problems.append(
+                _problem(
+                    "mixed_resolution",
+                    f"{point_id} at {measured_at} has resolution {resolution}, "
+                    f"expected {RESOLUTION_MINUTES}",
+                    point_id,
+                )
+            )
+
+        for channel in ("total_kwh", "grid_kwh", "community_kwh"):
+            value = row.get(channel)
+            if value is not None and float(value) < 0:
+                problems.append(
+                    _problem(
+                        "negative_value",
+                        f"{point_id} at {measured_at} has {channel}={value}",
+                        point_id,
+                    )
+                )
+
+        if measured_at not in grid:
+            # Assigning this by label would extend the frame with an interval
+            # nobody expects, and the period would still look complete.
+            problems.append(
+                _problem(
+                    "misaligned_interval",
+                    f"{point_id} ({direction}) at {measured_at} is not on the "
+                    f"{RESOLUTION_MINUTES}-minute grid of this period",
+                    point_id,
+                )
+            )
+            continue
+
+        key = (point_id, direction, measured_at)
+        if key in seen:
+            problems.append(
+                _problem(
+                    "duplicate_interval",
+                    f"{point_id} ({direction}) appears twice at {measured_at}",
+                    point_id,
+                )
+            )
+        seen.add(key)
+
+    _check_gaps(seen, mapping, expected_index, problems)
+
+
+def _check_gaps(seen, mapping, expected_index, problems):
+    """Every series present in the period must cover every interval.
+
+    A series that is absent altogether is not a gap: a member without a
+    production meter simply has no production series.
+    """
+    series = {(point_id, direction) for point_id, direction, _ in seen}
+    for point_id, direction in sorted(series):
+        missing = [
+            moment
+            for moment in expected_index
+            if (point_id, direction, moment.to_pydatetime()) not in seen
+        ]
+        if missing:
+            shown = ", ".join(
+                m.strftime("%Y-%m-%d %H:%M") for m in missing[:_MAX_REPORTED]
+            )
+            problems.append(
+                _problem(
+                    "missing_interval",
+                    f"{point_id} ({direction}) is missing {len(missing)} "
+                    f"interval(s): {shown}",
+                    point_id,
+                )
+            )
+
+
+def _empty_frame(index, participants):
+    return pd.DataFrame(0.0, index=index, columns=list(participants))
+
+
+def load_period_frames(
+    community_id, period_start, period_end, *, timezone=DEFAULT_TIMEZONE
+):
+    """Load one billable period as engine-ready frames.
+
+    The interval is half-open: ``[period_start, period_end)``. Naive boundaries
+    are interpreted in ``timezone``. Raises :class:`PeriodDataError` listing
+    every defect rather than the first one, so an operator can fix a period in
+    one pass.
+    """
+    tzinfo = ZoneInfo(timezone)
+    period_start = _localise(period_start, tzinfo)
+    period_end = _localise(period_end, tzinfo)
+    if period_end <= period_start:
+        raise PeriodDataError(
+            [_problem("empty_period", f"{period_end} is not after {period_start}")]
+        )
+
+    problems = []
+    points = db.get_community_metering_points(community_id)
+    mapping = _participant_map(points, problems)
+    readings = db.get_period_readings(community_id, period_start, period_end)
+
+    if not readings:
+        problems.append(
+            _problem(
+                "no_readings",
+                f"no readings for community {community_id} between "
+                f"{period_start.isoformat()} and {period_end.isoformat()}",
+            )
+        )
+        raise PeriodDataError(problems)
+
+    index = _expected_index(period_start, period_end, tzinfo)
+    _check_rows(readings, mapping, index, problems)
+    if problems:
+        raise PeriodDataError(problems)
+
+    participants = tuple(sorted(set(mapping.values())))
+    frames = {
+        "consumption": _empty_frame(index, participants),
+        "production": _empty_frame(index, participants),
+    }
+    vnb_totals = {
+        "consumption": dict.fromkeys(participants, 0.0),
+        "production": dict.fromkeys(participants, 0.0),
+    }
+    documents = set()
+
+    for row in readings:
+        participant = mapping[row["metering_point_id"]]
+        direction = row["direction"]
+        frame = frames.get(direction)
+        if frame is None:
+            continue
+        moment = pd.Timestamp(row["measured_at"]).tz_convert(tzinfo)
+        total = float(row.get("total_kwh") or 0.0)
+        frame.loc[moment, participant] += total
+        community = row.get("community_kwh")
+        if community is not None:
+            vnb_totals[direction][participant] += float(community)
+        if row.get("source_document_id"):
+            documents.add(row["source_document_id"])
+
+    vnb_reference = {
+        "community_consumption_kwh": round(sum(vnb_totals["consumption"].values()), 6),
+        "community_production_kwh": round(sum(vnb_totals["production"].values()), 6),
+        "per_participant": {
+            participant: {
+                "consumption_kwh": round(vnb_totals["consumption"][participant], 6),
+                "production_kwh": round(vnb_totals["production"][participant], 6),
+            }
+            for participant in participants
+        },
+    }
+    provenance = {
+        "source_document_ids": tuple(sorted(documents)),
+        "interval_count": len(index),
+        "resolution_minutes": RESOLUTION_MINUTES,
+        "period_start": period_start,
+        "period_end": period_end,
+        "timezone": timezone,
+    }
+
+    return PeriodFrames(
+        consumption=frames["consumption"].astype(float),
+        production=frames["production"].astype(float),
+        participants=participants,
+        vnb_reference=vnb_reference,
+        provenance=provenance,
+    )
+
+
+def reconcile_with_vnb(frames, summary):
+    """Compare the engine's allocation with the allocation the VNB delivered.
+
+    The E66 ``community_kwh`` channel is the VNB's own split between grid supply
+    and community supply. ``allocate_energy`` derives its own split from total
+    production and consumption. Both are defensible, they are not equal, and the
+    difference is what a member will ask about, so it gets reported.
+    """
+    vnb_allocated = float(frames.vnb_reference["community_consumption_kwh"])
+    engine_allocated = float(summary.get("total_allocated_kwh") or 0.0)
+
+    per_participant = {}
+    for item in summary.get("participants", []):
+        participant = item["id"]
+        reference = frames.vnb_reference["per_participant"].get(participant, {})
+        vnb_kwh = float(reference.get("consumption_kwh") or 0.0)
+        engine_kwh = float(item.get("allocated_kwh") or 0.0)
+        per_participant[participant] = {
+            "vnb_kwh": round(vnb_kwh, 6),
+            "engine_kwh": round(engine_kwh, 6),
+            "difference_kwh": round(engine_kwh - vnb_kwh, 6),
+        }
+
+    difference = engine_allocated - vnb_allocated
+    return {
+        "vnb_allocated_kwh": round(vnb_allocated, 6),
+        "engine_allocated_kwh": round(engine_allocated, 6),
+        "difference_kwh": round(difference, 6),
+        "difference_pct": round(difference / vnb_allocated * 100, 4)
+        if vnb_allocated
+        else None,
+        "per_participant": per_participant,
+    }

--- a/database.py
+++ b/database.py
@@ -1167,6 +1167,18 @@ from store.meter import (  # noqa: F401
     get_meter_readings,
     save_meter_readings,
 )
+from store.metering import (  # noqa: F401
+    get_community_metering_points,
+    get_metering_point,
+    get_metering_point_reading_stats,
+    get_metering_point_readings,
+    get_metering_points,
+    get_period_readings,
+    get_sdat_import,
+    record_sdat_import,
+    save_metering_point_readings,
+    upsert_metering_points,
+)
 from store.profile import (  # noqa: F401
     get_all_municipality_profile_bfs_numbers,
     get_all_municipality_profiles,

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -39,6 +39,76 @@ Expected effects:
 - keep unrelated municipality profile fields intact
 - allow repeated imports without duplicate records
 
+## SDAT Metering Data
+
+Citizen smart meter data is a separate pipeline from the public open data
+above. It never reaches the public API and never leaves the LEG.
+
+The VNB delivers ebIX SDAT files. The E66 message (`ValidatedMeteredData`)
+carries validated 15-minute readings; its E31 sibling is skipped on import.
+`sdat_e66.py` parses one document into rows, `store/metering.py` stores them,
+and `billing_readings.py` turns a period into frames for `billing_engine.py`.
+
+### Canonical tables
+
+| Table | Holds |
+| --- | --- |
+| `metering_points` | One row per metering point, with the mapping to an OpenLEG `building_id` and `community_id` |
+| `metering_point_readings` | One row per (point, direction, interval) |
+| `sdat_imports` | File ledger, one row per imported document |
+
+`metering_point_readings` is the canonical readings table. The older
+`meter_readings` table belongs to the manual `/meter-upload` path and is keyed
+on `building_id`, not on a metering point. The two are not interchangeable.
+
+### Ownership mapping
+
+Billing is participant-based, not point-based. A metering point is billable
+only when it carries both a `building_id` and a `community_id`, and when the
+matching `community_members` row has `status = 'confirmed'`. One member can own
+several points, for example a separate production meter, and one point can
+carry both directions. Participants are therefore keyed on `building_id`.
+
+An unmapped point or an unconfirmed member is a hard error, never a silent
+skip: billing a period while a participant is missing would spread that
+participant's share across everyone else.
+
+### Units and directions
+
+Volumes are kWh throughout. The readings table carries no unit column, so the
+unit gate sits at the parse boundary: a document whose `MeasureUnit` is not
+`KWH` is a hard parse error and never reaches storage. `direction` is
+constrained to `consumption` or `production` and is part of the readings key,
+because one physical point can be both at the same instant.
+
+Each reading carries three channels: `total_kwh`, plus the VNB's own split into
+`grid_kwh` and `community_kwh`. The billing engine does not use that split; it
+reallocates from totals. `billing_readings.reconcile_with_vnb` reports the
+difference between the two allocations, which is small but not zero.
+
+### Timezone semantics
+
+`measured_at` is `TIMESTAMPTZ` and holds the interval **start** in UTC, because
+the SDAT source is UTC and a naive local key would collide on the October DST
+repeat. Periods are half-open, `[start, end)`, and are expressed in
+`Europe/Zurich`. An inclusive end would bill the boundary interval twice.
+
+### Data quality policy
+
+`billing_readings.load_period_frames` refuses a period and reports every defect
+it found, rather than the first, so one pass fixes a period:
+
+- a point with no building, or a member who is not confirmed
+- readings from a point that is not billable in this community
+- a duplicated (point, direction, interval)
+- a gap in a series that is otherwise present
+- a timestamp off the quarter-hour grid
+- a negative volume on any channel
+- a resolution other than 15 minutes
+
+A member with no production meter is not a gap. That participant simply has a
+zero production column, which the engine needs in order to emit credits.
+
 ## Public API Reads
 
 The public API reads from normalized database helpers. It does not expose

--- a/sdat_e66.py
+++ b/sdat_e66.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Parser für Swiss ebIX E66 Messdaten (ValidatedMeteredData_16).
+
+Ein E66 Dokument liefert pro Messpunkt, Richtung und Produktkanal eine eigene
+Zeitreihe. Dieser Parser faltet die drei Produktkanäle eines Paars aus Messpunkt
+und Richtung zu einer breiten Zeile zusammen:
+
+    total_kwh      Gesamtenergie (ebIXCode 8716867000030)
+    grid_kwh       Netzanteil (VSENationalCode 2404050010124)
+    community_kwh  LEG-Anteil (VSENationalCode 2404050010123)
+
+Beobachtungen tragen keinen Zeitstempel. Der Zeitstempel entsteht aus dem
+Intervallbeginn des Blocks plus (Sequence - 1) mal Auflösung und bezeichnet
+immer den **Beginn** des Intervalls. Alle Zeitstempel sind UTC.
+
+Dieses Modul bleibt bewusst getrennt von `meter_data`: jenes speichert pro
+Gebäude, dieses pro Messpunkt.
+"""
+
+import logging
+import xml.etree.ElementTree as ET
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+
+from defusedxml.common import DefusedXmlException
+from defusedxml.ElementTree import fromstring as _safe_xml_fromstring
+
+logger = logging.getLogger(__name__)
+
+E66_PRODUCT_TOTAL = "8716867000030"
+E66_PRODUCT_GRID = "2404050010124"
+E66_PRODUCT_COMMUNITY = "2404050010123"
+
+CHANNEL_BY_PRODUCT_CODE = {
+    E66_PRODUCT_TOTAL: "total",
+    E66_PRODUCT_GRID: "grid",
+    E66_PRODUCT_COMMUNITY: "community",
+}
+
+DIRECTION_CONSUMPTION = "consumption"
+DIRECTION_PRODUCTION = "production"
+
+# Zwei unabhängig auf drei Stellen gerundete Werte weichen von der gerundeten
+# Summe um bis zu 0.001 ab. 0.0015 lässt etwas Luft.
+E66_BALANCE_TOLERANCE_KWH = Decimal("0.0015")
+
+MAX_E66_BYTES = 64 * 1024 * 1024
+
+_RESOLUTION_UNIT_MINUTES = {"MIN": 1, "HOUR": 60}
+
+_PARSE_ERRORS = (
+    ET.ParseError,
+    DefusedXmlException,
+    KeyError,
+    TypeError,
+    ValueError,
+    AttributeError,
+)
+
+
+def _local_name(tag) -> str:
+    """Elementname ohne Namespace."""
+    return str(tag).rsplit("}", 1)[-1]
+
+
+def _child(element, name):
+    if element is None:
+        return None
+    for candidate in element:
+        if _local_name(candidate.tag) == name:
+            return candidate
+    return None
+
+
+def _path(element, *names):
+    current = element
+    for name in names:
+        current = _child(current, name)
+        if current is None:
+            return None
+    return current
+
+
+def _text(element, *names):
+    found = _path(element, *names) if names else element
+    if found is None or found.text is None:
+        return None
+    value = found.text.strip()
+    return value or None
+
+
+def _utc(value):
+    """ISO 8601 mit Z in ein zeitzonenbewusstes UTC-datetime umwandeln."""
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def mask_point_id(metering_point_id) -> str:
+    """Messpunkt-ID auf die letzten sechs Zeichen kürzen.
+
+    Messpunkt-IDs sind Personendaten, sobald sie mit dem Register verknüpft
+    sind. Ausgaben und Logs zeigen nur das Kürzel.
+    """
+    if not metering_point_id:
+        return ""
+    return "..." + str(metering_point_id)[-6:]
+
+
+def is_e66_document(xml_content) -> bool:
+    """Ohne vollständiges Parsen prüfen, ob ein E66 Dokument vorliegt."""
+    if not xml_content:
+        return False
+    head = xml_content[:4096]
+    return "ValidatedMeteredData_" in head and "E66" in head
+
+
+def _resolution_minutes(block):
+    resolution = _child(block, "Resolution")
+    raw = _text(resolution, "Resolution")
+    unit = _text(resolution, "Unit") or "MIN"
+    if raw is None:
+        return None
+    factor = _RESOLUTION_UNIT_MINUTES.get(unit.upper())
+    if factor is None:
+        return None
+    return int(raw) * factor
+
+
+def _block_identity(block):
+    consumption = _child(block, "ConsumptionMeteringPoint")
+    if consumption is not None:
+        return DIRECTION_CONSUMPTION, _text(consumption, "VSENationalID")
+    production = _child(block, "ProductionMeteringPoint")
+    if production is not None:
+        return DIRECTION_PRODUCTION, _text(production, "VSENationalID")
+    return None, None
+
+
+def _channel(block):
+    product_id = _path(block, "Product", "ID")
+    if product_id is None:
+        return None
+    code = _text(product_id, "ebIXCode") or _text(product_id, "VSENationalCode")
+    return CHANNEL_BY_PRODUCT_CODE.get(code)
+
+
+def _observations(block):
+    """Beobachtungen als {sequence: (volume, condition)}; letzte Sequenz gewinnt.
+
+    Doppelte Sequenzen würden sonst denselben Konfliktschlüssel zweimal in eine
+    INSERT-Anweisung bringen, was Postgres abbricht.
+    """
+    values = {}
+    for observation in block:
+        if _local_name(observation.tag) != "Observation":
+            continue
+        sequence = _text(observation, "Position", "Sequence")
+        volume = _text(observation, "Volume")
+        if sequence is None or volume is None:
+            continue
+        values[int(sequence)] = (Decimal(volume), _text(observation, "Condition"))
+    return values
+
+
+def parse_e66_xml(xml_content):
+    """E66 Dokument einlesen.
+
+    Returns:
+        (document, errors). `document` ist bei einem harten Fehler leer.
+        Weiche Probleme stehen in `document["warnings"]`.
+    """
+    if not xml_content or not xml_content.strip():
+        return {}, ["SDAT E66: Leere Datei."]
+
+    if len(xml_content.encode("utf-8")) > MAX_E66_BYTES:
+        limit_mb = MAX_E66_BYTES // (1024 * 1024)
+        return {}, [f"SDAT E66: Datei zu gross (max. {limit_mb} MB)."]
+
+    try:
+        root = _safe_xml_fromstring(xml_content)
+    except _PARSE_ERRORS:
+        return {}, ["SDAT E66: Ungültiges Dateiformat."]
+
+    try:
+        return _parse_document(root)
+    except _PARSE_ERRORS + (InvalidOperation,):
+        logger.exception("[SDAT] E66 konnte nicht gelesen werden")
+        return {}, ["SDAT E66: Ungültiges Dateiformat."]
+
+
+def _parse_document(root):
+    header = None
+    for child in root:
+        if _local_name(child.tag).endswith("HeaderInformation"):
+            header = child
+            break
+
+    doc_type = _text(header, "InstanceDocument", "DocumentType", "ebIXCode")
+    if doc_type != "E66":
+        return {}, ["SDAT E66: Keine Messpunkt-Daten gefunden."]
+
+    period = _path(header, "BusinessScopeProcess", "ReportPeriod")
+    document = {
+        "document_id": _text(header, "InstanceDocument", "DocumentID"),
+        "doc_type": doc_type,
+        "sender_id": _text(header, "Sender", "ID", "EICID"),
+        "receiver_id": _text(header, "Receiver", "ID", "EICID"),
+        "document_created_at": _utc(_text(header, "InstanceDocument", "Creation")),
+        "period_start": _utc(_text(period, "StartDateTime")),
+        "period_end": _utc(_text(period, "EndDateTime")),
+        "vnb_community_id": None,
+        "block_count": 0,
+        "point_ids": [],
+        "rows": [],
+        "warnings": [],
+    }
+
+    groups, warnings, hard_error = _collect_groups(root, document)
+    if hard_error:
+        return {}, [hard_error]
+    if not groups:
+        return {}, ["SDAT E66: Keine Messpunkt-Daten gefunden."]
+
+    document["warnings"] = warnings
+    document["point_ids"] = sorted({point for point, _ in groups})
+    document["rows"] = _build_rows(groups, warnings)
+    _warn_on_balance(document["rows"], warnings)
+    _warn_on_interval_count(document, groups, warnings)
+    return document, []
+
+
+def _collect_groups(root, document):
+    """Blöcke nach (Messpunkt, Richtung) gruppieren."""
+    groups = {}
+    warnings = []
+    unit_error = None
+
+    for block in root:
+        if _local_name(block.tag) != "MeteringData":
+            continue
+        document["block_count"] += 1
+
+        direction, point_id = _block_identity(block)
+        if not point_id:
+            warnings.append("Block ohne Messpunkt übersprungen.")
+            continue
+
+        unit = _text(block, "Product", "MeasureUnit")
+        if unit and unit.upper() != "KWH":
+            # Ein Feed in Wh würde jede Abrechnung um Faktor 1000 verfälschen.
+            unit_error = f"SDAT E66: Unerwartete Masseinheit {unit}."
+            break
+
+        channel = _channel(block)
+        if channel is None:
+            warnings.append(
+                f"Messpunkt {mask_point_id(point_id)}: unbekannter Produktcode "
+                "übersprungen."
+            )
+            continue
+
+        resolution = _resolution_minutes(block)
+        interval_start = _utc(_text(block, "Interval", "StartDateTime"))
+        if resolution is None or interval_start is None:
+            warnings.append(
+                f"Messpunkt {mask_point_id(point_id)}: Intervall oder Auflösung "
+                "fehlt, Block übersprungen."
+            )
+            continue
+
+        community = _text(block, "Community", "CommunityID")
+        if community and not document["vnb_community_id"]:
+            document["vnb_community_id"] = community
+
+        key = (point_id, direction)
+        existing = groups.get(key)
+        if existing and (
+            existing["start"] != interval_start or existing["resolution"] != resolution
+        ):
+            return (
+                groups,
+                warnings,
+                f"SDAT E66: Messpunkt {mask_point_id(point_id)} hat widersprüchliche Intervalle.",
+            )
+
+        group = groups.setdefault(
+            key,
+            {"start": interval_start, "resolution": resolution, "channels": {}},
+        )
+        group["channels"][channel] = _observations(block)
+
+    return groups, warnings, unit_error
+
+
+def _build_rows(groups, warnings):
+    rows = []
+    for (point_id, direction), group in sorted(groups.items()):
+        channels = group["channels"]
+        for name in ("total", "grid", "community"):
+            if name not in channels:
+                warnings.append(
+                    f"Messpunkt {mask_point_id(point_id)} ({direction}): "
+                    f"Kanal {name} fehlt."
+                )
+
+        sequences = sorted({seq for values in channels.values() for seq in values})
+        for sequence in sequences:
+            measured_at = group["start"] + timedelta(
+                minutes=(sequence - 1) * group["resolution"]
+            )
+            volumes = {}
+            condition = None
+            for name in ("total", "grid", "community"):
+                entry = channels.get(name, {}).get(sequence)
+                volumes[name] = entry[0] if entry else None
+                if condition is None and entry and entry[1]:
+                    condition = entry[1]
+
+            rows.append(
+                {
+                    "metering_point_id": point_id,
+                    "direction": direction,
+                    "measured_at": measured_at,
+                    "resolution_minutes": group["resolution"],
+                    "total_kwh": volumes["total"],
+                    "grid_kwh": volumes["grid"],
+                    "community_kwh": volumes["community"],
+                    "condition_code": condition,
+                }
+            )
+    return rows
+
+
+def _warn_on_balance(rows, warnings):
+    """Prüfen, ob total dem Anteil aus Netz und LEG entspricht."""
+    deviations = []
+    for row in rows:
+        total, grid, community = (
+            row["total_kwh"],
+            row["grid_kwh"],
+            row["community_kwh"],
+        )
+        if total is None or grid is None or community is None:
+            continue
+        deviation = abs(total - (grid + community))
+        if deviation > E66_BALANCE_TOLERANCE_KWH:
+            deviations.append((deviation, row))
+
+    if not deviations:
+        return
+
+    worst = max(deviation for deviation, _ in deviations)
+    examples = ", ".join(
+        f"{mask_point_id(row['metering_point_id'])} {row['direction']} "
+        f"{row['measured_at']:%Y-%m-%d %H:%MZ}"
+        for _, row in deviations[:3]
+    )
+    warnings.append(
+        f"{len(deviations)} Intervalle mit Kanalsumme-Abweichung "
+        f"(max. {worst} kWh): {examples}"
+    )
+
+
+def _warn_on_interval_count(document, groups, warnings):
+    """Erwartete Intervallzahl aus dem Berichtszeitraum ableiten.
+
+    Nicht fest 480 annehmen: der Zeitraum ist an lokale Mitternacht verankert,
+    ein Fenster über den Zeitumstellungssonntag hat 479 oder 481 Intervalle.
+    """
+    start, end = document["period_start"], document["period_end"]
+    if not start or not end:
+        return
+    for (point_id, direction), group in groups.items():
+        minutes = (end - start).total_seconds() / 60
+        expected = int(minutes // group["resolution"])
+        actual = len({seq for values in group["channels"].values() for seq in values})
+        if expected and actual != expected:
+            warnings.append(
+                f"Messpunkt {mask_point_id(point_id)} ({direction}): "
+                f"{actual} Intervalle statt {expected}."
+            )
+
+
+def parse_e66_file(path):
+    """E66 Datei von der Platte lesen und einlesen."""
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return parse_e66_xml(handle.read())
+    except OSError:
+        return {}, [f"SDAT E66: Datei nicht lesbar: {path}"]

--- a/store/metering.py
+++ b/store/metering.py
@@ -1,0 +1,411 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""SDAT metering point persistence repository.
+
+Holds the VNB metering point registry, the 15-minute E66 series and the
+per-file import ledger. Resolves the connection seam via
+``database.get_connection`` at call time so monkeypatches keep working and
+``database`` can re-export these functions.
+
+Daily E66 deliveries cover a five day window, so consecutive files overlap by
+four days. Writes are therefore idempotent upserts that skip rows whose values
+did not change and report how many rows were new versus corrected.
+"""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_NUMERIC_FIELDS = ("total_kwh", "grid_kwh", "community_kwh")
+
+_READING_COLUMNS = (
+    "metering_point_id",
+    "direction",
+    "measured_at",
+    "resolution_minutes",
+    "total_kwh",
+    "grid_kwh",
+    "community_kwh",
+    "condition_code",
+    "source_document_id",
+)
+
+_POINT_STUB_SQL = """
+    INSERT INTO metering_points (metering_point_id) VALUES %s
+    ON CONFLICT (metering_point_id) DO NOTHING
+"""
+
+# The WHERE guard does double duty: it keeps the ~80 percent of rows that an
+# overlapping delivery repeats verbatim from churning the table, and it makes
+# RETURNING report exactly the rows that moved. xmax = 0 marks a fresh insert,
+# so anything else returned is a correction of an earlier delivery.
+_READING_UPSERT_SQL = f"""
+    INSERT INTO metering_point_readings ({", ".join(_READING_COLUMNS)})
+    VALUES %s
+    ON CONFLICT (metering_point_id, direction, measured_at) DO UPDATE SET
+        total_kwh = EXCLUDED.total_kwh,
+        grid_kwh = EXCLUDED.grid_kwh,
+        community_kwh = EXCLUDED.community_kwh,
+        condition_code = EXCLUDED.condition_code,
+        resolution_minutes = EXCLUDED.resolution_minutes,
+        source_document_id = EXCLUDED.source_document_id,
+        imported_at = NOW()
+    WHERE metering_point_readings.total_kwh
+              IS DISTINCT FROM EXCLUDED.total_kwh
+       OR metering_point_readings.grid_kwh
+              IS DISTINCT FROM EXCLUDED.grid_kwh
+       OR metering_point_readings.community_kwh
+              IS DISTINCT FROM EXCLUDED.community_kwh
+       OR metering_point_readings.condition_code
+              IS DISTINCT FROM EXCLUDED.condition_code
+       OR metering_point_readings.resolution_minutes
+              IS DISTINCT FROM EXCLUDED.resolution_minutes
+       OR metering_point_readings.source_document_id
+              IS DISTINCT FROM EXCLUDED.source_document_id
+    RETURNING metering_point_id, direction, measured_at, (xmax = 0) AS inserted
+"""
+
+_POINT_UPSERT_SQL = """
+    INSERT INTO metering_points
+        (metering_point_id, vnb_community_id, community_id, building_id,
+         alias, address)
+    VALUES %s
+    ON CONFLICT (metering_point_id) DO UPDATE SET
+        vnb_community_id = COALESCE(
+            EXCLUDED.vnb_community_id, metering_points.vnb_community_id),
+        community_id = COALESCE(
+            EXCLUDED.community_id, metering_points.community_id),
+        building_id = COALESCE(
+            EXCLUDED.building_id, metering_points.building_id),
+        alias = COALESCE(EXCLUDED.alias, metering_points.alias),
+        address = COALESCE(EXCLUDED.address, metering_points.address),
+        updated_at = NOW()
+"""
+
+
+def _get_connection():
+    import database
+
+    return database.get_connection()
+
+
+def _floatify(row):
+    """NUMERIC kommt als Decimal zurück; pandas und numpy brauchen float."""
+    result = dict(row)
+    for field in _NUMERIC_FIELDS:
+        if result.get(field) is not None:
+            result[field] = float(result[field])
+    return result
+
+
+def _dedupe(rows):
+    """Auf (Messpunkt, Richtung, Zeit) entdoppeln, letzter Eintrag gewinnt.
+
+    Derselbe Konfliktschlüssel zweimal in einer INSERT-Anweisung bricht die
+    ganze Anweisung ab, also die ganze Datei.
+    """
+    unique = {}
+    for row in rows:
+        key = (row["metering_point_id"], row["direction"], row["measured_at"])
+        unique[key] = row
+    return list(unique.values())
+
+
+def save_metering_point_readings(rows, source_document_id=None, batch_size=5000):
+    """E66 Zeilen schreiben, unveränderte überspringen.
+
+    Returns:
+        dict mit written, new, corrected, unchanged und samples.
+    """
+    empty = {"written": 0, "new": 0, "corrected": 0, "unchanged": 0, "samples": []}
+    rows = _dedupe(rows)
+    if not rows:
+        return empty
+
+    try:
+        from psycopg2.extras import execute_values
+
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                points = sorted({row["metering_point_id"] for row in rows})
+                execute_values(cur, _POINT_STUB_SQL, [(point,) for point in points])
+
+                values = [
+                    tuple(
+                        row.get(column)
+                        if column != "source_document_id"
+                        else row.get(column, source_document_id)
+                        for column in _READING_COLUMNS
+                    )
+                    for row in rows
+                ]
+                changed = []
+                for start in range(0, len(values), batch_size):
+                    batch = values[start : start + batch_size]
+                    returned = execute_values(
+                        cur,
+                        _READING_UPSERT_SQL,
+                        batch,
+                        page_size=1000,
+                        fetch=True,
+                    )
+                    changed.extend(returned or [])
+
+                new = sum(1 for row in changed if row["inserted"])
+                corrected = len(changed) - new
+                samples = [
+                    (
+                        row["metering_point_id"],
+                        row["direction"],
+                        row["measured_at"],
+                    )
+                    for row in changed
+                    if not row["inserted"]
+                ][:20]
+                return {
+                    "written": len(values),
+                    "new": new,
+                    "corrected": corrected,
+                    "unchanged": len(values) - len(changed),
+                    "samples": samples,
+                }
+    except Exception as e:
+        logger.error(f"[DB] Error saving metering point readings: {e}")
+        return empty
+
+
+def upsert_metering_points(points):
+    """Register anreichern, ohne bestehende Werte zu leeren."""
+    points = [p for p in points if p.get("metering_point_id")]
+    if not points:
+        return 0
+    try:
+        from psycopg2.extras import execute_values
+
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                values = [
+                    (
+                        point["metering_point_id"],
+                        point.get("vnb_community_id") or None,
+                        point.get("community_id") or None,
+                        point.get("building_id") or None,
+                        point.get("alias") or None,
+                        point.get("address") or None,
+                    )
+                    for point in points
+                ]
+                execute_values(cur, _POINT_UPSERT_SQL, values)
+                return len(values)
+    except Exception as e:
+        logger.error(f"[DB] Error upserting metering points: {e}")
+        return 0
+
+
+def get_metering_points(community_id=None, active_only=True):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                query = "SELECT * FROM metering_points WHERE 1 = 1"
+                params = []
+                if community_id:
+                    query += " AND community_id = %s"
+                    params.append(community_id)
+                if active_only:
+                    query += " AND active = TRUE"
+                query += " ORDER BY metering_point_id"
+                cur.execute(query, params)
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting metering points: {e}")
+        return []
+
+
+def get_metering_point(metering_point_id):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM metering_points WHERE metering_point_id = %s",
+                    (metering_point_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting metering point: {e}")
+        return None
+
+
+def get_metering_point_readings(
+    metering_point_id, direction=None, start=None, end=None, limit=1000
+):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                query = (
+                    "SELECT * FROM metering_point_readings WHERE metering_point_id = %s"
+                )
+                params = [metering_point_id]
+                if direction:
+                    query += " AND direction = %s"
+                    params.append(direction)
+                if start:
+                    query += " AND measured_at >= %s"
+                    params.append(start)
+                if end:
+                    query += " AND measured_at <= %s"
+                    params.append(end)
+                query += " ORDER BY measured_at DESC LIMIT %s"
+                params.append(limit)
+                cur.execute(query, params)
+                return [_floatify(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting metering point readings: {e}")
+        return []
+
+
+def get_community_metering_points(community_id):
+    """Alle aktiven Messpunkte einer LEG mit dem Mitgliedschaftsstatus.
+
+    LEFT JOIN, nicht INNER: ein Messpunkt ohne Mitgliedschaftszeile muss
+    zurückkommen, damit die Abrechnung ihn benennen kann statt ihn stillschweigend
+    zu übergehen.
+    """
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT mp.metering_point_id,
+                           mp.building_id,
+                           mp.alias,
+                           cm.status AS member_status
+                    FROM metering_points mp
+                    LEFT JOIN community_members cm
+                           ON cm.community_id = mp.community_id
+                          AND cm.building_id = mp.building_id
+                    WHERE mp.community_id = %s
+                      AND mp.active = TRUE
+                    ORDER BY mp.metering_point_id
+                    """,
+                    (community_id,),
+                )
+                return [dict(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting community metering points: {e}")
+        return []
+
+
+def get_period_readings(community_id, period_start, period_end):
+    """Messwerte einer LEG im halboffenen Intervall [period_start, period_end).
+
+    Das Ende ist exklusiv. Ein inklusives Ende würde das Grenzintervall in zwei
+    Perioden doppelt verrechnen.
+    """
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    SELECT r.metering_point_id,
+                           r.direction,
+                           r.measured_at,
+                           r.resolution_minutes,
+                           r.total_kwh,
+                           r.grid_kwh,
+                           r.community_kwh,
+                           r.source_document_id
+                    FROM metering_point_readings r
+                    JOIN metering_points mp
+                      ON mp.metering_point_id = r.metering_point_id
+                    WHERE mp.community_id = %s
+                      AND r.measured_at >= %s
+                      AND r.measured_at < %s
+                    ORDER BY r.measured_at, r.metering_point_id, r.direction
+                    """,
+                    (community_id, period_start, period_end),
+                )
+                return [_floatify(row) for row in cur.fetchall()]
+    except Exception as e:
+        logger.error(f"[DB] Error getting period readings: {e}")
+        return []
+
+
+def get_metering_point_reading_stats(metering_point_id=None):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                query = """
+                    SELECT COUNT(*) as total_readings,
+                           COUNT(DISTINCT metering_point_id) as total_points,
+                           MIN(measured_at) as first_reading,
+                           MAX(measured_at) as last_reading,
+                           SUM(total_kwh) as total_kwh,
+                           SUM(grid_kwh) as grid_kwh,
+                           SUM(community_kwh) as community_kwh
+                    FROM metering_point_readings
+                """
+                params = []
+                if metering_point_id:
+                    query += " WHERE metering_point_id = %s"
+                    params.append(metering_point_id)
+                cur.execute(query, params)
+                row = cur.fetchone()
+                return dict(row) if row else {}
+    except Exception as e:
+        logger.error(f"[DB] Error getting metering point stats: {e}")
+        return {}
+
+
+def record_sdat_import(document):
+    """Eine importierte Datei im Ledger festhalten."""
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO sdat_imports (
+                        document_id, doc_type, file_name, vnb_community_id,
+                        document_created_at, period_start, period_end,
+                        block_count, row_count, new_count, corrected_count
+                    ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                    ON CONFLICT (document_id) DO UPDATE SET
+                        file_name = EXCLUDED.file_name,
+                        block_count = EXCLUDED.block_count,
+                        row_count = EXCLUDED.row_count,
+                        new_count = EXCLUDED.new_count,
+                        corrected_count = EXCLUDED.corrected_count,
+                        imported_at = NOW()
+                """,
+                    (
+                        document.get("document_id"),
+                        document.get("doc_type"),
+                        document.get("file_name"),
+                        document.get("vnb_community_id"),
+                        document.get("document_created_at"),
+                        document.get("period_start"),
+                        document.get("period_end"),
+                        document.get("block_count", 0),
+                        document.get("row_count", 0),
+                        document.get("new_count", 0),
+                        document.get("corrected_count", 0),
+                    ),
+                )
+                return True
+    except Exception as e:
+        logger.error(f"[DB] Error recording SDAT import: {e}")
+        return False
+
+
+def get_sdat_import(document_id):
+    try:
+        with _get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT * FROM sdat_imports WHERE document_id = %s",
+                    (document_id,),
+                )
+                row = cur.fetchone()
+                return dict(row) if row else None
+    except Exception as e:
+        logger.error(f"[DB] Error getting SDAT import: {e}")
+        return None

--- a/store/schema.py
+++ b/store/schema.py
@@ -800,4 +800,76 @@ def create_tables():
                 "CREATE INDEX IF NOT EXISTS idx_ops_snapshots_created ON ops_snapshots(created_at DESC)"
             )
 
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS metering_points (
+                    metering_point_id VARCHAR(64) PRIMARY KEY,
+                    vnb_community_id VARCHAR(64),
+                    community_id VARCHAR(64) REFERENCES communities(community_id)
+                        ON DELETE SET NULL,
+                    building_id VARCHAR(64) REFERENCES buildings(building_id)
+                        ON DELETE SET NULL,
+                    alias VARCHAR(128),
+                    address TEXT,
+                    active BOOLEAN DEFAULT TRUE,
+                    first_seen_at TIMESTAMPTZ DEFAULT NOW(),
+                    updated_at TIMESTAMPTZ DEFAULT NOW()
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_metering_points_building ON metering_points(building_id)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_metering_points_community ON metering_points(community_id)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_metering_points_vnb_community ON metering_points(vnb_community_id)"
+            )
+
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS metering_point_readings (
+                    id BIGSERIAL PRIMARY KEY,
+                    metering_point_id VARCHAR(64) NOT NULL
+                        REFERENCES metering_points(metering_point_id)
+                        ON DELETE CASCADE,
+                    direction VARCHAR(16) NOT NULL
+                        CHECK (direction IN ('consumption', 'production')),
+                    measured_at TIMESTAMPTZ NOT NULL,
+                    resolution_minutes SMALLINT NOT NULL DEFAULT 15,
+                    total_kwh NUMERIC(12, 4),
+                    grid_kwh NUMERIC(12, 4),
+                    community_kwh NUMERIC(12, 4),
+                    condition_code VARCHAR(8),
+                    source_document_id VARCHAR(64),
+                    imported_at TIMESTAMPTZ DEFAULT NOW(),
+                    UNIQUE (metering_point_id, direction, measured_at)
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mpr_measured_at ON metering_point_readings(measured_at)"
+            )
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_mpr_document ON metering_point_readings(source_document_id)"
+            )
+
+            cur.execute("""
+                CREATE TABLE IF NOT EXISTS sdat_imports (
+                    id SERIAL PRIMARY KEY,
+                    document_id VARCHAR(64) NOT NULL UNIQUE,
+                    doc_type VARCHAR(8),
+                    file_name VARCHAR(255),
+                    vnb_community_id VARCHAR(64),
+                    document_created_at TIMESTAMPTZ,
+                    period_start TIMESTAMPTZ,
+                    period_end TIMESTAMPTZ,
+                    block_count INTEGER DEFAULT 0,
+                    row_count INTEGER DEFAULT 0,
+                    new_count INTEGER DEFAULT 0,
+                    corrected_count INTEGER DEFAULT 0,
+                    imported_at TIMESTAMPTZ DEFAULT NOW()
+                )
+            """)
+            cur.execute(
+                "CREATE INDEX IF NOT EXISTS idx_sdat_imports_period ON sdat_imports(period_start)"
+            )
+
             logger.info("[DB] Tables and indexes created successfully")

--- a/tests/fixtures/sdat_e66_sample.xml
+++ b/tests/fixtures/sdat_e66_sample.xml
@@ -1,0 +1,414 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Synthetic ebIX E66 sample. Structure mirrors a real VSE ValidatedMeteredData_16
+  delivery; every value is invented. Two metering points, one of which is both a
+  consumption and a production point. Three product channels per (point,
+  direction), three observations each: 9 blocks, 27 observations, 9 wide rows.
+  The interval anchor is 23:00Z (winter, CET) on purpose: 22:00Z is only correct
+  during CEST. One observation carries Condition 21 on a non-total channel, and
+  one row is off by exactly 0.001 kWh to sit inside the balance tolerance.
+-->
+<rsm:ValidatedMeteredData_16 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.strom.ch ValidatedMeteredData_1p6.xsd" xmlns:rsm="http://www.strom.ch">
+  <rsm:ValidatedMeteredData_HeaderInformation>
+    <rsm:HeaderVersion>1.0</rsm:HeaderVersion>
+    <rsm:Sender>
+      <rsm:ID>
+        <rsm:EICID schemeAgencyID="305">12X-TEST-SENDER-1</rsm:EICID>
+      </rsm:ID>
+      <rsm:Role>MDR</rsm:Role>
+    </rsm:Sender>
+    <rsm:Receiver>
+      <rsm:ID>
+        <rsm:EICID schemeAgencyID="305">12X-TEST-RECV-1</rsm:EICID>
+      </rsm:ID>
+      <rsm:Role>CEM</rsm:Role>
+    </rsm:Receiver>
+    <rsm:InstanceDocument>
+      <rsm:DictionaryAgencyID>260</rsm:DictionaryAgencyID>
+      <rsm:VersionID listAgencyID="260">2007B</rsm:VersionID>
+      <rsm:DocumentID>TESTDOC-1</rsm:DocumentID>
+      <rsm:DocumentType listAgencyID="260">
+        <rsm:ebIXCode>E66</rsm:ebIXCode>
+      </rsm:DocumentType>
+      <rsm:Creation>2026-01-06T04:30:00Z</rsm:Creation>
+      <rsm:Status>9</rsm:Status>
+    </rsm:InstanceDocument>
+    <rsm:BusinessScopeProcess>
+      <rsm:BusinessReasonType codeListAgency="260" codeListID="VSE">
+        <rsm:VSENationalCode>C40</rsm:VSENationalCode>
+      </rsm:BusinessReasonType>
+      <rsm:BusinessDomainType listAgencyID="260">E02</rsm:BusinessDomainType>
+      <rsm:BusinessSectorType>23</rsm:BusinessSectorType>
+      <rsm:ReportPeriod>
+        <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+        <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+      </rsm:ReportPeriod>
+      <rsm:BusinessService>
+        <rsm:ServiceTransaction isIntelligibleCheckRequired="true"></rsm:ServiceTransaction>
+      </rsm:BusinessService>
+    </rsm:BusinessScopeProcess>
+  </rsm:ValidatedMeteredData_HeaderInformation>
+
+  <!-- Point 1, consumption, total channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@1</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000001</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:ebIXCode schemeAgencyID="9">8716867000030</rsm:ebIXCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.100</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.200</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.300</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 1, consumption, grid channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@2</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000001</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010124</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.060</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.140</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.180</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 1, consumption, community channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@3</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000001</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010123</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.040</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.060</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.120</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2, consumption, total channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@4</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:ebIXCode schemeAgencyID="9">8716867000030</rsm:ebIXCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.500</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.400</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.250</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2, consumption, grid channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@5</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010124</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.300</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.200</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.150</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2, consumption, community channel. Sequence 3 makes the row sum to
+       0.251 against a total of 0.250: inside the balance tolerance. -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@6</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010123</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.200</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.200</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.101</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2 again, this time as a production point -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@7</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ProductionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ProductionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:ebIXCode schemeAgencyID="9">8716867000030</rsm:ebIXCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>1.000</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>2.000</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>3.000</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2, production, grid channel. Sequence 3 carries Condition 21, on a
+       channel other than the total, so the roll-up onto the wide row is tested. -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@8</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ProductionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ProductionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010124</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.800</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>1.500</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>2.400</rsm:Volume>
+      <rsm:Condition>21</rsm:Condition>
+    </rsm:Observation>
+  </rsm:MeteringData>
+
+  <!-- Point 2, production, community channel -->
+  <rsm:MeteringData>
+    <rsm:DocumentID>TESTDOC-1@9</rsm:DocumentID>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:45:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ProductionMeteringPoint>
+      <rsm:VSENationalID schemeID="VSE" schemeAgencyID="260">CH000000000000000000000000000002</rsm:VSENationalID>
+    </rsm:ProductionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>
+        <rsm:VSENationalCode schemeAgencyID="260">2404050010123</rsm:VSENationalCode>
+      </rsm:ID>
+      <rsm:MeasureUnit>KWH</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+      <rsm:CommunityType codeListAgency="260">
+        <rsm:VSENationalCode>CT01</rsm:VSENationalCode>
+      </rsm:CommunityType>
+    </rsm:Community>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>1</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.200</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>2</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.500</rsm:Volume>
+    </rsm:Observation>
+    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>3</rsm:Sequence></rsm:Position>
+      <rsm:Volume>0.600</rsm:Volume>
+    </rsm:Observation>
+  </rsm:MeteringData>
+</rsm:ValidatedMeteredData_16>

--- a/tests/test_billing_readings.py
+++ b/tests/test_billing_readings.py
@@ -1,0 +1,416 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Contract for the SDAT metering to billing adapter.
+
+The billing engine wants participant-keyed 15-minute frames with identical
+indexes. The metering store holds point-keyed rows in UTC. This adapter is the
+only place that translation happens, so it also owns the data-quality gate:
+a period that cannot be billed must fail loudly, naming the offending point.
+
+Fixtures are synthetic SDAT-E66 documents. No citizen data enters this suite.
+"""
+
+from copy import deepcopy
+from datetime import datetime, timedelta
+from pathlib import Path
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+import pytest
+
+import billing_engine
+import billing_readings
+import database
+import sdat_e66
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sdat_e66_sample.xml"
+ZURICH = ZoneInfo("Europe/Zurich")
+COMMUNITY = "COMM-TEST"
+POINT_A = "CH000000000000000000000000000001"
+POINT_B = "CH000000000000000000000000000002"
+BUILDING_A = "BLD-A"
+BUILDING_B = "BLD-B"
+
+# The fixture covers 2026-01-05 23:00 to 23:45 UTC, which is 2026-01-06
+# 00:00 to 00:45 in Europe/Zurich. Crossing midnight keeps the timezone
+# handling honest.
+PERIOD_START = datetime(2026, 1, 6, 0, 0, tzinfo=ZURICH)
+PERIOD_END = datetime(2026, 1, 6, 0, 45, tzinfo=ZURICH)
+
+
+def _fixture_rows():
+    document, errors = sdat_e66.parse_e66_file(FIXTURE)
+    assert errors == [], errors
+    return document
+
+
+def _points(status_a="confirmed", status_b="confirmed", building_a=BUILDING_A):
+    return [
+        {
+            "metering_point_id": POINT_A,
+            "building_id": building_a,
+            "member_status": status_a,
+        },
+        {
+            "metering_point_id": POINT_B,
+            "building_id": BUILDING_B,
+            "member_status": status_b,
+        },
+    ]
+
+
+def _install(monkeypatch, points, rows):
+    """Fake the repository seam the way the real SQL behaves."""
+
+    def _get_points(community_id):
+        assert community_id == COMMUNITY
+        return deepcopy(points)
+
+    def _get_readings(community_id, period_start, period_end):
+        assert community_id == COMMUNITY
+        return [
+            deepcopy(row)
+            for row in rows
+            if period_start <= row["measured_at"] < period_end
+        ]
+
+    monkeypatch.setattr(database, "get_community_metering_points", _get_points)
+    monkeypatch.setattr(database, "get_period_readings", _get_readings)
+
+
+@pytest.fixture
+def rows():
+    return _fixture_rows()["rows"]
+
+
+# --- Step 1: participant-keyed frames for a half-open period ---
+
+
+def test_loads_participant_keyed_frames(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert list(frames.consumption.columns) == [BUILDING_A, BUILDING_B]
+    assert len(frames.consumption) == 3
+    assert frames.consumption[BUILDING_A].sum() == pytest.approx(0.6)
+    assert frames.consumption[BUILDING_B].sum() == pytest.approx(1.15)
+    assert frames.production[BUILDING_B].sum() == pytest.approx(6.0)
+
+
+def test_index_is_local_quarter_hours(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert str(frames.consumption.index.tz) == "Europe/Zurich"
+    assert frames.consumption.index[0] == PERIOD_START
+    assert frames.consumption.index[-1] == PERIOD_START + timedelta(minutes=30)
+
+
+def test_period_end_is_exclusive(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(
+        COMMUNITY, PERIOD_START, PERIOD_START + timedelta(minutes=30)
+    )
+
+    assert len(frames.consumption) == 2
+
+
+def test_naive_boundaries_are_read_in_the_period_timezone(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+    # Naive on purpose: an operator entering a period says "1 July", not
+    # "1 July 00:00+02:00". DTZ001 is the rule under test here.
+    naive_start = datetime(2026, 1, 6, 0, 0)  # noqa: DTZ001
+    naive_end = datetime(2026, 1, 6, 0, 45)  # noqa: DTZ001
+
+    frames = billing_readings.load_period_frames(COMMUNITY, naive_start, naive_end)
+
+    assert len(frames.consumption) == 3
+
+
+def test_production_frame_matches_the_consumption_shape(monkeypatch, rows):
+    """The engine asserts index equality and needs a column per participant."""
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert frames.production.index.equals(frames.consumption.index)
+    assert list(frames.production.columns) == list(frames.consumption.columns)
+    # Building A has no production meter and must read as zero, not as absent.
+    assert frames.production[BUILDING_A].sum() == 0.0
+
+
+def test_values_are_floats_not_decimals(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert frames.consumption.to_numpy().dtype.kind == "f"
+    assert frames.production.to_numpy().dtype.kind == "f"
+
+
+def test_two_points_of_one_member_collapse_into_one_column(monkeypatch, rows):
+    """A member with a separate production meter is still one participant."""
+    points = _points()
+    points[1]["building_id"] = BUILDING_A
+    _install(monkeypatch, points, rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert list(frames.consumption.columns) == [BUILDING_A]
+    assert frames.consumption[BUILDING_A].sum() == pytest.approx(1.75)
+    assert frames.production[BUILDING_A].sum() == pytest.approx(6.0)
+
+
+# --- Step 3: data quality must fail with actionable diagnostics ---
+
+
+def _kinds(excinfo):
+    return {problem["kind"] for problem in excinfo.value.problems}
+
+
+def test_unconfirmed_member_is_rejected(monkeypatch, rows):
+    _install(monkeypatch, _points(status_b="invited"), rows)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "unconfirmed_member" in _kinds(excinfo)
+    assert POINT_B in str(excinfo.value)
+
+
+def test_point_without_a_member_is_rejected(monkeypatch, rows):
+    _install(monkeypatch, _points(building_a=None), rows)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "unmapped_point" in _kinds(excinfo)
+    assert POINT_A in str(excinfo.value)
+
+
+def test_unknown_metering_point_is_rejected(monkeypatch, rows):
+    stray = deepcopy(rows[0])
+    stray["metering_point_id"] = "CH000000000000000000000000000099"
+    _install(monkeypatch, _points(), rows + [stray])
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "unknown_point" in _kinds(excinfo)
+
+
+def test_duplicate_interval_is_rejected(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows + [deepcopy(rows[0])])
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "duplicate_interval" in _kinds(excinfo)
+
+
+def test_missing_interval_is_rejected(monkeypatch, rows):
+    gapped = [row for row in rows if row["measured_at"].minute != 15]
+    _install(monkeypatch, _points(), gapped)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "missing_interval" in _kinds(excinfo)
+    assert "00:15" in str(excinfo.value)
+
+
+def test_negative_value_is_rejected(monkeypatch, rows):
+    dirty = deepcopy(rows)
+    dirty[0]["total_kwh"] = -1
+    _install(monkeypatch, _points(), dirty)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "negative_value" in _kinds(excinfo)
+
+
+def test_misaligned_interval_is_rejected(monkeypatch, rows):
+    """A timestamp off the quarter-hour grid must not silently add a row.
+
+    Assigning by label would extend the frame with an extra index entry, which
+    would leave the period looking complete while carrying an interval nobody
+    expects.
+    """
+    dirty = deepcopy(rows)
+    dirty[0]["measured_at"] = dirty[0]["measured_at"] + timedelta(minutes=7)
+    _install(monkeypatch, _points(), dirty)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "misaligned_interval" in _kinds(excinfo)
+
+
+def test_mixed_resolution_is_rejected(monkeypatch, rows):
+    dirty = deepcopy(rows)
+    dirty[0]["resolution_minutes"] = 30
+    _install(monkeypatch, _points(), dirty)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "mixed_resolution" in _kinds(excinfo)
+
+
+def test_mixed_units_never_reach_the_adapter():
+    """The unit gate lives at the parse boundary; readings carry no unit column.
+
+    A document in Wh must fail before anything is stored, so the adapter can
+    trust that every row it loads is in kWh.
+    """
+    xml = FIXTURE.read_text(encoding="utf-8").replace(
+        "<rsm:MeasureUnit>KWH</rsm:MeasureUnit>",
+        "<rsm:MeasureUnit>WH</rsm:MeasureUnit>",
+        1,
+    )
+    document, errors = sdat_e66.parse_e66_xml(xml)
+
+    assert errors, "a non-kWh document must be a hard parse error"
+    assert not document.get("rows")
+
+
+def test_all_problems_are_reported_at_once(monkeypatch, rows):
+    """One run per period: an operator should see every defect, not the first."""
+    dirty = deepcopy(rows)
+    dirty[0]["total_kwh"] = -1
+    dirty[1]["resolution_minutes"] = 30
+    _install(monkeypatch, _points(status_b="invited"), dirty)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert {"negative_value", "mixed_resolution", "unconfirmed_member"} <= _kinds(
+        excinfo
+    )
+
+
+def test_empty_period_is_rejected(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(
+            COMMUNITY,
+            datetime(2026, 2, 1, tzinfo=ZURICH),
+            datetime(2026, 2, 2, tzinfo=ZURICH),
+        )
+
+    assert "no_readings" in _kinds(excinfo)
+
+
+# --- Step 5: the frames drive the billing engine ---
+
+
+def _summary(frames, price=0.11):
+    return billing_engine.generate_billing_summary(
+        frames.production,
+        frames.consumption,
+        grid_fee_per_kwh=0.09,
+        internal_price_per_kwh=price,
+        network_level="same",
+    )
+
+
+def test_frames_drive_the_engine_into_charges_and_credits(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    summary = _summary(frames)
+
+    charges = [i for i in summary["line_items"] if i["item_type"] == "consumer_charge"]
+    credits = {
+        i["participant_id"]: i
+        for i in summary["line_items"]
+        if i["item_type"] == "producer_credit"
+    }
+    assert charges, "consumption must produce positive charges"
+    assert all(item["amount_chf"] > 0 for item in charges)
+    # Building B owns the only production meter, so it carries the credit.
+    assert credits[BUILDING_B]["amount_chf"] < 0
+    # Building A produced nothing. The engine still emits a zero-value credit
+    # line because the frames must share their columns; it must not be positive.
+    assert credits[BUILDING_A]["amount_chf"] == pytest.approx(0.0)
+    assert summary["internal_price_chf_per_kwh"] == 0.11
+
+
+def test_engine_ledger_balances_to_zero(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    summary = _summary(frames)
+
+    assert sum(item["amount_chf"] for item in summary["line_items"]) == pytest.approx(
+        0.0, abs=1e-9
+    )
+
+
+def test_reconciliation_reports_the_gap_to_the_vnb_allocation(monkeypatch, rows):
+    """The VNB already allocated. The engine reallocates. Surface the delta."""
+    _install(monkeypatch, _points(), rows)
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+    summary = _summary(frames)
+
+    report = billing_readings.reconcile_with_vnb(frames, summary)
+
+    # The fixture's VNB community channel sums to 0.721 kWh on the consumption
+    # side while proportional allocation reaches 1.75 kWh.
+    assert report["vnb_allocated_kwh"] == pytest.approx(0.721)
+    assert report["engine_allocated_kwh"] == pytest.approx(1.75)
+    assert report["difference_kwh"] == pytest.approx(1.029)
+    assert report["per_participant"][BUILDING_A]["vnb_kwh"] == pytest.approx(0.22)
+
+
+def test_nothing_is_persisted_by_the_adapter(monkeypatch, rows):
+    """This slice reads. Writing a period stays with save_billing_period."""
+
+    def _fail(*_args, **_kwargs):
+        raise AssertionError("the adapter must not write")
+
+    monkeypatch.setattr(database, "save_billing_period", _fail)
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+    _summary(frames)
+
+
+# --- Provenance ---
+
+
+def test_frames_carry_import_provenance(monkeypatch, rows):
+    sourced = deepcopy(rows)
+    for row in sourced:
+        row["source_document_id"] = "TESTDOC-1"
+    _install(monkeypatch, _points(), sourced)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert frames.provenance["source_document_ids"] == ("TESTDOC-1",)
+    assert frames.provenance["interval_count"] == 3
+    assert frames.provenance["resolution_minutes"] == 15
+
+
+def test_provenance_survives_multiple_source_documents(monkeypatch, rows):
+    sourced = deepcopy(rows)
+    for index, row in enumerate(sourced):
+        row["source_document_id"] = "DOC-B" if index % 2 else "DOC-A"
+    _install(monkeypatch, _points(), sourced)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert frames.provenance["source_document_ids"] == ("DOC-A", "DOC-B")
+
+
+def test_frames_are_plain_pandas(monkeypatch, rows):
+    _install(monkeypatch, _points(), rows)
+
+    frames = billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert isinstance(frames.consumption, pd.DataFrame)
+    assert isinstance(frames.production, pd.DataFrame)

--- a/tests/test_metering_schema.py
+++ b/tests/test_metering_schema.py
@@ -1,0 +1,125 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Schema contract for the SDAT metering point tables.
+
+E66 files carry one series per (metering point, direction, product channel).
+One physical point can be both a consumption and a production point, so the
+readings key must include direction; without it the second series silently
+overwrites the first. measured_at is TIMESTAMPTZ because the source is UTC and
+a naive local key would collide on the October DST repeat.
+"""
+
+import os
+import re
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+def _schema_source() -> str:
+    with open(
+        os.path.join(PROJECT_ROOT, "store/schema.py"), encoding="utf-8"
+    ) as handle:
+        return handle.read()
+
+
+def _create_block(source: str, table: str) -> str:
+    match = re.search(
+        rf"CREATE TABLE IF NOT EXISTS {table} \((.*?)\)\s*\"\"\"",
+        source,
+        flags=re.DOTALL,
+    )
+    assert match, f"CREATE TABLE {table} block not found"
+    return match.group(1)
+
+
+def test_metering_points_is_keyed_on_the_point_id():
+    block = _create_block(_schema_source(), "metering_points")
+    assert re.search(r"metering_point_id VARCHAR\(64\) PRIMARY KEY", block), (
+        "metering_points must be keyed on metering_point_id"
+    )
+
+
+def test_metering_points_keeps_vnb_and_openleg_community_ids_apart():
+    block = _create_block(_schema_source(), "metering_points")
+    assert re.search(r"vnb_community_id VARCHAR\(64\)", block), (
+        "the VNB CommunityID needs its own column"
+    )
+    assert re.search(r"community_id VARCHAR\(64\) REFERENCES communities", block), (
+        "community_id must reference the OpenLEG communities table"
+    )
+
+
+def test_metering_points_does_not_cascade_deletes_from_buildings():
+    block = _create_block(_schema_source(), "metering_points")
+    assert "ON DELETE SET NULL" in block, (
+        "deleting a building must not delete VNB measurement history"
+    )
+
+
+def test_readings_measured_at_is_timestamptz():
+    block = _create_block(_schema_source(), "metering_point_readings")
+    assert re.search(r"measured_at TIMESTAMPTZ NOT NULL", block), (
+        "measured_at must be TIMESTAMPTZ; the SDAT source is UTC"
+    )
+
+
+def test_readings_unique_key_includes_direction():
+    block = _create_block(_schema_source(), "metering_point_readings")
+    assert re.search(
+        r"UNIQUE\s*\(metering_point_id,\s*direction,\s*measured_at\)", block
+    ), (
+        "the unique key must include direction; one point can be both a "
+        "consumption and a production point at the same instant"
+    )
+
+
+def test_readings_direction_is_constrained():
+    block = _create_block(_schema_source(), "metering_point_readings")
+    assert "consumption" in block and "production" in block
+    assert "CHECK" in block, "direction needs a CHECK constraint"
+
+
+def test_readings_reference_the_point_registry():
+    block = _create_block(_schema_source(), "metering_point_readings")
+    assert "REFERENCES metering_points" in block
+
+
+def test_readings_carry_the_three_channels_and_provenance():
+    block = _create_block(_schema_source(), "metering_point_readings")
+    for column in ("total_kwh", "grid_kwh", "community_kwh"):
+        assert re.search(rf"{column} NUMERIC\(12, 4\)", block), (
+            f"{column} must be NUMERIC(12, 4)"
+        )
+    assert "condition_code" in block
+    assert "source_document_id" in block
+    assert "resolution_minutes" in block
+
+
+def test_sdat_imports_is_keyed_on_the_document_id():
+    block = _create_block(_schema_source(), "sdat_imports")
+    assert re.search(r"document_id VARCHAR\(64\) NOT NULL UNIQUE", block), (
+        "the file ledger must be keyed on the SDAT document id"
+    )
+    for column in ("new_count", "corrected_count", "row_count"):
+        assert column in block
+
+
+def test_tables_are_created_before_the_completion_log():
+    source = _schema_source()
+    log_line = 'logger.info("[DB] Tables and indexes created successfully")'
+    for table in ("metering_points", "metering_point_readings", "sdat_imports"):
+        ddl = f"CREATE TABLE IF NOT EXISTS {table} ("
+        assert source.index(ddl) < source.index(log_line), (
+            f"{table} DDL must run inside create_tables()"
+        )
+
+
+def test_metering_indexes_exist():
+    source = _schema_source()
+    for index in (
+        "idx_metering_points_building",
+        "idx_metering_points_community",
+        "idx_mpr_measured_at",
+        "idx_mpr_document",
+        "idx_sdat_imports_period",
+    ):
+        assert f"CREATE INDEX IF NOT EXISTS {index}" in source, f"missing index {index}"

--- a/tests/test_sdat_e66.py
+++ b/tests/test_sdat_e66.py
@@ -1,0 +1,382 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Parser contract for Swiss ebIX E66 (ValidatedMeteredData_16) documents.
+
+An E66 file carries one series per (metering point, direction, product
+channel). The parser folds the three product channels of a (point, direction)
+pair into one wide row, derives each timestamp from the block interval and the
+observation sequence, and reports data problems as warnings rather than
+refusing the file.
+"""
+
+import os
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import sdat_e66
+
+FIXTURES_DIR = os.path.join(os.path.dirname(__file__), "fixtures")
+
+POINT_ONE = "CH000000000000000000000000000001"
+POINT_TWO = "CH000000000000000000000000000002"
+
+
+def _load_fixture(filename):
+    with open(os.path.join(FIXTURES_DIR, filename), encoding="utf-8") as handle:
+        return handle.read()
+
+
+def _sample():
+    return _load_fixture("sdat_e66_sample.xml")
+
+
+def _parsed():
+    document, errors = sdat_e66.parse_e66_xml(_sample())
+    assert errors == [], errors
+    return document
+
+
+def _row(rows, point, direction, sequence):
+    measured_at = datetime(2026, 1, 5, 23, 0, tzinfo=timezone.utc)
+    measured_at = measured_at.replace(minute=15 * (sequence - 1))
+    for row in rows:
+        if (
+            row["metering_point_id"] == point
+            and row["direction"] == direction
+            and row["measured_at"] == measured_at
+        ):
+            return row
+    raise AssertionError(f"no row for {point} {direction} seq {sequence}")
+
+
+# ==== Document metadata ====
+
+
+def test_parses_document_metadata():
+    document = _parsed()
+    assert document["document_id"] == "TESTDOC-1"
+    assert document["doc_type"] == "E66"
+    assert document["vnb_community_id"] == "TEST-COMMUNITY"
+    assert document["block_count"] == 9
+    assert document["period_start"] == datetime(2026, 1, 5, 23, 0, tzinfo=timezone.utc)
+    assert document["period_end"] == datetime(2026, 1, 5, 23, 45, tzinfo=timezone.utc)
+
+
+def test_reports_the_distinct_metering_points():
+    document = _parsed()
+    assert document["point_ids"] == [POINT_ONE, POINT_TWO]
+
+
+def test_folds_three_channels_per_pair_into_one_row_each():
+    document = _parsed()
+    assert len(document["rows"]) == 9
+
+
+# ==== Timestamps ====
+
+
+def test_derives_timestamps_from_sequence_and_resolution():
+    rows = _parsed()["rows"]
+    stamps = sorted(
+        row["measured_at"] for row in rows if row["metering_point_id"] == POINT_ONE
+    )
+    assert stamps == [
+        datetime(2026, 1, 5, 23, 0, tzinfo=timezone.utc),
+        datetime(2026, 1, 5, 23, 15, tzinfo=timezone.utc),
+        datetime(2026, 1, 5, 23, 30, tzinfo=timezone.utc),
+    ]
+
+
+def test_every_timestamp_is_timezone_aware_utc():
+    for row in _parsed()["rows"]:
+        assert row["measured_at"].tzinfo is not None
+        assert row["measured_at"].utcoffset() == timezone.utc.utcoffset(None)
+
+
+def test_rows_are_labelled_with_the_interval_start():
+    rows = _parsed()["rows"]
+    first = _row(rows, POINT_ONE, "consumption", 1)
+    assert first["measured_at"] == datetime(2026, 1, 5, 23, 0, tzinfo=timezone.utc)
+    assert first["resolution_minutes"] == 15
+
+
+# ==== Channel folding ====
+
+
+def test_wide_row_carries_total_grid_and_community():
+    row = _row(_parsed()["rows"], POINT_ONE, "consumption", 1)
+    assert row["total_kwh"] == Decimal("0.100")
+    assert row["grid_kwh"] == Decimal("0.060")
+    assert row["community_kwh"] == Decimal("0.040")
+
+
+def test_volumes_are_decimals_not_floats():
+    row = _row(_parsed()["rows"], POINT_ONE, "consumption", 1)
+    for field in ("total_kwh", "grid_kwh", "community_kwh"):
+        assert isinstance(row[field], Decimal), f"{field} must stay Decimal"
+
+
+# ==== The dual role point ====
+
+
+def test_dual_role_point_yields_both_directions():
+    rows = _parsed()["rows"]
+    directions = {
+        row["direction"] for row in rows if row["metering_point_id"] == POINT_TWO
+    }
+    assert directions == {"consumption", "production"}
+
+
+def test_dual_role_point_rows_do_not_collide():
+    rows = _parsed()["rows"]
+    keys = {
+        (row["metering_point_id"], row["direction"], row["measured_at"]) for row in rows
+    }
+    assert len(keys) == len(rows), "point, direction and time must be unique together"
+    consumption = _row(rows, POINT_TWO, "consumption", 1)
+    production = _row(rows, POINT_TWO, "production", 1)
+    assert consumption["measured_at"] == production["measured_at"]
+    assert consumption["total_kwh"] != production["total_kwh"]
+
+
+# ==== Condition ====
+
+
+def test_condition_rolls_up_from_a_non_total_channel():
+    rows = _parsed()["rows"]
+    flagged = [row for row in rows if row["condition_code"] is not None]
+    assert len(flagged) == 1
+    assert flagged[0]["condition_code"] == "21"
+    assert flagged[0]["metering_point_id"] == POINT_TWO
+    assert flagged[0]["direction"] == "production"
+
+
+# ==== Balance validation ====
+
+
+def test_rounding_inside_tolerance_does_not_warn():
+    document = _parsed()
+    balance_warnings = [w for w in document["warnings"] if "Kanalsumme" in w]
+    assert balance_warnings == [], document["warnings"]
+
+
+def test_channel_imbalance_warns_but_still_returns_rows():
+    document, errors = sdat_e66.parse_e66_xml(E66_IMBALANCED)
+    assert errors == []
+    assert document["rows"], "an imbalance must not discard the data"
+    assert any("Kanalsumme" in warning for warning in document["warnings"])
+
+
+def test_missing_channel_is_null_and_warns():
+    document, errors = sdat_e66.parse_e66_xml(E66_MISSING_CHANNEL)
+    assert errors == []
+    assert document["rows"][0]["community_kwh"] is None
+    assert any("Kanal" in warning for warning in document["warnings"])
+
+
+# ==== Hard errors ====
+
+
+def test_unexpected_measure_unit_is_a_hard_error():
+    document, errors = sdat_e66.parse_e66_xml(E66_BAD_UNIT)
+    assert document == {}
+    assert errors and "Masseinheit" in errors[0]
+
+
+def test_one_series_cannot_mix_interval_definitions():
+    xml = _sample().replace(
+        "<rsm:Resolution>15</rsm:Resolution>",
+        "<rsm:Resolution>30</rsm:Resolution>",
+        1,
+    )
+
+    document, errors = sdat_e66.parse_e66_xml(xml)
+
+    assert document == {}
+    assert errors and "widersprüchliche Intervalle" in errors[0]
+
+
+def test_empty_input_returns_an_error():
+    document, errors = sdat_e66.parse_e66_xml("")
+    assert document == {}
+    assert errors
+
+
+def test_malformed_xml_does_not_leak_the_input():
+    secret = "sensitive test payload"
+    document, errors = sdat_e66.parse_e66_xml(f"<broken>{secret}")
+    assert document == {}
+    assert errors
+    assert all(secret not in message for message in errors)
+
+
+def test_oversize_input_is_rejected(monkeypatch):
+    monkeypatch.setattr(sdat_e66, "MAX_E66_BYTES", 100)
+    document, errors = sdat_e66.parse_e66_xml(_sample())
+    assert document == {}
+    assert errors and "gross" in errors[0]
+
+
+def test_parser_never_raises_on_truncated_input():
+    sample = _sample()
+    for cut in range(0, len(sample), max(1, len(sample) // 12)):
+        result = sdat_e66.parse_e66_xml(sample[:cut])
+        assert isinstance(result, tuple) and len(result) == 2
+
+
+def test_duplicate_sequence_keeps_the_last_value():
+    document, errors = sdat_e66.parse_e66_xml(E66_DUPLICATE_SEQUENCE)
+    assert errors == []
+    assert len(document["rows"]) == 1
+    assert document["rows"][0]["total_kwh"] == Decimal("0.900")
+
+
+# ==== Document type detection ====
+
+
+def test_recognises_an_e66_document():
+    assert sdat_e66.is_e66_document(_sample()) is True
+
+
+def test_does_not_recognise_an_e31_document():
+    assert sdat_e66.is_e66_document(E31_SAMPLE) is False
+
+
+def test_parsing_an_e31_document_returns_an_error_not_a_crash():
+    document, errors = sdat_e66.parse_e66_xml(E31_SAMPLE)
+    assert document == {}
+    assert errors
+
+
+# ==== Masking ====
+
+
+def test_mask_point_id_hides_all_but_the_last_six_digits():
+    masked = sdat_e66.mask_point_id(POINT_ONE)
+    assert masked.endswith("000001")
+    assert POINT_ONE not in masked
+    assert len(masked) < len(POINT_ONE)
+
+
+def test_mask_point_id_tolerates_short_and_empty_values():
+    assert sdat_e66.mask_point_id("") == ""
+    assert sdat_e66.mask_point_id(None) == ""
+    assert sdat_e66.mask_point_id("abc")
+
+
+# ==== Module boundary ====
+
+
+def test_sdat_e66_does_not_import_meter_data():
+    path = os.path.join(os.path.dirname(FIXTURES_DIR), "..", "sdat_e66.py")
+    with open(os.path.abspath(path), encoding="utf-8") as handle:
+        source = handle.read()
+    assert "import meter_data" not in source, (
+        "sdat_e66 and meter_data must stay decoupled; they model different grains"
+    )
+
+
+# ==== Inline edge case documents ====
+
+
+def _document(blocks: str) -> str:
+    return f"""<?xml version="1.0" encoding="utf-8"?>
+<rsm:ValidatedMeteredData_16 xmlns:rsm="http://www.strom.ch">
+  <rsm:ValidatedMeteredData_HeaderInformation>
+    <rsm:InstanceDocument>
+      <rsm:DocumentID>EDGE-1</rsm:DocumentID>
+      <rsm:DocumentType listAgencyID="260">
+        <rsm:ebIXCode>E66</rsm:ebIXCode>
+      </rsm:DocumentType>
+      <rsm:Creation>2026-01-06T04:30:00Z</rsm:Creation>
+    </rsm:InstanceDocument>
+    <rsm:BusinessScopeProcess>
+      <rsm:ReportPeriod>
+        <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+        <rsm:EndDateTime>2026-01-05T23:15:00Z</rsm:EndDateTime>
+      </rsm:ReportPeriod>
+    </rsm:BusinessScopeProcess>
+  </rsm:ValidatedMeteredData_HeaderInformation>
+{blocks}
+</rsm:ValidatedMeteredData_16>"""
+
+
+def _block(product_xml: str, observations: str, unit: str = "KWH") -> str:
+    return f"""  <rsm:MeteringData>
+    <rsm:Interval>
+      <rsm:StartDateTime>2026-01-05T23:00:00Z</rsm:StartDateTime>
+      <rsm:EndDateTime>2026-01-05T23:15:00Z</rsm:EndDateTime>
+    </rsm:Interval>
+    <rsm:Resolution>
+      <rsm:Resolution>15</rsm:Resolution>
+      <rsm:Unit>MIN</rsm:Unit>
+    </rsm:Resolution>
+    <rsm:ConsumptionMeteringPoint>
+      <rsm:VSENationalID>{POINT_ONE}</rsm:VSENationalID>
+    </rsm:ConsumptionMeteringPoint>
+    <rsm:Product>
+      <rsm:ID>{product_xml}</rsm:ID>
+      <rsm:MeasureUnit>{unit}</rsm:MeasureUnit>
+    </rsm:Product>
+    <rsm:Community>
+      <rsm:CommunityID>TEST-COMMUNITY</rsm:CommunityID>
+    </rsm:Community>
+{observations}
+  </rsm:MeteringData>"""
+
+
+def _observation(sequence: int, volume: str) -> str:
+    return f"""    <rsm:Observation>
+      <rsm:Position><rsm:Sequence>{sequence}</rsm:Sequence></rsm:Position>
+      <rsm:Volume>{volume}</rsm:Volume>
+    </rsm:Observation>"""
+
+
+TOTAL_ID = '<rsm:ebIXCode schemeAgencyID="9">8716867000030</rsm:ebIXCode>'
+GRID_ID = (
+    '<rsm:VSENationalCode schemeAgencyID="260">2404050010124</rsm:VSENationalCode>'
+)
+COMMUNITY_ID = (
+    '<rsm:VSENationalCode schemeAgencyID="260">2404050010123</rsm:VSENationalCode>'
+)
+
+E66_IMBALANCED = _document(
+    "\n".join(
+        [
+            _block(TOTAL_ID, _observation(1, "1.000")),
+            _block(GRID_ID, _observation(1, "0.500")),
+            _block(COMMUNITY_ID, _observation(1, "0.100")),
+        ]
+    )
+)
+
+E66_MISSING_CHANNEL = _document(
+    "\n".join(
+        [
+            _block(TOTAL_ID, _observation(1, "1.000")),
+            _block(GRID_ID, _observation(1, "1.000")),
+        ]
+    )
+)
+
+E66_BAD_UNIT = _document(_block(TOTAL_ID, _observation(1, "1.000"), unit="WH"))
+
+E66_DUPLICATE_SEQUENCE = _document(
+    _block(TOTAL_ID, _observation(1, "0.100") + "\n" + _observation(1, "0.900"))
+)
+
+E31_SAMPLE = """<?xml version="1.0" encoding="utf-8"?>
+<rsm:AggregatedMeteredData_13 xmlns:rsm="http://www.strom.ch">
+  <rsm:AggregatedMeteredData_HeaderInformation>
+    <rsm:InstanceDocument>
+      <rsm:DocumentID>AGG-1</rsm:DocumentID>
+      <rsm:DocumentType listAgencyID="260">
+        <rsm:ebIXCode>E31</rsm:ebIXCode>
+      </rsm:DocumentType>
+    </rsm:InstanceDocument>
+  </rsm:AggregatedMeteredData_HeaderInformation>
+  <rsm:MeteringData>
+    <rsm:MeteringGridArea>
+      <rsm:EICID schemeAgencyID="305">12Y-0000000041-T</rsm:EICID>
+    </rsm:MeteringGridArea>
+  </rsm:MeteringData>
+</rsm:AggregatedMeteredData_13>"""

--- a/tests/test_store_metering.py
+++ b/tests/test_store_metering.py
@@ -1,0 +1,404 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Repository contract for SDAT metering points and readings.
+
+Daily E66 deliveries overlap by four of five days, so the same interval is
+written again and again. The upsert must key on point, direction and time,
+skip rows whose values did not move, and report how many rows were new versus
+corrected so an import can be audited without a revision table.
+"""
+
+import subprocess
+import sys
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+import database
+from store import metering
+
+MEASURED_AT = datetime(2026, 1, 5, 23, 0, tzinfo=timezone.utc)
+POINT = "CH000000000000000000000000000001"
+
+
+class _FakeCursor:
+    def __init__(self, rows=None, one=None):
+        self.rows = rows or []
+        self.one = one
+        self.executed = []
+
+    def execute(self, query, params=None):
+        self.executed.append((query, params))
+
+    def fetchall(self):
+        return self.rows
+
+    def fetchone(self):
+        return self.one
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_):
+        return False
+
+
+class _FakeConnection:
+    def __init__(self, cursor):
+        self._cursor = cursor
+
+    def cursor(self):
+        return self._cursor
+
+
+def _conn_ctx(cursor):
+    @contextmanager
+    def _factory():
+        yield _FakeConnection(cursor)
+
+    return _factory
+
+
+def _broken_conn():
+    @contextmanager
+    def _factory():
+        raise RuntimeError("db down")
+        yield
+
+    return _factory
+
+
+def _row(sequence=1, total="0.100"):
+    return {
+        "metering_point_id": POINT,
+        "direction": "consumption",
+        "measured_at": MEASURED_AT + timedelta(minutes=15 * (sequence - 1)),
+        "resolution_minutes": 15,
+        "total_kwh": Decimal(total),
+        "grid_kwh": Decimal("0.060"),
+        "community_kwh": Decimal("0.040"),
+        "condition_code": None,
+    }
+
+
+def _capture_execute_values(monkeypatch, returned):
+    """Record the SQL and values handed to execute_values."""
+    calls = []
+
+    def _fake(cur, sql, values, page_size=None, fetch=False):
+        calls.append({"sql": sql, "values": list(values), "fetch": fetch})
+        return returned if fetch else None
+
+    import psycopg2.extras
+
+    monkeypatch.setattr(psycopg2.extras, "execute_values", _fake)
+    return calls
+
+
+# ==== Re-export contract ====
+
+
+def test_database_reexports_are_identical_objects():
+    for name in (
+        "upsert_metering_points",
+        "get_metering_points",
+        "get_metering_point",
+        "save_metering_point_readings",
+        "get_metering_point_readings",
+        "get_metering_point_reading_stats",
+        "record_sdat_import",
+        "get_sdat_import",
+    ):
+        assert getattr(database, name) is getattr(metering, name), (
+            f"database.{name} must be the store.metering object"
+        )
+
+
+def test_store_metering_imports_without_database_bootstrap():
+    result = subprocess.run(
+        [sys.executable, "-c", "import store.metering; print('ok')"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+# ==== The upsert ====
+
+
+def test_readings_upsert_keys_on_point_direction_and_time(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.save_metering_point_readings([_row()], source_document_id="DOC-1")
+
+    readings_sql = calls[-1]["sql"]
+    assert "ON CONFLICT (metering_point_id, direction, measured_at)" in readings_sql, (
+        "one point can be both consumer and producer; direction belongs in the key"
+    )
+
+
+def test_readings_upsert_skips_rows_whose_values_did_not_move(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.save_metering_point_readings([_row()])
+
+    readings_sql = calls[-1]["sql"]
+    assert "IS DISTINCT FROM" in readings_sql, (
+        "overlapping deliveries rewrite mostly identical rows; skip the unchanged"
+    )
+
+
+def test_readings_upsert_keeps_resolution_and_provenance_corrections(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.save_metering_point_readings([_row()])
+
+    readings_sql = calls[-1]["sql"]
+    assert "metering_point_readings.resolution_minutes" in readings_sql
+    assert "metering_point_readings.source_document_id" in readings_sql
+
+
+def test_readings_upsert_registers_points_before_readings(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.save_metering_point_readings([_row()])
+
+    assert len(calls) == 2, "expected a point stub insert then the readings insert"
+    assert "INSERT INTO metering_points" in calls[0]["sql"]
+    assert "ON CONFLICT (metering_point_id) DO NOTHING" in calls[0]["sql"]
+    assert "INSERT INTO metering_point_readings" in calls[1]["sql"]
+
+
+def test_readings_upsert_reports_new_and_corrected_counts(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    returned = [
+        {
+            "metering_point_id": POINT,
+            "direction": "consumption",
+            "measured_at": MEASURED_AT,
+            "inserted": True,
+        },
+        {
+            "metering_point_id": POINT,
+            "direction": "consumption",
+            "measured_at": MEASURED_AT,
+            "inserted": False,
+        },
+    ]
+    _capture_execute_values(monkeypatch, returned)
+
+    result = metering.save_metering_point_readings(
+        [_row(1), _row(2), _row(3), _row(4), _row(5)]
+    )
+
+    assert result["written"] == 5
+    assert result["new"] == 1
+    assert result["corrected"] == 1
+    assert result["unchanged"] == 3
+
+
+def test_readings_upsert_dedupes_repeated_keys(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    duplicate = _row(1, total="0.900")
+    metering.save_metering_point_readings([_row(1), duplicate])
+
+    values = calls[-1]["values"]
+    assert len(values) == 1, (
+        "a repeated conflict key in one INSERT aborts the whole statement"
+    )
+    assert Decimal("0.900") in values[0], "the last occurrence must win"
+
+
+def test_readings_upsert_accepts_an_iterator(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.save_metering_point_readings(iter([_row(1), _row(2)]))
+
+    assert len(calls[-1]["values"]) == 2
+
+
+def test_saving_no_rows_touches_no_database(monkeypatch):
+    monkeypatch.setattr(database, "get_connection", _broken_conn())
+    result = metering.save_metering_point_readings([])
+    assert result["written"] == 0
+
+
+# ==== Reads ====
+
+
+def test_get_readings_applies_direction_and_time_window(monkeypatch):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    metering.get_metering_point_readings(
+        POINT, direction="production", start=MEASURED_AT, end=MEASURED_AT, limit=50
+    )
+
+    query, params = cur.executed[0]
+    assert "FROM metering_point_readings" in query
+    assert "direction = %s" in query
+    assert "measured_at >= %s" in query and "measured_at <= %s" in query
+    assert params == [POINT, "production", MEASURED_AT, MEASURED_AT, 50]
+
+
+def test_get_readings_coerces_numerics_to_float(monkeypatch):
+    cur = _FakeCursor(
+        rows=[
+            {
+                "metering_point_id": POINT,
+                "total_kwh": Decimal("0.100"),
+                "grid_kwh": Decimal("0.060"),
+                "community_kwh": None,
+            }
+        ]
+    )
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    row = metering.get_metering_point_readings(POINT)[0]
+    assert type(row["total_kwh"]) is float
+    assert type(row["grid_kwh"]) is float
+    assert row["community_kwh"] is None, "a missing channel stays missing"
+
+
+def test_get_metering_points_filters_by_community(monkeypatch):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    metering.get_metering_points(community_id="leg-1")
+
+    query, params = cur.executed[0]
+    assert "FROM metering_points" in query
+    assert "community_id = %s" in query
+    assert "leg-1" in params
+
+
+# ==== Registry enrichment ====
+
+
+def test_upsert_points_does_not_blank_existing_fields(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    calls = _capture_execute_values(monkeypatch, [])
+
+    metering.upsert_metering_points([{"metering_point_id": POINT, "alias": "Haus 1"}])
+
+    sql = calls[-1]["sql"]
+    assert "COALESCE" in sql, (
+        "a re-run with blank columns must not erase existing registry data"
+    )
+
+
+# ==== File ledger ====
+
+
+def test_record_sdat_import_is_idempotent(monkeypatch):
+    cur = _FakeCursor()
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    metering.record_sdat_import({"document_id": "DOC-1", "doc_type": "E66"})
+
+    query, _ = cur.executed[0]
+    assert "INSERT INTO sdat_imports" in query
+    assert "ON CONFLICT (document_id) DO UPDATE" in query
+
+
+def test_get_sdat_import_returns_none_when_absent(monkeypatch):
+    cur = _FakeCursor(one=None)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    assert metering.get_sdat_import("nope") is None
+
+
+# ==== Billing reads ====
+
+
+def test_community_points_expose_membership_status(monkeypatch):
+    """Billing may only bill a confirmed member, so the status must come along."""
+    cur = _FakeCursor(
+        rows=[
+            {
+                "metering_point_id": POINT,
+                "building_id": "BLD-A",
+                "alias": None,
+                "member_status": "confirmed",
+            }
+        ]
+    )
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    points = metering.get_community_metering_points("COMM-1")
+
+    query, params = cur.executed[0]
+    assert "LEFT JOIN community_members" in query, (
+        "a point mapped to a building with no membership row must still be "
+        "returned, so the adapter can name it"
+    )
+    assert "active = TRUE" in query
+    assert params == ("COMM-1",)
+    assert points[0]["member_status"] == "confirmed"
+
+
+def test_period_readings_use_a_half_open_interval(monkeypatch):
+    cur = _FakeCursor(rows=[])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+    start = MEASURED_AT
+    end = MEASURED_AT + timedelta(minutes=45)
+
+    metering.get_period_readings("COMM-1", start, end)
+
+    query, params = cur.executed[0]
+    assert "measured_at >= %s" in query
+    assert "measured_at < %s" in query, (
+        "the period end must be exclusive; an inclusive end double-counts the "
+        "boundary interval across two periods"
+    )
+    assert params == ("COMM-1", start, end)
+
+
+def test_period_readings_convert_numerics_to_float(monkeypatch):
+    cur = _FakeCursor(rows=[_row(total="0.250")])
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
+
+    readings = metering.get_period_readings(
+        "COMM-1", MEASURED_AT, MEASURED_AT + timedelta(minutes=15)
+    )
+
+    assert isinstance(readings[0]["total_kwh"], float)
+    assert not isinstance(readings[0]["total_kwh"], Decimal)
+
+
+# ==== Failure behaviour ====
+
+
+def test_connection_failure_returns_safe_defaults(monkeypatch):
+    monkeypatch.setattr(database, "get_connection", _broken_conn())
+
+    assert metering.get_community_metering_points("COMM-1") == []
+    assert (
+        metering.get_period_readings(
+            "COMM-1", MEASURED_AT, MEASURED_AT + timedelta(minutes=15)
+        )
+        == []
+    )
+    assert metering.get_metering_point_readings(POINT) == []
+    assert metering.get_metering_points() == []
+    assert metering.get_metering_point(POINT) is None
+    assert metering.get_metering_point_reading_stats() == {}
+    assert metering.get_sdat_import("DOC-1") is None
+    assert metering.record_sdat_import({"document_id": "DOC-1"}) is False
+    assert metering.upsert_metering_points([{"metering_point_id": POINT}]) == 0
+    assert metering.save_metering_point_readings([_row()])["written"] == 0


### PR DESCRIPTION
Bridges the imported SDAT-E66 readings into the billing core merged in #262.

Closes the adapter half of #261. I own the importer this data came from, so the
PR also brings the schema and repository that were missing here.

## What this adds

- `metering_points`, `metering_point_readings`, `sdat_imports` in `_create_tables()`
- `store/metering.py`, re-exported from `database.py`
- `sdat_e66.py`, the E66 parser, so the test path starts from real XML
- `billing_readings.py`, the adapter: `load_period_frames` and `reconcile_with_vnb`
- `docs/data-pipeline.md`, the written contract for tables, mapping, units,
  timezone semantics, and the data-quality policy

## Design decisions worth reviewing

**Participants are keyed on `building_id`, not on the metering point.** A member
with a separate production meter is one participant with two points, and
`billing_line_items.participant_id` already speaks building ids. A member with
no production meter gets a zero column rather than no column, because
`generate_billing_summary` asserts index and column equality before it emits
credits.

**A point is billable only when it maps to a confirmed member.** It needs
`building_id` and `community_id`, and the matching `community_members` row needs
`status = 'confirmed'`. Both reads go through one `LEFT JOIN` so an unmapped
point comes back and can be named instead of vanishing. Billing a period with a
participant missing would spread that participant's share across everyone else.

**The unit gate sits at the parse boundary.** `metering_point_readings` carries
no unit column, so a document whose `MeasureUnit` is not `KWH` has to fail
before storage. Covered in `tests/test_sdat_e66.py` and pinned again from the
adapter side.

**The adapter reports every defect in a period, not the first.** Unmapped
points, unconfirmed members, unknown points, duplicate intervals, gaps,
misaligned timestamps, negative volumes, mixed resolutions. One pass fixes a
period.

## One thing I would like your view on

The E66 file already contains the VNB's own allocation in the `community_kwh`
channel. `allocate_energy` ignores it and reallocates from totals. Both are
defensible, and they do not agree: on one real month the engine allocated
277.31 kWh where the VNB allocated 275.458 kWh, a gap of 1.852 kWh or 0.67
percent. At an internal price of CHF 0.11 that is about 20 Rappen, so it is not
a money problem yet, but it means the LEG's internal bill and the VNB's grid
bill disagree about how much energy came from the community.

`reconcile_with_vnb` reports the gap rather than hiding it. Whether the LEG
should bill its own allocation or the VNB's is a decision above this adapter, so
I left the engine untouched. Happy to open a separate issue.

Smaller observation: the engine emits a zero-value `producer_credit` line for a
participant who produced nothing, because the frames must share their columns.
Harmless, slightly odd on a bill.

## Out of scope, as requested

No operator CLI, no invoices, no cron, no production data. `app.py` is not
touched, so the `process-billing` stub stays exactly as it is, and nothing here
persists a period; that stays with `save_billing_period`.

The import scripts, the Swisseldex FTPS connector, and the download collector
are a separate retrieval slice. There is still no UI for any of this.

## Follow-ups I would suggest

- A configured internal price on the community that a period copies at
  creation. Storing it on the period is right for audit, but there is still no
  place where a LEG records the price to use next.
- `billing_periods.period_start` and `period_end` are naive `TIMESTAMP` while
  `measured_at` is `TIMESTAMPTZ`. Harmless in July, not in the October period
  that contains the DST repeat.
- Filling `community_id` and `building_id` on existing metering points. Against
  real data the adapter correctly refuses today, because those columns are empty
  and no `communities` row exists yet.

## Data hygiene

Fixtures are synthetic: metering point IDs `CH0000...0001` and `0002`, no names,
no addresses. I also added a `.gitignore` rule for `/data/*` keeping only
`data/public/`: the repo had no such rule, which left a real VNB export one
broad `git add` away from a public commit.

## Verification

`pytest tests/ -q`, `ruff check .`, `ruff format --check .` all green.

Beyond the suite I ran the adapter against a real month locally, read-only:
29,760 readings, 2,976 intervals, 5 participants, ledger summing to exactly
zero. Those numbers are not in the tests and no citizen data is in this PR.

Refs #261

🤖 Generated with [Claude Code](https://claude.com/claude-code)
