### PR TITLE
[codex] Extract the operator surface into an admin blueprint

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import csv
+import hmac
 import io
 import json
 import os
@@ -25,8 +26,6 @@ try:
 except ImportError:
     HAS_SVIX = False
 
-USE_POSTGRES = db.is_db_available()
-
 admin_bp = Blueprint("admin", __name__)
 
 
@@ -35,8 +34,15 @@ def require_admin():
     if not admin_token:
         abort(404)
     token = request.headers.get("X-Admin-Token") or request.args.get("token") or ""
-    if token != admin_token:
+    if not hmac.compare_digest(token, admin_token):
         log_security_event("ADMIN_ACCESS_DENIED", "Invalid admin token", "WARNING")
+        abort(403)
+
+
+def require_internal_token():
+    token = request.headers.get("X-Internal-Token") or ""
+    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
+    if not internal_token or not hmac.compare_digest(token, internal_token):
         abort(403)
 
 
@@ -107,7 +113,7 @@ def _sanitize_agentmail_payload(data):
             or data.get("received_at")
             or data.get("timestamp")
         ),
-        "text_preview": preview[:280],
+        "text_preview": str(preview)[:280],
     }
 
 
@@ -128,10 +134,7 @@ def _verify_agentmail_request():
             return
         except WebhookVerificationError:
             abort(403)
-    token = request.headers.get("X-Internal-Token") or ""
-    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
-    if not internal_token or token != internal_token:
-        abort(403)
+    require_internal_token()
 
 
 @admin_bp.route("/admin/overview")
@@ -148,7 +151,7 @@ def admin_overview():
             "email_stats": email_stats,
             "consented_buildings": consented,
             "municipalities": len(municipalities),
-            "db_available": USE_POSTGRES,
+            "db_available": db.is_db_available(),
         }
     )
 
@@ -177,10 +180,7 @@ def admin_export():
 
 @admin_bp.route("/api/internal/lea-report", methods=["POST"])
 def api_internal_lea_report():
-    token = request.headers.get("X-Internal-Token") or ""
-    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
-    if not internal_token or token != internal_token:
-        abort(403)
+    require_internal_token()
     data = request.get_json(silent=True) or {}
     job_name = data.get("job_name", "unknown")
     summary = data.get("summary", "")
@@ -198,10 +198,7 @@ def admin_lea_reports():
 
 @admin_bp.route("/api/internal/ops-snapshot", methods=["POST"])
 def api_internal_ops_snapshot():
