### PR TITLE
[codex] Replace the SciPy convex hull with a pure Python hull

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,13 +29,6 @@ from jinja2 import TemplateNotFound
 load_dotenv()
 
 try:
-    from scipy.spatial import ConvexHull
-
-    HAS_SCIPY = True
-except ImportError:
-    HAS_SCIPY = False
-
-try:
     from svix.webhooks import Webhook, WebhookVerificationError
 
     HAS_SVIX = True
@@ -60,6 +53,7 @@ import data_enricher
 
 # --- PostgreSQL Database ---
 import database as db
+import geometry
 import ml_models
 import registration
 import security_utils
@@ -397,15 +391,9 @@ def create_simple_polygon(coords):
                 [lat1 - o, lon2 + o],
                 [lat1 - o, lon1 - o],
             ]
-    if HAS_SCIPY:
-        try:
-            points = np.array(coords)
-            hull = ConvexHull(points)
-            polygon = [coords[i] for i in hull.vertices]
-            polygon.append(polygon[0])
-            return polygon
-        except Exception:
-            logger.debug("Convex hull calculation failed", exc_info=True)
+    hull = geometry.convex_hull(coords)
+    if hull is not None:
+        return hull + [hull[0]]
     lats = [c[0] for c in coords]
     lons = [c[1] for c in coords]
     o = 0.0003

--- a/geometry.py
+++ b/geometry.py
@@ -1,0 +1,34 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# Squared degrees: float noise is ~1e-19; few-metre triangles are ~1e-10.
+_COLLINEAR_EPSILON = 1e-15
+
+
+def convex_hull(points: list[list[float]]) -> list[list[float]] | None:
+    """Return the outer points in counterclockwise order."""
+    unique = {}
+    for point in points:
+        unique.setdefault(tuple(point), point)
+    ordered = sorted(unique.items())
+    if len(ordered) < 3:
+        return None
+
+    def cross(origin, a, b):
+        left = (a[0] - origin[0]) * (b[1] - origin[1])
+        right = (a[1] - origin[1]) * (b[0] - origin[0])
+        cross_product = left - right
+        return 0 if abs(cross_product) < _COLLINEAR_EPSILON else cross_product
+
+    def half(scan):
+        result = []
+        for coordinates, point in scan:
+            while (
+                len(result) >= 2
+                and cross(result[-2][0], result[-1][0], coordinates) <= 0
+            ):
+                result.pop()
+            result.append((coordinates, point))
+        return result
+
+    hull = half(ordered)[:-1] + half(reversed(ordered))[:-1]
+    return [point for _, point in hull] if len(hull) >= 3 else None

--- a/geometry.py
+++ b/geometry.py
@@ -5,7 +5,11 @@ _COLLINEAR_EPSILON = 1e-15
 
 
 def convex_hull(points: list[list[float]]) -> list[list[float]] | None:
-    """Return the outer points in counterclockwise order."""
+    """Return the outer points counterclockwise, or ``None`` for degenerate input.
+
+    ``None`` means fewer than three distinct points or all points collinear
+    within ``_COLLINEAR_EPSILON``.
+    """
     unique = {}
     for point in points:
         unique.setdefault(tuple(point), point)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 Flask==3.1.3
 pandas==3.0.5
 numpy==1.26.4
-scipy==1.17.1
 
 # Security dependencies
 Flask-Limiter==4.1.1

