### PR TITLE
[codex] refactor(app): remove legacy application proxy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -154,7 +154,7 @@ Use a production WSGI server instead of Flask's development server:
 pip install gunicorn
 
 # Run with Gunicorn
-gunicorn -w 4 -b 0.0.0.0:8000 app:app
+gunicorn -w 4 -b 0.0.0.0:8000 wsgi:app
 ```
 
 #### Reverse Proxy
@@ -305,4 +305,3 @@ Please do NOT publicly disclose security issues without coordination.
 ---
 
 Last updated: November 2024
-

--- a/app.py
+++ b/app.py
@@ -23,7 +23,6 @@ from flask import (
     send_from_directory,
 )
 from jinja2 import TemplateNotFound
-from werkzeug.local import LocalProxy
 
 import dashboard as dashboard_module
 import data_enricher
@@ -1172,20 +1171,6 @@ def create_app(config=None, *, load_environment=True, check_database=True):
         logger.info("Security features enabled")
 
     return application
-
-
-_compatibility_app = None
-
-
-def _get_compatibility_app():
-    # ponytail: lazy legacy export; remove when callers use create_app or wsgi:app.
-    global _compatibility_app
-    if _compatibility_app is None:
-        _compatibility_app = create_app()
-    return _compatibility_app
-
-
-app = LocalProxy(_get_compatibility_app)
 
 
 if __name__ == "__main__":

--- a/tests/test_admin_ops.py
+++ b/tests/test_admin_ops.py
@@ -32,7 +32,9 @@ class TestAdminOpsRoutes:
             patch("database._connection_pool", MagicMock()),
             patch("database.is_db_available", return_value=True),
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.get("/admin/ops")
@@ -74,7 +76,9 @@ class TestAdminOpsRoutes:
             patch("database.get_ops_snapshots", return_value=snapshots),
             patch("database.get_lea_reports", return_value=[]),
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.get(
@@ -102,7 +106,9 @@ class TestAdminOpsRoutes:
             patch("database.is_db_available", return_value=True),
             patch("database.save_ops_snapshot", return_value=True),
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post(
@@ -132,7 +138,9 @@ class TestAdminOpsRoutes:
             patch("database.is_db_available", return_value=True),
             patch("database.save_ops_snapshot", return_value=True) as save_snapshot,
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post(
@@ -159,7 +167,9 @@ class TestAdminOpsRoutes:
             patch("database.is_db_available", return_value=True),
             patch("database.save_ops_snapshot", return_value=True) as save_snapshot,
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post(
@@ -223,7 +233,9 @@ class TestAdminRegistryModeration:
             patch("database.list_registry_entries", return_value=[{"id": 1}]),
             patch("database.get_registry_pending_count", return_value=1),
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.get(
@@ -252,7 +264,9 @@ class TestAdminRegistryModeration:
                 "database.update_registry_entry_moderation", return_value=True
             ) as mock_update,
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post("/admin/registry/1/approve")
@@ -276,7 +290,9 @@ class TestAdminRegistryModeration:
                 "database.update_registry_entry_moderation", return_value=True
             ) as mock_update,
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post(
@@ -303,7 +319,9 @@ class TestAdminRegistryModeration:
                 "database.update_registry_entry_moderation", return_value=True
             ) as mock_update,
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.post(
@@ -354,7 +372,9 @@ class TestAdminRegistryModeration:
                 return_value=[{"operator_name": "Regionalwerke Baden AG"}],
             ),
         ):
-            from app import app
+            from app import create_app
+
+            app = create_app(load_environment=False)
 
             client = app.test_client()
             resp = client.get(

--- a/tests/test_app_factory.py
+++ b/tests/test_app_factory.py
@@ -3,6 +3,7 @@
 
 import subprocess
 import sys
+from pathlib import Path
 
 
 def test_import_is_inert_and_factory_instances_are_isolated():
@@ -21,6 +22,14 @@ with (
 
 database_probe.assert_not_called()
 logging_probe.assert_not_called()
+assert 'app' not in vars(app)
+assert not hasattr(app, 'app')
+try:
+    from app import app as legacy_app
+except ImportError:
+    pass
+else:
+    raise AssertionError(f'legacy app export still available: {legacy_app!r}')
 first = app.create_app(
     {'TESTING': True, 'SECRET_KEY': 'first', 'RATELIMIT_STORAGE_URI': 'memory://'},
     load_environment=False,
@@ -35,12 +44,6 @@ assert first is not second
 assert first.config['SECRET_KEY'] == 'first'
 assert second.config['SECRET_KEY'] == 'second'
 assert first.test_client().get('/livez').status_code == 200
-
-with patch.object(app, 'create_app', return_value=object()) as factory:
-    app._compatibility_app = None
-    app.app._get_current_object()
-
-factory.assert_called_once_with()
 """,
         ],
         capture_output=True,
@@ -49,3 +52,10 @@ factory.assert_called_once_with()
     )
 
     assert result.returncode == 0, result.stderr
+
+
+def test_documented_gunicorn_target_uses_wsgi_entrypoint():
+    security = Path("SECURITY.md").read_text()
+
+    assert "gunicorn -w 4 -b 0.0.0.0:8000 wsgi:app" in security
+    assert "app:app" not in security

--- a/tests/test_app_organic_routes.py
+++ b/tests/test_app_organic_routes.py
@@ -50,15 +50,16 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
-        hooks = _disable_rate_limit_hooks(app_module.app)
+        app_module.web = app_module.create_app(load_environment=False)
+        hooks = _disable_rate_limit_hooks(app_module.web)
         try:
             yield app_module
         finally:
-            app_module.app.before_request_funcs[None] = hooks
+            app_module.web.before_request_funcs[None] = hooks
 
 
 def test_robots_allows_api_docs_but_blocks_api(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     resp = client.get("/robots.txt")
     assert resp.status_code == 200
     body = resp.data.decode("utf-8", errors="ignore")
@@ -67,7 +68,7 @@ def test_robots_allows_api_docs_but_blocks_api(full_app_module):
 
 
 def test_security_policy_allows_google_analytics_region_collect(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     resp = client.get("/robots.txt")
 
     csp = resp.headers.get("Content-Security-Policy", "")
@@ -80,7 +81,7 @@ def test_security_policy_allows_google_analytics_region_collect(full_app_module)
 
 
 def test_security_policy_allows_brand_font_assets(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     resp = client.get("/dashboard/demo")
 
     csp = resp.headers.get("Content-Security-Policy", "")
@@ -99,7 +100,7 @@ def test_security_policy_allows_brand_font_assets(full_app_module):
 
 
 def test_root_favicon_serves_static_icon(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.get("/favicon.ico")
 
@@ -121,7 +122,7 @@ def test_sitemap_contains_directory_docs_and_profile_urls(full_app_module, monke
         "get_all_municipality_profile_bfs_numbers",
         lambda: [261, 247],
     )
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.get("/sitemap.xml")
     assert resp.status_code == 200
@@ -137,7 +138,7 @@ def test_sitemap_contains_directory_docs_and_profile_urls(full_app_module, monke
 
 
 def test_open_source_page_explains_codebase(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.get("/open-source")
     assert resp.status_code == 200
@@ -167,7 +168,7 @@ def test_open_source_page_explains_codebase(full_app_module):
     ],
 )
 def test_public_guides_have_share_metadata(full_app_module, route, headline):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.get(route)
 
@@ -202,7 +203,7 @@ def test_backfill_elcom_invalid_secret_returns_403_and_no_mutation(
         "save_elcom_tariffs",
         lambda rows: called.__setitem__("save", called["save"] + 1),
     )
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.post("/api/cron/backfill-elcom")
     assert resp.status_code == 403
@@ -234,7 +235,7 @@ def test_backfill_elcom_processes_batch_and_returns_summary(
     monkeypatch.setattr(
         full_app_module.db, "save_elcom_tariffs", lambda rows: len(rows)
     )
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     resp = client.post(
         "/api/cron/backfill-elcom?limit=2&year=2026",

--- a/tests/test_conversion_paths.py
+++ b/tests/test_conversion_paths.py
@@ -44,6 +44,7 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
+        app_module.web = app_module.create_app(load_environment=False)
         yield app_module
 
 
@@ -164,7 +165,7 @@ class TestMunicipalitySearch:
 
 class TestRateLimitResponse:
     def test_429_returns_german_json(self, full_app_module):
-        app = full_app_module.app
+        app = full_app_module.web
         handler = app.error_handler_spec[None].get(429)
         assert handler, (
             "no 429 errorhandler registered; rate-limited visitors get an English HTML page"
@@ -229,7 +230,7 @@ class TestSuggestAddressesOutage:
     """
 
     def test_upstream_failure_returns_503_json(self, full_app_module):
-        client = full_app_module.app.test_client()
+        client = full_app_module.web.test_client()
         with patch.object(
             full_app_module.data_enricher, "get_address_suggestions", return_value=None
         ):
@@ -239,7 +240,7 @@ class TestSuggestAddressesOutage:
         assert "verfügbar" in resp.get_json()["error"]
 
     def test_genuinely_empty_result_stays_200(self, full_app_module):
-        client = full_app_module.app.test_client()
+        client = full_app_module.web.test_client()
         with patch.object(
             full_app_module.data_enricher, "get_address_suggestions", return_value=[]
         ):

--- a/tests/test_dashboard_demo.py
+++ b/tests/test_dashboard_demo.py
@@ -28,15 +28,16 @@ def app_module():
         import app as imported_app
 
         imported_app = importlib.reload(imported_app)
-        hooks = _disable_rate_limit_hooks(imported_app.app)
+        imported_app.web = imported_app.create_app(load_environment=False)
+        hooks = _disable_rate_limit_hooks(imported_app.web)
         try:
             yield imported_app
         finally:
-            imported_app.app.before_request_funcs[None] = hooks
+            imported_app.web.before_request_funcs[None] = hooks
 
 
 def test_dashboard_demo_route_renders_fake_data(app_module):
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     response = client.get("/dashboard/demo")
 
     assert response.status_code == 200
@@ -76,7 +77,7 @@ def test_readiness_counts_neighbors_at_zero_coordinates(monkeypatch):
 
 
 def test_dashboard_uses_brand_system_not_bespoke_css(app_module):
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     html = client.get("/dashboard/demo").get_data(as_text=True)
     # the old template shipped its own .dashboard-* stylesheet
     assert ".dashboard-wrap{" not in html.replace(" ", "")
@@ -84,14 +85,14 @@ def test_dashboard_uses_brand_system_not_bespoke_css(app_module):
 
 
 def test_dashboard_open_checks_are_actionable(app_module):
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     html = client.get("/dashboard/demo").get_data(as_text=True)
     # demo data has exactly one open check; it must carry an action link
     assert html.count("check-action") >= 1
 
 
 def test_dashboard_calculator_has_visible_feedback(app_module):
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     html = client.get("/dashboard/demo").get_data(as_text=True)
     assert 'id="calc-error"' in html
 
@@ -99,9 +100,9 @@ def test_dashboard_calculator_has_visible_feedback(app_module):
 def test_dashboard_internal_links_resolve(app_module):
     import re as _re
 
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     html = client.get("/dashboard/demo").get_data(as_text=True)
-    adapter = app_module.app.url_map.bind("localhost")
+    adapter = app_module.web.url_map.bind("localhost")
     hrefs = {
         h.split("#")[0].split("?")[0]
         for h in _re.findall(r'href="(/[^"]*)"', html)

--- a/tests/test_dashboard_readiness_polish.py
+++ b/tests/test_dashboard_readiness_polish.py
@@ -29,11 +29,12 @@ def client():
         import app as imported_app
 
         imported_app = importlib.reload(imported_app)
-        hooks = _disable_rate_limit_hooks(imported_app.app)
+        application = imported_app.create_app(load_environment=False)
+        hooks = _disable_rate_limit_hooks(application)
         try:
-            yield imported_app.app.test_client()
+            yield application.test_client()
         finally:
-            imported_app.app.before_request_funcs[None] = hooks
+            application.before_request_funcs[None] = hooks
 
 
 def _html(client, path):

--- a/tests/test_fuer_gemeinden_page.py
+++ b/tests/test_fuer_gemeinden_page.py
@@ -2,8 +2,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 class TestFuerGemeindenPage:
     def test_page_renders(self):
@@ -20,11 +18,9 @@ class TestFuerGemeindenPage:
             patch("database.init_db", return_value=True),
             patch("database._connection_pool", MagicMock()),
         ):
-            try:
-                from app import app
-            except Exception:
-                pytest.skip("App import requires live DB")
+            from app import create_app
 
+            app = create_app(load_environment=False)
             client = app.test_client()
             hooks = list(app.before_request_funcs.get(None, []))
             app.before_request_funcs[None] = [
@@ -61,11 +57,9 @@ class TestFuerGemeindenPage:
             patch("database.init_db", return_value=True),
             patch("database._connection_pool", MagicMock()),
         ):
-            try:
-                from app import app
-            except Exception:
-                pytest.skip("App import requires live DB")
+            from app import create_app
 
+            app = create_app(load_environment=False)
             client = app.test_client()
             hooks = list(app.before_request_funcs.get(None, []))
             app.before_request_funcs[None] = [

--- a/tests/test_gemeinde_dashboard.py
+++ b/tests/test_gemeinde_dashboard.py
@@ -4,8 +4,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 
 def _client():
     with (
@@ -21,10 +19,9 @@ def _client():
         patch("database.init_db", return_value=True),
         patch("database._connection_pool", MagicMock()),
     ):
-        try:
-            from app import app
-        except Exception:
-            pytest.skip("App import requires live DB")
+        from app import create_app
+
+        app = create_app(load_environment=False)
         return app.test_client()
 
 

--- a/tests/test_github_security_fixes.py
+++ b/tests/test_github_security_fixes.py
@@ -49,11 +49,12 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
-        hooks = _disable_rate_limit_hooks(app_module.app)
+        app_module.web = app_module.create_app(load_environment=False)
+        hooks = _disable_rate_limit_hooks(app_module.web)
         try:
             yield app_module
         finally:
-            app_module.app.before_request_funcs[None] = hooks
+            app_module.web.before_request_funcs[None] = hooks
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +141,7 @@ def test_check_potential_does_not_expose_exception_text(full_app_module, monkeyp
         MagicMock(side_effect=RuntimeError("boom")),
     )
 
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     resp = client.post(
         "/api/check_potential", json={"address": "Bahnhofstrasse 1, Zürich"}
     )
@@ -153,7 +154,7 @@ def test_check_potential_does_not_expose_exception_text(full_app_module, monkeyp
 
 def test_meter_data_upload_malformed_tier_returns_json_error(full_app_module):
     app_module = full_app_module
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     resp = client.post(
         "/api/meter-data/upload",
         json={"building_id": "b-123", "csv_content": "x", "tier": "not-an-int"},
@@ -175,7 +176,7 @@ def test_meter_data_upload_get_building_error_is_generic(full_app_module, monkey
         app_module.db, "get_building", MagicMock(side_effect=RuntimeError("db down"))
     )
 
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     resp = client.post(
         "/api/meter-data/upload",
         json={"building_id": "b-123", "csv_content": "x", "tier": 1},
@@ -198,7 +199,7 @@ def test_meter_data_upload_save_consent_error_is_generic(full_app_module, monkey
         MagicMock(side_effect=RuntimeError("consent save failed")),
     )
 
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     resp = client.post(
         "/api/meter-data/upload",
         json={"building_id": "b-123", "csv_content": "x", "tier": 1},
@@ -221,7 +222,7 @@ def test_meter_data_upload_does_not_expose_exception_text(full_app_module, monke
         app_module.db, "get_building", lambda _bid: {"building_id": _bid}
     )
 
-    client = app_module.app.test_client()
+    client = app_module.web.test_client()
     resp = client.post(
         "/api/meter-data/upload",
         json={"building_id": "b-123", "csv_content": "x", "tier": 1},

--- a/tests/test_index_screenshots.py
+++ b/tests/test_index_screenshots.py
@@ -5,8 +5,6 @@ import os
 import re
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SCREENSHOT_DIR = os.path.join(PROJECT_ROOT, "static", "images", "screenshots")
 LANDING_DIR = os.path.join(PROJECT_ROOT, "static", "images", "landing")
@@ -28,10 +26,9 @@ def _index_html():
         patch("database._connection_pool", MagicMock()),
         patch("database.get_stats", return_value={"total_buildings": 7}),
     ):
-        try:
-            from app import app
-        except Exception:
-            pytest.skip("App import requires live DB")
+        from app import create_app
+
+        app = create_app(load_environment=False)
         client = app.test_client()
         response = client.get("/")
         assert response.status_code == 200

--- a/tests/test_lea_reports.py
+++ b/tests/test_lea_reports.py
@@ -4,8 +4,6 @@
 import os
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
@@ -24,17 +22,16 @@ class TestLeaReportWebhook:
             patch("database._connection_pool", MagicMock()),
             patch("database.is_db_available", return_value=True),
         ):
-            try:
-                from app import app
+            from app import create_app
 
-                client = app.test_client()
-                resp = client.post(
-                    "/api/internal/lea-report",
-                    json={"job_name": "test", "summary": "hi"},
-                )
-                assert resp.status_code == 403
-            except Exception:
-                pytest.skip("App import requires live DB")
+            client = create_app(
+                {"RATELIMIT_STORAGE_URI": "memory://"}, load_environment=False
+            ).test_client()
+            resp = client.post(
+                "/api/internal/lea-report",
+                json={"job_name": "test", "summary": "hi"},
+            )
+            assert resp.status_code == 403
 
     def test_lea_report_accepts_with_valid_token(self):
         with (
@@ -51,19 +48,17 @@ class TestLeaReportWebhook:
             patch("database.is_db_available", return_value=True),
             patch("database.save_lea_report", return_value=True),
         ):
-            try:
-                from app import app
+            from app import create_app
 
-                client = app.test_client()
-                resp = client.post(
-                    "/api/internal/lea-report",
-                    json={"job_name": "daily-health-check", "summary": "All good"},
-                    headers={"X-Internal-Token": "secret-internal"},
-                )
-                # Route exists; may 403 if env var not picked up at module level
-                assert resp.status_code in (200, 403)
-            except Exception:
-                pytest.skip("App import requires live DB")
+            client = create_app(
+                {"RATELIMIT_STORAGE_URI": "memory://"}, load_environment=False
+            ).test_client()
+            resp = client.post(
+                "/api/internal/lea-report",
+                json={"job_name": "daily-health-check", "summary": "All good"},
+                headers={"X-Internal-Token": "secret-internal"},
+            )
+            assert resp.status_code == 200
 
 
 class TestAdminLeaReports:
@@ -80,14 +75,13 @@ class TestAdminLeaReports:
             patch("database._connection_pool", MagicMock()),
             patch("database.is_db_available", return_value=True),
         ):
-            try:
-                from app import app
+            from app import create_app
 
-                client = app.test_client()
-                resp = client.get("/admin/lea-reports")
-                assert resp.status_code == 403
-            except Exception:
-                pytest.skip("App import requires live DB")
+            client = create_app(
+                {"RATELIMIT_STORAGE_URI": "memory://"}, load_environment=False
+            ).test_client()
+            resp = client.get("/admin/lea-reports")
+            assert resp.status_code == 403
 
     def test_admin_lea_reports_returns_json(self):
         with (
@@ -103,19 +97,16 @@ class TestAdminLeaReports:
             patch("database.is_db_available", return_value=True),
             patch("database.get_lea_reports", return_value=[]),
         ):
-            try:
-                from app import app
+            from app import create_app
 
-                client = app.test_client()
-                resp = client.get(
-                    "/admin/lea-reports", headers={"X-Admin-Token": "test123"}
-                )
-                assert resp.status_code in (200, 500)
-                if resp.status_code == 200:
-                    data = resp.get_json()
-                    assert "reports" in data
-            except Exception:
-                pytest.skip("App import requires live DB")
+            client = create_app(
+                {"RATELIMIT_STORAGE_URI": "memory://"}, load_environment=False
+            ).test_client()
+            resp = client.get(
+                "/admin/lea-reports", headers={"X-Admin-Token": "test123"}
+            )
+            assert resp.status_code == 200
+            assert "reports" in resp.get_json()
 
 
 class TestLeaReportRouteExists:

--- a/tests/test_leg_founder_journey.py
+++ b/tests/test_leg_founder_journey.py
@@ -83,10 +83,11 @@ def founder_page():
         import app as app_module
 
         app_module = importlib.reload(app_module)
-        response = app_module.app.test_client().get("/leg-gruenden")
+        application = app_module.create_app(load_environment=False)
+        response = application.test_client().get("/leg-gruenden")
         parser = FounderPageParser()
         parser.feed(response.get_data(as_text=True))
-        yield app_module.app, response, parser
+        yield application, response, parser
 
 
 def _jsonld(parser, schema_type):

--- a/tests/test_leg_registry_routes.py
+++ b/tests/test_leg_registry_routes.py
@@ -364,7 +364,7 @@ def test_cron_verify_registry_entries_requires_secret(monkeypatch):
         import app as app_module
 
         app_module = importlib.reload(app_module)
-        client = app_module.app.test_client()
+        client = app_module.create_app(load_environment=False).test_client()
         resp = client.post("/api/cron/verify-registry-entries")
         assert resp.status_code == 403
 
@@ -433,7 +433,7 @@ def test_cron_verify_registry_entries_calls_nudge_job(monkeypatch):
             "leg_registry.send_verification_nudges",
             return_value={"candidates": 0, "sent": 0, "errors": 0},
         ) as mock_job:
-            client = app_module.app.test_client()
+            client = app_module.create_app(load_environment=False).test_client()
             resp = client.post(
                 "/api/cron/verify-registry-entries",
                 headers={"X-Cron-Secret": "test-cron-secret"},

--- a/tests/test_open_source_pathway.py
+++ b/tests/test_open_source_pathway.py
@@ -32,6 +32,7 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
+        app_module.web = app_module.create_app(load_environment=False)
         app_module.db.get_stats = lambda **_kwargs: {"total_buildings": 0}
         yield app_module
 
@@ -43,14 +44,14 @@ def _html(client, route):
 
 
 def test_install_command_renders_verbatim_on_self_host_and_homepage(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
 
     for route in ("/self-host", "/"):
         assert INSTALL_COMMAND in _html(client, route)
 
 
 def test_install_endpoint_serves_script_unchanged(full_app_module):
-    response = full_app_module.app.test_client().get("/install.sh")
+    response = full_app_module.web.test_client().get("/install.sh")
 
     assert response.status_code == 200
     assert response.data == (ROOT / "scripts" / "install.sh").read_bytes()
@@ -58,7 +59,7 @@ def test_install_endpoint_serves_script_unchanged(full_app_module):
 
 @pytest.mark.parametrize("route", PATHWAY_ROUTES)
 def test_pathway_routes_state_agpl_and_data_ownership(full_app_module, route):
-    html = _html(full_app_module.app.test_client(), route)
+    html = _html(full_app_module.web.test_client(), route)
 
     assert "AGPL-3.0-or-later" in html
     assert 'href="https://github.com/Open-LEG-ch/openleg/blob/main/LICENSE"' in html
@@ -71,8 +72,8 @@ def test_pathway_routes_state_agpl_and_data_ownership(full_app_module, route):
 def test_pathway_routes_use_municipality_operating_model_vocabulary(
     full_app_module, route
 ):
-    municipality_html = _html(full_app_module.app.test_client(), "/fuer-gemeinden")
-    pathway_html = _html(full_app_module.app.test_client(), route)
+    municipality_html = _html(full_app_module.web.test_client(), "/fuer-gemeinden")
+    pathway_html = _html(full_app_module.web.test_client(), route)
 
     for model in OPERATING_MODELS:
         assert model in municipality_html
@@ -95,11 +96,11 @@ def test_documented_install_paths_are_backed_by_repository_files():
 
 @pytest.mark.parametrize("route", PATHWAY_ROUTES)
 def test_pathway_routes_return_200(full_app_module, route):
-    assert full_app_module.app.test_client().get(route).status_code == 200
+    assert full_app_module.web.test_client().get(route).status_code == 200
 
 
 def test_open_source_gives_technical_users_concrete_entry_points(full_app_module):
-    html = _html(full_app_module.app.test_client(), "/open-source")
+    html = _html(full_app_module.web.test_client(), "/open-source")
 
     for entry_point in (
         "app.py",

--- a/tests/test_pilot_case_study.py
+++ b/tests/test_pilot_case_study.py
@@ -178,6 +178,7 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
+        app_module.web = app_module.create_app(load_environment=False)
         yield app_module
 
 
@@ -187,7 +188,7 @@ def test_sitemap_contains_case_study(full_app_module, monkeypatch):
         "get_all_municipality_profile_bfs_numbers",
         lambda: [4021],
     )
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     xml = client.get("/sitemap.xml").data.decode("utf-8", errors="ignore")
     assert "/pilotgemeinde/baden" in xml
 
@@ -211,7 +212,7 @@ def test_pilot_uses_latest_tariffs_not_hardcoded_year(monkeypatch):
 
 
 def test_fuer_bewohner_links_to_case_study(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     resp = client.get("/fuer-bewohner")
     assert resp.status_code == 200
     html = resp.data.decode("utf-8", errors="ignore")

--- a/tests/test_registration_contract.py
+++ b/tests/test_registration_contract.py
@@ -28,17 +28,7 @@ def app_module():
         app = importlib.reload(app)
         if app.limiter:
             app.limiter.enabled = False
-        hooks = list(app.app.before_request_funcs.get(None, []))
-        app.app.before_request_funcs[None] = [
-            hook
-            for hook in hooks
-            if not (
-                getattr(hook, "__module__", "").startswith("flask_limiter")
-                or getattr(hook, "__name__", "") == "_check_request_limit"
-            )
-        ]
         yield app
-        app.app.before_request_funcs[None] = hooks
 
 
 @pytest.fixture
@@ -106,7 +96,8 @@ def registration(app_module, monkeypatch):
         app_module.email_automation, "schedule_sequence_for_user", MagicMock()
     )
 
-    return app_module.app.test_client(), db, threads
+    application = app_module.create_app(load_environment=False)
+    return application.test_client(), db, threads
 
 
 def valid_data(**updates):

--- a/tests/test_resident_journey.py
+++ b/tests/test_resident_journey.py
@@ -53,7 +53,8 @@ def resident_client():
         with patch.object(
             app_module.db, "get_stats", return_value={"total_buildings": 0}
         ):
-            yield app_module.app.test_client()
+            application = app_module.create_app(load_environment=False)
+            yield application.test_client()
 
 
 @pytest.fixture

--- a/tests/test_stakeholder_pathways.py
+++ b/tests/test_stakeholder_pathways.py
@@ -34,8 +34,9 @@ def full_app_module():
         import app as app_module
 
         app_module = importlib.reload(app_module)
-        hooks = list(app_module.app.before_request_funcs.get(None, []))
-        app_module.app.before_request_funcs[None] = [
+        app_module.web = app_module.create_app(load_environment=False)
+        hooks = list(app_module.web.before_request_funcs.get(None, []))
+        app_module.web.before_request_funcs[None] = [
             hook
             for hook in hooks
             if not (
@@ -46,7 +47,7 @@ def full_app_module():
         try:
             yield app_module
         finally:
-            app_module.app.before_request_funcs[None] = hooks
+            app_module.web.before_request_funcs[None] = hooks
 
 
 # --- Landing pathways wayfinding ---
@@ -66,7 +67,7 @@ def test_landing_has_four_stakeholder_pathways():
 
 
 def test_fuer_bewohner_route_renders(full_app_module):
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     resp = client.get("/fuer-bewohner", follow_redirects=True)
     assert resp.status_code == 200
     html = resp.data.decode("utf-8", errors="ignore")
@@ -137,7 +138,7 @@ def test_fuer_bewohner_in_sitemap(full_app_module, monkeypatch):
     monkeypatch.setattr(
         full_app_module.db, "get_all_municipality_profile_bfs_numbers", lambda: [4021]
     )
-    client = full_app_module.app.test_client()
+    client = full_app_module.web.test_client()
     xml = client.get("/sitemap.xml", follow_redirects=True).data.decode(
         "utf-8", errors="ignore"
     )


### PR DESCRIPTION
Closes #274.

- migrate supported callers to `create_app()`
- delete the lazy `app` compatibility export
- remove silent app-import skips and weak LEA status assertions

TDD: factory contract failed before proxy deletion.
Gate: 990 tests passed; Ruff lint/format passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified application startup by removing the legacy module-level application proxy.
  * Application instances are now created explicitly through the supported application factory.

* **Tests**
  * Updated route, dashboard, administration, registration, and integration tests to use isolated application instances.
  * Improved test reliability by removing legacy import fallbacks and conditional skips.
  * Tests now validate expected responses more consistently.

* **Documentation**
  * Updated deployment guidance with the correct Gunicorn application target.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->