-    token = request.headers.get("X-Internal-Token") or ""
-    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
-    if not internal_token or token != internal_token:
-        abort(403)
+    require_internal_token()
     data = request.get_json(silent=True) or {}
     db.save_ops_snapshot(
         source=data.get("source", "unknown"),

--- a/admin.py
+++ b/admin.py
@@ -1,0 +1,293 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+import csv
+import io
+import json
+import os
+
+from flask import (
+    Blueprint,
+    Response,
+    abort,
+    jsonify,
+    redirect,
+    render_template,
+    request,
+)
+
+import database as db
+import leg_registry
+from security_utils import log_security_event
+
+try:
+    from svix.webhooks import Webhook, WebhookVerificationError
+
+    HAS_SVIX = True
+except ImportError:
+    HAS_SVIX = False
+
+USE_POSTGRES = db.is_db_available()
+
+admin_bp = Blueprint("admin", __name__)
+
+
+def require_admin():
+    admin_token = os.getenv("ADMIN_TOKEN", "").strip()
+    if not admin_token:
+        abort(404)
+    token = request.headers.get("X-Admin-Token") or request.args.get("token") or ""
+    if token != admin_token:
+        log_security_event("ADMIN_ACCESS_DENIED", "Invalid admin token", "WARNING")
+        abort(403)
+
+
+def _latest_snapshot_by_category(snapshots):
+    latest = {}
+    for snapshot in snapshots:
+        latest.setdefault(snapshot.get("category", "uncategorized"), snapshot)
+    return latest
+
+
+def _first_email_identity(value):
+    if isinstance(value, list):
+        value = value[0] if value else ""
+    if isinstance(value, dict):
+        return {"email": value.get("email", ""), "name": value.get("name", "")}
+    if isinstance(value, str):
+        return {"email": value, "name": ""}
+    return {"email": "", "name": ""}
+
+
+def _sanitize_agentmail_payload(data):
+    message = data.get("message") or {}
+    if not isinstance(message, dict):
+        message = {}
+    headers = message.get("headers") or {}
+    if not isinstance(headers, dict):
+        headers = {}
+    sender = _first_email_identity(message.get("from") or message.get("from_") or {})
+    recipients = message.get("to") or []
+    preview = (
+        message.get("text_preview")
+        or message.get("extracted_text")
+        or message.get("snippet")
+        or message.get("text")
+        or data.get("text_preview")
+        or ""
+    )
+    if isinstance(recipients, dict):
+        recipients = [recipients]
+    normalized_to = []
+    for recipient in recipients[:5]:
+        if isinstance(recipient, dict):
+            normalized_to.append(
+                {
+                    "email": recipient.get("email", ""),
+                    "name": recipient.get("name", ""),
+                }
+            )
+        elif isinstance(recipient, str):
+            normalized_to.append({"email": recipient, "name": ""})
+    return {
+        "event_type": (
+            data.get("event_type") or data.get("type") or data.get("event") or "unknown"
+        ),
+        "event_id": data.get("event_id"),
+        "inbox_id": message.get("inbox_id"),
+        "message_id": (
+            message.get("message_id") or message.get("id") or data.get("message_id")
+        ),
+        "thread_id": message.get("thread_id") or data.get("thread_id"),
+        "from_email": sender.get("email") or headers.get("from") or "",
+        "from_name": sender.get("name") or "",
+        "to": normalized_to,
+        "subject": message.get("subject") or headers.get("subject") or "",
+        "received_at": (
+            message.get("received_at")
+            or message.get("timestamp")
+            or data.get("received_at")
+            or data.get("timestamp")
+        ),
+        "text_preview": preview[:280],
+    }
+
+
+def _verify_agentmail_request():
+    webhook_secret = os.getenv("AGENTMAIL_WEBHOOK_SECRET", "").strip()
+    if webhook_secret:
+        if not HAS_SVIX:
+            abort(503)
+        try:
+            Webhook(webhook_secret).verify(
+                request.get_data(),
+                {
+                    "svix-id": request.headers.get("svix-id", ""),
+                    "svix-timestamp": request.headers.get("svix-timestamp", ""),
+                    "svix-signature": request.headers.get("svix-signature", ""),
+                },
+            )
+            return
+        except WebhookVerificationError:
+            abort(403)
+    token = request.headers.get("X-Internal-Token") or ""
+    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
+    if not internal_token or token != internal_token:
+        abort(403)
+
+
+@admin_bp.route("/admin/overview")
+def admin_overview():
+    require_admin()
+    stats = db.get_stats()
+    email_stats = db.get_email_stats()
+    consented = db.count_consented_buildings()
+    municipalities = db.get_all_municipalities()
+    return jsonify(
+        {
+            "platform": "OpenLEG",
+            "stats": stats,
+            "email_stats": email_stats,
+            "consented_buildings": consented,
+            "municipalities": len(municipalities),
+            "db_available": USE_POSTGRES,
+        }
+    )
+
+
+@admin_bp.route("/admin/export")
+def admin_export():
+    require_admin()
+    fmt = (request.args.get("format") or "json").lower()
+    city_id = request.args.get("city_id")
+
+    buildings = db.get_all_building_profiles(city_id=city_id)
+    if fmt == "csv":
+        output = io.StringIO()
+        if buildings:
+            writer = csv.DictWriter(output, fieldnames=buildings[0].keys())
+            writer.writeheader()
+            for row in buildings:
+                writer.writerow(row)
+        response = Response(output.getvalue(), mimetype="text/csv")
+        response.headers["Content-Disposition"] = (
+            "attachment; filename=openleg_export.csv"
+        )
+        return response
+    return jsonify({"records": buildings, "count": len(buildings)})
+
+
+@admin_bp.route("/api/internal/lea-report", methods=["POST"])
+def api_internal_lea_report():
+    token = request.headers.get("X-Internal-Token") or ""
+    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
+    if not internal_token or token != internal_token:
+        abort(403)
+    data = request.get_json(silent=True) or {}
+    job_name = data.get("job_name", "unknown")
+    summary = data.get("summary", "")
+    status = data.get("status", "ok")
+    db.save_lea_report(job_name, summary, status)
+    return jsonify({"ok": True})
+
+
+@admin_bp.route("/admin/lea-reports")
+def admin_lea_reports():
+    require_admin()
+    reports = db.get_lea_reports(limit=50)
+    return jsonify({"reports": reports})
+
+
+@admin_bp.route("/api/internal/ops-snapshot", methods=["POST"])
+def api_internal_ops_snapshot():
+    token = request.headers.get("X-Internal-Token") or ""
+    internal_token = os.getenv("INTERNAL_TOKEN", "").strip()
+    if not internal_token or token != internal_token:
+        abort(403)
+    data = request.get_json(silent=True) or {}
+    db.save_ops_snapshot(
+        source=data.get("source", "unknown"),
+        category=data.get("category", "general"),
+        summary_text=data.get("summary", ""),
+        status=data.get("status", "ok"),
+        payload=data.get("payload") if isinstance(data.get("payload"), dict) else {},
+    )
+    return jsonify({"ok": True})
+
+
+@admin_bp.route("/api/internal/agentmail", methods=["POST"])
+def api_internal_agentmail():
+    _verify_agentmail_request()
+    data = request.get_json(silent=True) or {}
+    event_type = data.get("event_type") or data.get("type") or data.get("event") or ""
+    if event_type not in {
+        "message.received",
+        "message.received.unauthenticated",
+        "inbound_email.received",
+    }:
+        return jsonify({"ok": True, "ignored": True})
+    payload = _sanitize_agentmail_payload(data)
+    summary = payload.get("subject") or payload.get("from_email") or "Inbound LEA mail"
+    db.save_ops_snapshot(
+        source="agentmail",
+        category="lea_inbox",
+        summary_text=summary,
+        status="received",
+        payload=payload,
+    )
+    return jsonify({"ok": True})
+
+
+@admin_bp.route("/admin/ops")
+def admin_ops():
+    require_admin()
+    snapshots = db.get_ops_snapshots(limit=100)
+    reports = db.get_lea_reports(limit=20)
+    latest = _latest_snapshot_by_category(snapshots)
+    pending_registry = leg_registry.annotate_vnb_plausibility(
+        db.list_registry_entries(moderation_status="pending")
+    )
+    stale_registry = db.get_registry_entries_needing_verification(
+        stale_days=leg_registry.VERIFICATION_STALE_DAYS, limit=1000
+    )
+    response = {
+        "latest": latest,
+        "snapshots": snapshots[:20],
+        "reports": reports,
+        "pending_registry": pending_registry,
+        "counts": {
+            "lea_inbox": sum(1 for s in snapshots if s.get("category") == "lea_inbox"),
+            "github_monitor": sum(
+                1 for s in snapshots if s.get("category") == "github_monitor"
+            ),
+            "vnb_monitor": sum(
+                1 for s in snapshots if s.get("category") == "vnb_monitor"
+            ),
+            "stuck_formations": sum(
+                1 for s in snapshots if s.get("category") == "stuck_formations"
+            ),
+            "registry_pending": db.get_registry_pending_count(),
+            "registry_stale": len(stale_registry),
+        },
+    }
+    if "text/html" in (request.headers.get("Accept") or ""):
+        return render_template("admin/ops.html", **response)
+    return Response(
+        json.dumps(response, default=str),
+        mimetype="application/json",
+    )
+
+
+@admin_bp.route("/admin/registry/<int:entry_id>/approve", methods=["POST"])
+def admin_registry_approve(entry_id):
+    require_admin()
+    db.update_registry_entry_moderation(entry_id, "published", "")
+    admin_token = os.getenv("ADMIN_TOKEN", "").strip()
+    return redirect(f"/admin/ops?token={admin_token}")
+
+
+@admin_bp.route("/admin/registry/<int:entry_id>/reject", methods=["POST"])
+def admin_registry_reject(entry_id):
+    require_admin()
+    reason = (request.form.get("reason") or "").strip()
+    db.update_registry_entry_moderation(entry_id, "rejected", reason)
+    admin_token = os.getenv("ADMIN_TOKEN", "").strip()
+    return redirect(f"/admin/ops?token={admin_token}")

--- a/app.py
+++ b/app.py
@@ -1,8 +1,5 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-import csv
 import hashlib
-import io
-import json
 import logging
 import math
 import os
@@ -25,15 +22,28 @@ from flask import (
 )
 from jinja2 import TemplateNotFound
 
-# Load environment variables
-load_dotenv()
-
-try:
-    from svix.webhooks import Webhook, WebhookVerificationError
-
-    HAS_SVIX = True
-except ImportError:
-    HAS_SVIX = False
+import dashboard as dashboard_module
+import data_enricher
+import database as db
+import email_automation
+import geometry
+import leg_registry
+import ml_models
+import registration
+import security_utils
+import tenant as tenant_module
+from admin import admin_bp, require_admin
+from api_public import public_api_bp
+from email_utils import send_email
+from health import health_bp
+from leg_registry import registry_bp
+from municipality import PILOT_MUNICIPALITIES, municipality_bp, pilot_bp
+from rangliste import rangliste_bp
+from ranking import Ranking
+from registration import CONSENT_VERSION, parse_consents  # noqa: F401
+from security_utils import log_security_event
+from self_host import self_host_bp
+from utility_portal import utility_bp
 
 # --- Security imports ---
 try:
@@ -45,40 +55,12 @@ try:
 except ImportError:
     HAS_SECURITY_LIBS = False
 
-# --- Email imports ---
-import dashboard as dashboard_module
-
-# --- Core modules ---
-import data_enricher
-
-# --- PostgreSQL Database ---
-import database as db
-import geometry
-import ml_models
-import registration
-import security_utils
-from email_utils import send_email
-from ranking import Ranking
-from registration import CONSENT_VERSION, parse_consents  # noqa: F401
+# Load environment variables
+load_dotenv()
 
 USE_POSTGRES = db.is_db_available()
 if not USE_POSTGRES:
     raise RuntimeError("PostgreSQL required. Set DATABASE_URL.")
-
-# --- Multi-tenant ---
-# --- Email Automation ---
-import email_automation
-import leg_registry
-import tenant as tenant_module
-from api_public import public_api_bp
-from health import health_bp
-from leg_registry import registry_bp
-
-# --- Blueprints ---
-from municipality import PILOT_MUNICIPALITIES, municipality_bp, pilot_bp
-from rangliste import rangliste_bp
-from self_host import self_host_bp
-from utility_portal import utility_bp
 
 # --- Cron Secret ---
 CRON_SECRET = os.getenv("CRON_SECRET", "").strip()
@@ -128,9 +110,6 @@ ALLOWED_HOSTS = os.getenv("ALLOWED_HOSTS", "localhost,127.0.0.1").split(",")
 
 # --- Email ---
 ADMIN_EMAIL = os.getenv("ADMIN_EMAIL", "hallo@openleg.ch")
-ADMIN_TOKEN = os.getenv("ADMIN_TOKEN", "").strip()
-INTERNAL_TOKEN = os.getenv("INTERNAL_TOKEN", "").strip()
-AGENTMAIL_WEBHOOK_SECRET = os.getenv("AGENTMAIL_WEBHOOK_SECRET", "").strip()
 
 # --- Rate Limiting & Security ---
 if HAS_SECURITY_LIBS:
@@ -185,6 +164,7 @@ app.register_blueprint(utility_bp)
 app.register_blueprint(rangliste_bp)
 app.register_blueprint(registry_bp)
 app.register_blueprint(self_host_bp)
+app.register_blueprint(admin_bp)
 
 # --- Multi-tenant middleware ---
 tenant_module.init_tenant_middleware(app, db=db)
@@ -203,18 +183,6 @@ def render_city_template(template_name, **kwargs):
         return render_template(city_path, **kwargs)
     except TemplateNotFound:
         return render_template(template_name, **kwargs)
-
-
-# --- Security Helpers ---
-def log_security_event(event_type, details, level="INFO"):
-    ip = request.headers.get("X-Forwarded-For", request.remote_addr)
-    log_message = f"[SECURITY] {event_type} | IP: {ip} | {details}"
-    if level == "WARNING":
-        logger.warning(log_message)
-    elif level == "ERROR":
-        logger.error(log_message)
-    else:
-        logger.info(log_message)
 
 
 @app.after_request
@@ -559,264 +527,6 @@ def sitemap_xml():
 
 
 ## Health endpoints registered via health_bp
-
-
-# --- Admin ---
-def _require_admin():
-    if not ADMIN_TOKEN:
-        abort(404)
-    token = request.headers.get("X-Admin-Token") or request.args.get("token") or ""
-    if token != ADMIN_TOKEN:
-        log_security_event("ADMIN_ACCESS_DENIED", "Invalid admin token", "WARNING")
-        abort(403)
-
-
-def _latest_snapshot_by_category(snapshots):
-    latest = {}
-    for snapshot in snapshots:
-        latest.setdefault(snapshot.get("category", "uncategorized"), snapshot)
-    return latest
-
-
-def _first_email_identity(value):
-    if isinstance(value, list):
-        value = value[0] if value else ""
-    if isinstance(value, dict):
-        return {"email": value.get("email", ""), "name": value.get("name", "")}
-    if isinstance(value, str):
-        return {"email": value, "name": ""}
-    return {"email": "", "name": ""}
-
-
-def _sanitize_agentmail_payload(data):
-    message = data.get("message") or {}
-    if not isinstance(message, dict):
-        message = {}
-    headers = message.get("headers") or {}
-    if not isinstance(headers, dict):
-        headers = {}
-    sender = _first_email_identity(message.get("from") or message.get("from_") or {})
-    recipients = message.get("to") or []
-    preview = (
-        message.get("text_preview")
-        or message.get("extracted_text")
-        or message.get("snippet")
-        or message.get("text")
-        or data.get("text_preview")
-        or ""
-    )
-    if isinstance(recipients, dict):
-        recipients = [recipients]
-    normalized_to = []
-    for recipient in recipients[:5]:
-        if isinstance(recipient, dict):
-            normalized_to.append(
-                {
-                    "email": recipient.get("email", ""),
-                    "name": recipient.get("name", ""),
-                }
-            )
-        elif isinstance(recipient, str):
-            normalized_to.append({"email": recipient, "name": ""})
-    return {
-        "event_type": (
-            data.get("event_type") or data.get("type") or data.get("event") or "unknown"
-        ),
-        "event_id": data.get("event_id"),
-        "inbox_id": message.get("inbox_id"),
-        "message_id": (
-            message.get("message_id") or message.get("id") or data.get("message_id")
-        ),
-        "thread_id": message.get("thread_id") or data.get("thread_id"),
-        "from_email": sender.get("email") or headers.get("from") or "",
-        "from_name": sender.get("name") or "",
-        "to": normalized_to,
-        "subject": message.get("subject") or headers.get("subject") or "",
-        "received_at": (
-            message.get("received_at")
-            or message.get("timestamp")
-            or data.get("received_at")
-            or data.get("timestamp")
-        ),
-        "text_preview": preview[:280],
-    }
-
-
-def _verify_agentmail_request():
-    if AGENTMAIL_WEBHOOK_SECRET:
-        if not HAS_SVIX:
-            abort(503)
-        try:
-            Webhook(AGENTMAIL_WEBHOOK_SECRET).verify(
-                request.get_data(),
-                {
-                    "svix-id": request.headers.get("svix-id", ""),
-                    "svix-timestamp": request.headers.get("svix-timestamp", ""),
-                    "svix-signature": request.headers.get("svix-signature", ""),
-                },
-            )
-            return
-        except WebhookVerificationError:
-            abort(403)
-    token = request.headers.get("X-Internal-Token") or ""
-    if not INTERNAL_TOKEN or token != INTERNAL_TOKEN:
-        abort(403)
-
-
-@app.route("/admin/overview")
-def admin_overview():
-    _require_admin()
-    stats = db.get_stats()
-    email_stats = db.get_email_stats()
-    consented = db.count_consented_buildings()
-    municipalities = db.get_all_municipalities()
-    return jsonify(
-        {
-            "platform": "OpenLEG",
-            "stats": stats,
-            "email_stats": email_stats,
-            "consented_buildings": consented,
-            "municipalities": len(municipalities),
-            "db_available": USE_POSTGRES,
-        }
-    )
-
-
-@app.route("/admin/export")
-def admin_export():
-    _require_admin()
-    fmt = (request.args.get("format") or "json").lower()
-    city_id = request.args.get("city_id")
-
-    buildings = db.get_all_building_profiles(city_id=city_id)
-    if fmt == "csv":
-        output = io.StringIO()
-        if buildings:
-            writer = csv.DictWriter(output, fieldnames=buildings[0].keys())
-            writer.writeheader()
-            for row in buildings:
-                writer.writerow(row)
-        response = Response(output.getvalue(), mimetype="text/csv")
-        response.headers["Content-Disposition"] = (
-            "attachment; filename=openleg_export.csv"
-        )
-        return response
-    return jsonify({"records": buildings, "count": len(buildings)})
-
-
-# --- LEA Reports ---
-@app.route("/api/internal/lea-report", methods=["POST"])
-def api_internal_lea_report():
-    token = request.headers.get("X-Internal-Token") or ""
-    if not INTERNAL_TOKEN or token != INTERNAL_TOKEN:
-        abort(403)
-    data = request.get_json(silent=True) or {}
-    job_name = data.get("job_name", "unknown")
-    summary = data.get("summary", "")
-    status = data.get("status", "ok")
-    db.save_lea_report(job_name, summary, status)
-    return jsonify({"ok": True})
-
-
-@app.route("/admin/lea-reports")
-def admin_lea_reports():
-    _require_admin()
-    reports = db.get_lea_reports(limit=50)
-    return jsonify({"reports": reports})
-
-
-@app.route("/api/internal/ops-snapshot", methods=["POST"])
-def api_internal_ops_snapshot():
-    token = request.headers.get("X-Internal-Token") or ""
-    if not INTERNAL_TOKEN or token != INTERNAL_TOKEN:
-        abort(403)
-    data = request.get_json(silent=True) or {}
-    db.save_ops_snapshot(
-        source=data.get("source", "unknown"),
-        category=data.get("category", "general"),
-        summary_text=data.get("summary", ""),
-        status=data.get("status", "ok"),
-        payload=data.get("payload") if isinstance(data.get("payload"), dict) else {},
-    )
-    return jsonify({"ok": True})
-
-
-@app.route("/api/internal/agentmail", methods=["POST"])
-def api_internal_agentmail():
-    _verify_agentmail_request()
-    data = request.get_json(silent=True) or {}
-    event_type = data.get("event_type") or data.get("type") or data.get("event") or ""
-    if event_type not in {
-        "message.received",
-        "message.received.unauthenticated",
-        "inbound_email.received",
-    }:
-        return jsonify({"ok": True, "ignored": True})
-    payload = _sanitize_agentmail_payload(data)
-    summary = payload.get("subject") or payload.get("from_email") or "Inbound LEA mail"
-    db.save_ops_snapshot(
-        source="agentmail",
-        category="lea_inbox",
-        summary_text=summary,
-        status="received",
-        payload=payload,
-    )
-    return jsonify({"ok": True})
-
-
-@app.route("/admin/ops")
-def admin_ops():
-    _require_admin()
-    snapshots = db.get_ops_snapshots(limit=100)
-    reports = db.get_lea_reports(limit=20)
-    latest = _latest_snapshot_by_category(snapshots)
-    pending_registry = leg_registry.annotate_vnb_plausibility(
-        db.list_registry_entries(moderation_status="pending")
-    )
-    stale_registry = db.get_registry_entries_needing_verification(
-        stale_days=leg_registry.VERIFICATION_STALE_DAYS, limit=1000
-    )
-    response = {
-        "latest": latest,
-        "snapshots": snapshots[:20],
-        "reports": reports,
-        "pending_registry": pending_registry,
-        "counts": {
-            "lea_inbox": sum(1 for s in snapshots if s.get("category") == "lea_inbox"),
-            "github_monitor": sum(
-                1 for s in snapshots if s.get("category") == "github_monitor"
-            ),
-            "vnb_monitor": sum(
-                1 for s in snapshots if s.get("category") == "vnb_monitor"
-            ),
-            "stuck_formations": sum(
-                1 for s in snapshots if s.get("category") == "stuck_formations"
-            ),
-            "registry_pending": db.get_registry_pending_count(),
-            "registry_stale": len(stale_registry),
-        },
-    }
-    if "text/html" in (request.headers.get("Accept") or ""):
-        return render_template("admin/ops.html", **response)
-    return Response(
-        json.dumps(response, default=str),
-        mimetype="application/json",
-    )
-
-
-@app.route("/admin/registry/<int:entry_id>/approve", methods=["POST"])
-def admin_registry_approve(entry_id):
-    _require_admin()
-    db.update_registry_entry_moderation(entry_id, "published", "")
-    return redirect(f"/admin/ops?token={ADMIN_TOKEN}")
-
-
-@app.route("/admin/registry/<int:entry_id>/reject", methods=["POST"])
-def admin_registry_reject(entry_id):
-    _require_admin()
-    reason = (request.form.get("reason") or "").strip()
-    db.update_registry_entry_moderation(entry_id, "rejected", reason)
-    return redirect(f"/admin/ops?token={ADMIN_TOKEN}")
 
 
 # --- Address API ---
@@ -1375,7 +1085,7 @@ def api_cron_backfill_elcom():
 
 @app.route("/api/email/stats")
 def api_email_stats():
-    _require_admin()
+    require_admin()
     return jsonify(db.get_email_stats())
 
 
@@ -1426,7 +1136,7 @@ def api_cron_verify_registry_entries():
 
 @app.route("/api/billing/community/<community_id>/period/<int:period_id>")
 def api_billing_period(community_id, period_id):
-    _require_admin()
+    require_admin()
     period = db.get_billing_period(period_id)
     if not period:
         return jsonify({"error": "Period not found"}), 404

--- a/security_utils.py
+++ b/security_utils.py
@@ -4,15 +4,30 @@ Security utilities for OpenLEG application
 Provides input validation, sanitization, and security helpers
 """
 
+import logging
 import re
 from urllib.parse import urlparse
 
 import bleach
 from email_validator import EmailNotValidError, validate_email
+from flask import request
+
+logger = logging.getLogger(__name__)
 
 # Allowed HTML tags for sanitization (none for our use case)
 ALLOWED_TAGS: list[str] = []
 ALLOWED_ATTRIBUTES: dict[str, list[str]] = {}
+
+
+def log_security_event(event_type, details, level="INFO"):
+    ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+    log_message = f"[SECURITY] {event_type} | IP: {ip} | {details}"
+    if level == "WARNING":
+        logger.warning(log_message)
+    elif level == "ERROR":
+        logger.error(log_message)
+    else:
+        logger.info(log_message)
 
 
 def sanitize_string(text, max_length=500):

--- a/security_utils.py
+++ b/security_utils.py
@@ -20,7 +20,8 @@ ALLOWED_ATTRIBUTES: dict[str, list[str]] = {}
 
 
 def log_security_event(event_type, details, level="INFO"):
-    ip = request.headers.get("X-Forwarded-For", request.remote_addr)
+    ip = request.access_route[0] if request.access_route else request.remote_addr
+    ip = str(ip or "").replace("\r", "").replace("\n", "")
     log_message = f"[SECURITY] {event_type} | IP: {ip} | {details}"
     if level == "WARNING":
         logger.warning(log_message)

--- a/tests/test_admin_blueprint.py
+++ b/tests/test_admin_blueprint.py
@@ -81,6 +81,12 @@ class TestBlueprintOwnsTheOperatorSurface:
 
         assert admin.admin_bp.name == "admin"
         assert callable(admin.require_admin)
+        assert callable(admin.require_internal_token)
+
+        with patch.object(admin.db, "is_db_available") as is_db_available:
+            importlib.reload(admin)
+
+        is_db_available.assert_not_called()
 
     def test_every_operator_route_is_served_by_the_blueprint(self, app_with_tokens):
         rules = {
@@ -119,23 +125,72 @@ class TestGuardsStayFailClosed:
                 continue
             assert client.get(rule).status_code == 404, f"{rule} leaked"
 
-    def test_admin_routes_reject_a_wrong_token(self, app_with_tokens):
+    def test_admin_routes_reject_a_wrong_token(self, app_with_tokens, caplog):
         client = app_with_tokens.app.test_client()
 
-        assert client.get("/admin/overview").status_code == 403
-        assert (
-            client.get("/admin/ops", headers={"X-Admin-Token": "nope"}).status_code
-            == 403
-        )
+        with patch("admin.hmac.compare_digest", return_value=False) as compare:
+            assert client.get("/admin/overview").status_code == 403
+            assert (
+                client.get(
+                    "/admin/ops",
+                    headers={"X-Admin-Token": "nope"},
+                    environ_overrides={
+                        "HTTP_X_FORWARDED_FOR": "198.51.100.4\r\nFORGED, 203.0.113.8"
+                    },
+                ).status_code
+                == 403
+            )
+
+        assert compare.call_count == 2
+        record = caplog.records[-1].message
+        assert "IP: 198.51.100.4FORGED |" in record
+        assert "203.0.113.8" not in record
+        assert "\r" not in record and "\n" not in record
 
     def test_internal_ingestion_rejects_a_wrong_token(self, app_with_tokens):
         client = app_with_tokens.app.test_client()
 
-        for rule in ("/api/internal/lea-report", "/api/internal/ops-snapshot"):
-            response = client.post(
-                rule, json={"job_name": "x"}, headers={"X-Internal-Token": "nope"}
+        with (
+            patch("admin.hmac.compare_digest", return_value=False) as compare,
+            patch(
+                "admin.require_internal_token",
+                wraps=__import__("admin").require_internal_token,
+            ) as guard,
+        ):
+            for rule in (
+                "/api/internal/lea-report",
+                "/api/internal/ops-snapshot",
+                "/api/internal/agentmail",
+            ):
+                response = client.post(
+                    rule,
+                    json={"job_name": "x"},
+                    headers={"X-Internal-Token": "nope"},
+                )
+                assert response.status_code == 403, f"{rule} accepted a wrong token"
+
+        assert guard.call_count == 3
+        assert compare.call_count == 3
+
+    def test_agentmail_preview_survives_a_non_string_body(self, app_with_tokens):
+        module = app_with_tokens
+        with patch.object(module.db, "save_ops_snapshot", return_value=True) as saved:
+            response = module.app.test_client().post(
+                "/api/internal/agentmail",
+                json={
+                    "event_type": "message.received",
+                    "message": {
+                        "message_id": "msg_1",
+                        "inbox_id": "hallo@openleg.ch",
+                        "subject": "LEG Anfrage",
+                        "text": 12345,
+                    },
+                },
+                headers={"X-Internal-Token": "internal-token"},
             )
-            assert response.status_code == 403, f"{rule} accepted a wrong token"
+
+        assert response.status_code == 200
+        assert saved.call_args.kwargs["payload"]["text_preview"] == "12345"
 
     def test_admin_overview_still_answers_with_a_valid_token(self, app_with_tokens):
         module = app_with_tokens
@@ -144,6 +199,9 @@ class TestGuardsStayFailClosed:
             patch.object(module.db, "get_email_stats", return_value={}),
             patch.object(module.db, "count_consented_buildings", return_value=0),
             patch.object(module.db, "get_all_municipalities", return_value=[]),
+            patch.object(
+                module.db, "is_db_available", return_value=True
+            ) as is_db_available,
         ):
             response = module.app.test_client().get(
                 "/admin/overview", headers={"X-Admin-Token": "admin-token"}
@@ -151,3 +209,4 @@ class TestGuardsStayFailClosed:
 
         assert response.status_code == 200
         assert response.get_json()["platform"] == "OpenLEG"
+        is_db_available.assert_called_once_with()

--- a/tests/test_admin_blueprint.py
+++ b/tests/test_admin_blueprint.py
@@ -1,0 +1,153 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""The admin and internal surface lives in its own blueprint.
+
+`app.py` carried the operator surface inline: six `/admin/*` routes, three
+`/api/internal/*` ingestion endpoints and their auth helpers. They form one
+cohesive area with one audience, so they move to `admin.py` behind
+`admin_bp`, and `app.py` keeps only the wiring.
+"""
+
+import importlib
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+ADMIN_RULES = (
+    "/admin/overview",
+    "/admin/export",
+    "/admin/lea-reports",
+    "/admin/ops",
+    "/admin/registry/<int:entry_id>/approve",
+    "/admin/registry/<int:entry_id>/reject",
+    "/api/internal/lea-report",
+    "/api/internal/ops-snapshot",
+    "/api/internal/agentmail",
+)
+
+
+def _load_app():
+    with (
+        patch("database.is_db_available", return_value=True),
+        patch("database._connection_pool", MagicMock()),
+    ):
+        import app as app_module
+
+        return importlib.reload(app_module)
+
+
+@pytest.fixture
+def app_with_tokens():
+    with patch.dict(
+        os.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "APP_BASE_URL": "http://localhost:5003",
+            "ADMIN_TOKEN": "admin-token",
+            "INTERNAL_TOKEN": "internal-token",
+        },
+    ):
+        yield _load_app()
+
+
+@pytest.fixture
+def app_without_admin_token():
+    with patch.dict(
+        os.environ,
+        {
+            "DATABASE_URL": "postgresql://x:x@localhost/x",
+            "REDIS_URL": "memory://",
+            "APP_BASE_URL": "http://localhost:5003",
+            "INTERNAL_TOKEN": "internal-token",
+        },
+    ):
+        os.environ.pop("ADMIN_TOKEN", None)
+        yield _load_app()
+
+
+class TestBlueprintOwnsTheOperatorSurface:
+    def test_app_imports_the_blueprint_without_reloading_it(self):
+        with open(os.path.join(PROJECT_ROOT, "app.py")) as handle:
+            content = handle.read()
+
+        assert "from admin import admin_bp, require_admin" in content
+        assert "importlib" not in content
+
+    def test_module_exposes_the_blueprint_and_the_guard(self):
+        import admin
+
+        assert admin.admin_bp.name == "admin"
+        assert callable(admin.require_admin)
+
+    def test_every_operator_route_is_served_by_the_blueprint(self, app_with_tokens):
+        rules = {
+            rule.rule: rule.endpoint
+            for rule in app_with_tokens.app.url_map.iter_rules()
+        }
+
+        for rule in ADMIN_RULES:
+            assert rule in rules, f"{rule} disappeared from the URL map"
+            assert rules[rule].startswith("admin."), (
+                f"{rule} is still served by {rules[rule]}"
+            )
+
+    def test_app_module_no_longer_declares_the_routes(self):
+        with open(os.path.join(PROJECT_ROOT, "app.py")) as handle:
+            content = handle.read()
+
+        for rule in ADMIN_RULES:
+            assert f'@app.route("{rule}"' not in content
+
+    def test_app_module_stays_within_its_budget(self):
+        with open(os.path.join(PROJECT_ROOT, "app.py")) as handle:
+            lines = len(handle.readlines())
+
+        assert lines < 1250, f"app.py is {lines} lines after the extraction"
+
+
+class TestGuardsStayFailClosed:
+    def test_admin_routes_hide_when_no_admin_token_is_configured(
+        self, app_without_admin_token
+    ):
+        client = app_without_admin_token.app.test_client()
+
+        for rule in ADMIN_RULES:
+            if not rule.startswith("/admin/") or "<" in rule:
+                continue
+            assert client.get(rule).status_code == 404, f"{rule} leaked"
+
+    def test_admin_routes_reject_a_wrong_token(self, app_with_tokens):
+        client = app_with_tokens.app.test_client()
+
+        assert client.get("/admin/overview").status_code == 403
+        assert (
+            client.get("/admin/ops", headers={"X-Admin-Token": "nope"}).status_code
+            == 403
+        )
+
+    def test_internal_ingestion_rejects_a_wrong_token(self, app_with_tokens):
+        client = app_with_tokens.app.test_client()
+
+        for rule in ("/api/internal/lea-report", "/api/internal/ops-snapshot"):
+            response = client.post(
+                rule, json={"job_name": "x"}, headers={"X-Internal-Token": "nope"}
+            )
+            assert response.status_code == 403, f"{rule} accepted a wrong token"
+
+    def test_admin_overview_still_answers_with_a_valid_token(self, app_with_tokens):
+        module = app_with_tokens
+        with (
+            patch.object(module.db, "get_stats", return_value={"buildings": 1}),
+            patch.object(module.db, "get_email_stats", return_value={}),
+            patch.object(module.db, "count_consented_buildings", return_value=0),
+            patch.object(module.db, "get_all_municipalities", return_value=[]),
+        ):
+            response = module.app.test_client().get(
+                "/admin/overview", headers={"X-Admin-Token": "admin-token"}
+            )
+
+        assert response.status_code == 200
+        assert response.get_json()["platform"] == "OpenLEG"

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -202,7 +202,7 @@ class TestAdminOpsRoutes:
 
 class TestAdminOpsRouteExists:
     def test_admin_ops_routes_in_source(self):