--- a/tests/test_geometry_hull.py
+++ b/tests/test_geometry_hull.py
@@ -1,0 +1,103 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Cluster polygons come from a pure Python convex hull, not from SciPy.
+
+SciPy was a full scientific dependency pulled in for a single call site. The
+hull it computed is small, well defined and deterministic, so the behaviour it
+produced is pinned here and served by ``geometry.convex_hull``.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+SQUARE = [[47.0, 8.0], [47.0, 8.01], [47.01, 8.01], [47.01, 8.0]]
+INTERIOR = [47.005, 8.005]
+COLLINEAR = [[47.0, 8.0], [47.001, 8.001], [47.002, 8.002]]
+
+
+class TestConvexHull:
+    def test_hull_keeps_only_the_outer_points(self):
+        import geometry
+
+        hull = geometry.convex_hull(SQUARE + [INTERIOR])
+
+        assert hull is not None
+        assert INTERIOR not in hull
+        assert {tuple(point) for point in hull} == {tuple(p) for p in SQUARE}
+
+    def test_hull_walks_the_ring_in_order(self):
+        import geometry
+
+        hull = geometry.convex_hull(SQUARE + [INTERIOR])
+
+        # Each step moves along one edge of the square, never across a diagonal.
+        for current, following in zip(hull, hull[1:] + hull[:1]):
+            shared_axis = current[0] == following[0] or current[1] == following[1]
+            assert shared_axis, f"{current} to {following} cuts across the square"
+
+    def test_hull_returns_none_for_degenerate_input(self):
+        import geometry
+
+        assert geometry.convex_hull(COLLINEAR) is None
+        assert geometry.convex_hull([[47.0, 8.0], [47.0, 8.0]]) is None
+
+    def test_hull_points_are_returned_unchanged(self):
+        import geometry
+
+        hull = geometry.convex_hull(SQUARE)
+
+        assert all(isinstance(point, list) for point in hull)
+        assert all(len(point) == 2 for point in hull)
+
+
+class TestClusterPolygon:
+    @pytest.fixture
+    def create_simple_polygon(self):
+        with patch("database.is_db_available", return_value=True):
+            import app as app_module
+
+        return app_module.create_simple_polygon
+
+    def test_polygon_closes_the_hull_ring(self, create_simple_polygon):
+        polygon = create_simple_polygon(SQUARE + [INTERIOR])
+
+        assert len(polygon) == 5
+        assert polygon[0] == polygon[-1]
+        assert INTERIOR not in polygon
+        assert {tuple(point) for point in polygon[:-1]} == {tuple(p) for p in SQUARE}
+
+    def test_polygon_falls_back_to_a_padded_box_when_the_hull_degenerates(
+        self, create_simple_polygon
+    ):
+        polygon = create_simple_polygon(COLLINEAR)
+
+        assert len(polygon) == 5
+        assert polygon[0] == polygon[-1]
+        lats = [point[0] for point in polygon]
+        lons = [point[1] for point in polygon]
+        assert min(lats) == pytest.approx(47.0 - 0.0003)
+        assert max(lats) == pytest.approx(47.002 + 0.0003)
+        assert min(lons) == pytest.approx(8.0 - 0.0003)
+        assert max(lons) == pytest.approx(8.002 + 0.0003)
+
+    def test_single_and_paired_coordinates_keep_their_shapes(
+        self, create_simple_polygon
+    ):
+        assert len(create_simple_polygon([[47.0, 8.0]])) == 5
+        assert len(create_simple_polygon([[47.0, 8.0], [47.01, 8.01]])) == 5
+
+
+class TestSciPyIsGone:
+    def test_requirements_do_not_pin_scipy(self):
+        with open(os.path.join(PROJECT_ROOT, "requirements.txt")) as handle:
+            assert "scipy" not in handle.read().lower()
+
+    def test_app_does_not_import_scipy(self):
+        with open(os.path.join(PROJECT_ROOT, "app.py")) as handle:
+            content = handle.read()
+        assert "scipy" not in content
+        assert "ConvexHull" not in content
+        assert "HAS_SCIPY" not in content

--- a/tests/test_geometry_hull.py
+++ b/tests/test_geometry_hull.py
@@ -33,6 +33,7 @@ class TestConvexHull:
 
         hull = geometry.convex_hull(SQUARE + [INTERIOR])
 
+        assert hull is not None
         # Each step moves along one edge of the square, never across a diagonal.
         for current, following in zip(hull, hull[1:] + hull[:1]):
             shared_axis = current[0] == following[0] or current[1] == following[1]
@@ -49,6 +50,7 @@ class TestConvexHull:
 
         hull = geometry.convex_hull(SQUARE)
 
+        assert hull is not None
         assert all(isinstance(point, list) for point in hull)
         assert all(len(point) == 2 for point in hull)
 


### PR DESCRIPTION
## Summary

- add `geometry.convex_hull`: Andrew monotone chain over [lat, lon] pairs, returning `None` for degenerate input
- `create_simple_polygon` calls it and keeps the existing padded bounding box fallback
- drop the `scipy` pin

## Why

SciPy was pinned for exactly one call: `ConvexHull` in `create_simple_polygon`. That is a large dependency for self-hosters to install so cluster polygons can be drawn.

## Impact

Same polygons, smaller image. Parity checked against SciPy on 300 randomized point sets: identical hull vertex sets in every case, and the degenerate cases where SciPy raised QhullError now return `None`, which routes to the same bounding box fallback as before.

Collinearity uses a documented absolute tolerance (`1e-15` squared degrees). Float noise for street scale coordinates lands near `1e-19` and a triangle of a few metres produces about `1e-10`, so the tolerance separates the two. A relative tolerance would be meaningless for a determinant that is near zero by construction.

## Validation

- new red tests first: `tests/test_geometry_hull.py`
- `pytest tests/ -q`: 855 passed, 11 skipped
- `ruff check .` and `ruff format --check .` clean on the pinned 0.16.1
- `coderabbit review --committed --base main`: one minor finding on the tolerance, addressed above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV8L9ETLiU5CZsbrc2ZTgS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added reliable polygon generation using built-in geometry processing.
  * Preserves closed polygon shapes when a valid convex boundary can be created.
  * Retains a padded bounding-box fallback for insufficient or degenerate input points.

* **Bug Fixes**
  * Improved handling of duplicate, collinear, and near-collinear points.
  * Preserved support for single-point and two-point inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->