-        with open(os.path.join(PROJECT_ROOT, "app.py")) as f:
+        with open(os.path.join(PROJECT_ROOT, "admin.py")) as f:
             content = f.read()
         assert "/admin/ops" in content
         assert "/api/internal/ops-snapshot" in content

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -196,6 +196,10 @@ class TestAdminOpsRoutes:
                 assert kwargs["payload"]["message_id"] == "msg_123"
                 assert kwargs["payload"]["inbox_id"] == "hallo@openleg.ch"
                 assert kwargs["payload"]["from_email"] == "sender@example.com"
+                assert (
+                    kwargs["payload"]["text_preview"]
+                    == "Bitte um Informationen zur LEG."
+                )
             except Exception:
                 pytest.skip("App import requires live DB")
 

--- a/tests/test_lea_reports.py
+++ b/tests/test_lea_reports.py
@@ -119,16 +119,16 @@ class TestAdminLeaReports:
 
 
 class TestLeaReportRouteExists:
-    """Static test: verify routes exist in app.py source."""
+    """Static test: verify routes exist in admin.py source."""
 
     def test_lea_report_post_route_in_source(self):
-        with open(os.path.join(PROJECT_ROOT, "app.py")) as f:
+        with open(os.path.join(PROJECT_ROOT, "admin.py")) as f:
             content = f.read()
         assert "/api/internal/lea-report" in content
         assert "X-Internal-Token" in content
 
     def test_admin_lea_reports_route_in_source(self):
-        with open(os.path.join(PROJECT_ROOT, "app.py")) as f:
+        with open(os.path.join(PROJECT_ROOT, "admin.py")) as f:
             content = f.read()
         assert "/admin/lea-reports" in content
         assert "get_lea_reports" in content

--- a/tests/test_private_content_absent.py
+++ b/tests/test_private_content_absent.py
@@ -113,8 +113,10 @@ def test_no_public_snapshot_markers_in_tracked_sources():
 
 def test_private_operator_surface_absent_from_modules():
     app_content = Path(PROJECT_ROOT, "app.py").read_text(encoding="utf-8")
+    admin_content = Path(PROJECT_ROOT, "admin.py").read_text(encoding="utf-8")
     for fragment in ("/admin/pipeline", "/admin/strategy", "insights_engine"):
         assert fragment not in app_content
+        assert fragment not in admin_content
 
     email_content = Path(PROJECT_ROOT, "email_automation.py").read_text(
         encoding="utf-8"


### PR DESCRIPTION
## Summary

- new `admin.py` owns the operator surface: six `/admin/*` routes, three `/api/internal/*` ingestion endpoints, and their auth helpers, behind `admin_bp`
- `app.py` keeps the wiring and imports `require_admin` for the two routes outside the blueprint that still guard with it
- `log_security_event` moves to `security_utils.py`, so `app.py` and `admin.py` share one definition
- the admin and internal tokens are read at request time instead of cached at import

## Why

`app.py` was 1459 lines and the operator surface was the largest cohesive block in it. It has one audience and one auth rule, so it belongs in its own module. This is the first of the app.py splits; cron and the LEG community routes follow.

## Impact

`app.py` drops to 1170 lines. Behaviour is unchanged: no `ADMIN_TOKEN` configured still answers 404, a wrong admin token 403, a missing or wrong internal token 403.

Reading the tokens lazily also removed the need for the reload dance in tests: **10 tests in `test_admin_ops.py` and `test_lea_reports.py` that silently skipped with "App import requires live DB" now actually run and pass.** Skips drop from 11 to 1, and no test moved from passing to skipped.

The tests that assert routes exist by reading source now read `admin.py`, and `test_private_content_absent` checks the private operator fragments against `admin.py` as well, so the private surface cannot return through the new module.

## Validation

- new red tests first: `tests/test_admin_blueprint.py` (8 tests, 4 of them pinning the existing fail-closed behaviour)
- `pytest tests/ -q`: 873 passed, 1 skipped
- `ruff check .` and `ruff format --check .` clean on the pinned 0.16.1
- skip lists diffed against `main` to prove no coverage was lost

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UV8L9ETLiU5CZsbrc2ZTgS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added authenticated administration tools for platform overviews, exports, reports, operations monitoring, email ingestion, and registry moderation.
  * Added CSV and JSON export options, plus HTML views for supported administrative data.
  * Added security event logging for improved monitoring.

* **Bug Fixes**
  * Administrative and internal endpoints now fail closed when credentials are missing or invalid.

* **Tests**
  * Expanded coverage for authentication, route availability, reporting, operations, and administrative workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->