### PR TITLE
[codex] feat(billing): wire fail-closed period runner

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ from flask import (
 )
 from jinja2 import TemplateNotFound
 
+import billing_runner
 import dashboard as dashboard_module
 import data_enricher
 import database as db
@@ -1041,12 +1042,31 @@ def api_cron_process_billing():
     _require_cron_secret()
 
     communities = db.get_active_communities()
+    period_start, period_end = billing_runner.previous_complete_month()
+    processed = 0
+    already_processed = 0
+    failures = []
+    for community in communities:
+        community_id = community["community_id"]
+        try:
+            result = billing_runner.run_billing_period(
+                community_id, period_start, period_end
+            )
+        except billing_runner.BillingRunError as exc:
+            failures.append({"community_id": community_id, "error": str(exc)})
+            continue
+        if result["status"] == "created":
+            processed += 1
+        elif result["status"] == "already_processed":
+            already_processed += 1
     return jsonify(
         {
-            "activated": False,
-            "status": "not_activated",
-            "reason": "Billing period generation is not wired to this cron yet; see follow-up issue #261.",
-            "processed": 0,
+            "activated": True,
+            "status": "ok" if not failures else "partial_failure",
+            "processed": processed,
+            "already_processed": already_processed,
+            "failed": len(failures),
+            "failures": failures,
             "communities": len(communities),
         }
     )

--- a/billing_readings.py
+++ b/billing_readings.py
@@ -160,6 +160,17 @@ def _check_rows(readings, mapping, expected_index, problems):
                         point_id,
                     )
                 )
+        if (
+            direction in {"consumption", "production"}
+            and row.get("community_kwh") is None
+        ):
+            problems.append(
+                _problem(
+                    "missing_vnb_allocation",
+                    f"{point_id} ({direction}) at {measured_at} has no community_kwh",
+                    point_id,
+                )
+            )
 
         if measured_at not in grid:
             # Assigning this by label would extend the frame with an interval
@@ -321,14 +332,34 @@ def reconcile_with_vnb(frames, summary):
     difference is what a member will ask about, so it gets reported.
     """
     vnb_allocated = float(frames.vnb_reference["community_consumption_kwh"])
-    engine_allocated = float(summary.get("total_allocated_kwh") or 0.0)
+    charges = [
+        item
+        for item in summary.get("line_items", [])
+        if item.get("item_type") == "consumer_charge"
+    ]
+    engine_allocated = (
+        sum(float(item.get("quantity_kwh") or 0.0) for item in charges)
+        if charges
+        else float(summary.get("total_allocated_kwh") or 0.0)
+    )
+    charged_by_participant = {
+        item["participant_id"]: float(item.get("quantity_kwh") or 0.0)
+        for item in charges
+    }
+    production_credits = {
+        item["participant_id"]: float(item.get("quantity_kwh") or 0.0)
+        for item in summary.get("line_items", [])
+        if item.get("item_type") == "producer_credit"
+    }
 
     per_participant = {}
     for item in summary.get("participants", []):
         participant = item["id"]
         reference = frames.vnb_reference["per_participant"].get(participant, {})
         vnb_kwh = float(reference.get("consumption_kwh") or 0.0)
-        engine_kwh = float(item.get("allocated_kwh") or 0.0)
+        engine_kwh = charged_by_participant.get(
+            participant, float(item.get("allocated_kwh") or 0.0)
+        )
         per_participant[participant] = {
             "vnb_kwh": round(vnb_kwh, 6),
             "engine_kwh": round(engine_kwh, 6),
@@ -336,6 +367,17 @@ def reconcile_with_vnb(frames, summary):
         }
 
     difference = engine_allocated - vnb_allocated
+    vnb_production = float(frames.vnb_reference["community_production_kwh"])
+    engine_production = sum(production_credits.values())
+    production_per_participant = {}
+    for participant, reference in frames.vnb_reference["per_participant"].items():
+        vnb_kwh = float(reference.get("production_kwh") or 0.0)
+        engine_kwh = production_credits.get(participant, 0.0)
+        production_per_participant[participant] = {
+            "vnb_kwh": round(vnb_kwh, 6),
+            "engine_kwh": round(engine_kwh, 6),
+            "difference_kwh": round(engine_kwh - vnb_kwh, 6),
+        }
     return {
         "vnb_allocated_kwh": round(vnb_allocated, 6),
         "engine_allocated_kwh": round(engine_allocated, 6),
@@ -344,4 +386,8 @@ def reconcile_with_vnb(frames, summary):
         if vnb_allocated
         else None,
         "per_participant": per_participant,
+        "vnb_production_kwh": round(vnb_production, 6),
+        "engine_production_kwh": round(engine_production, 6),
+        "production_difference_kwh": round(engine_production - vnb_production, 6),
+        "production_per_participant": production_per_participant,
     }

--- a/billing_runner.py
+++ b/billing_runner.py
@@ -1,0 +1,102 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Fail-closed orchestration for one LEG billing period."""
+
+import hashlib
+import json
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import billing_engine
+import billing_readings
+import database as db
+
+
+class BillingRunError(ValueError):
+    """Billing inputs are complete but not safe to persist."""
+
+
+def previous_complete_month(now=None):
+    """Return the previous local calendar month as a half-open interval."""
+    timezone = ZoneInfo(billing_readings.DEFAULT_TIMEZONE)
+    now = now.astimezone(timezone) if now else datetime.now(timezone)
+    period_end = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    period_start = (period_end - timedelta(days=1)).replace(day=1)
+    return period_start, period_end
+
+
+def _fingerprint(frames, policy, summary, reconciliation):
+    payload = {
+        "community_id": policy["community_id"],
+        "period_start": frames.provenance["period_start"].isoformat(),
+        "period_end": frames.provenance["period_end"].isoformat(),
+        "source_document_ids": list(frames.provenance["source_document_ids"]),
+        "tariff_id": policy["tariff_id"],
+        "internal_price_chf_per_kwh": str(policy["internal_price_chf_per_kwh"]),
+        "grid_fee_chf_per_kwh": str(policy["grid_fee_chf_per_kwh"]),
+        "network_level": policy["network_level"],
+        "distribution_model": policy["distribution_model"],
+        "vnb_reference": frames.vnb_reference,
+        "summary": summary,
+        "reconciliation": reconciliation,
+    }
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def run_billing_period(community_id, period_start, period_end):
+    """Validate, reconcile and persist one immutable draft billing period."""
+    try:
+        policy = db.get_billing_policy(community_id, period_start, period_end)
+        if not policy:
+            raise BillingRunError("No effective billing tariff configured")
+        policy = {**policy, "community_id": community_id}
+
+        frames = billing_readings.load_period_frames(
+            community_id, period_start, period_end
+        )
+        if not frames.provenance["source_document_ids"]:
+            raise BillingRunError("Billing readings have no import provenance")
+        summary = billing_engine.generate_billing_summary(
+            frames.production,
+            frames.consumption,
+            grid_fee_per_kwh=policy["grid_fee_chf_per_kwh"],
+            internal_price_per_kwh=policy["internal_price_chf_per_kwh"],
+            network_level=policy["network_level"],
+            distribution_model=policy["distribution_model"],
+        )
+        reconciliation = billing_readings.reconcile_with_vnb(frames, summary)
+        participant_gaps = reconciliation["per_participant"].values()
+        production_gaps = reconciliation["production_per_participant"].values()
+        if (
+            reconciliation["difference_kwh"] != 0
+            or reconciliation["production_difference_kwh"] != 0
+            or any(item["difference_kwh"] != 0 for item in participant_gaps)
+            or any(item["difference_kwh"] != 0 for item in production_gaps)
+        ):
+            raise BillingRunError(
+                "OpenLEG allocation does not match the VNB allocation"
+            )
+
+        fingerprint = _fingerprint(frames, policy, summary, reconciliation)
+        existing = db.get_billing_period_for_window(
+            community_id, period_start, period_end
+        )
+        if existing:
+            if existing["input_fingerprint"] != fingerprint:
+                raise BillingRunError("Billing period inputs changed after processing")
+            return {"status": "already_processed", "period_id": existing["id"]}
+
+        summary.update(
+            input_fingerprint=fingerprint,
+            source_document_ids=list(frames.provenance["source_document_ids"]),
+            reconciliation=reconciliation,
+            timezone=frames.provenance["timezone"],
+        )
+        period_id = db.save_billing_period(
+            community_id, period_start, period_end, summary
+        )
+        return {"status": "created", "period_id": period_id}
+    except BillingRunError:
+        raise
+    except (KeyError, ValueError) as exc:
+        raise BillingRunError(str(exc)) from exc

--- a/database.py
+++ b/database.py
@@ -1146,6 +1146,8 @@ def is_db_available() -> bool:
 from store.billing import (  # noqa: F401
     get_active_communities,
     get_billing_period,
+    get_billing_period_for_window,
+    get_billing_policy,
     get_community_for_building,
     save_billing_period,
 )

--- a/docs/data-pipeline.md
+++ b/docs/data-pipeline.md
@@ -82,9 +82,9 @@ constrained to `consumption` or `production` and is part of the readings key,
 because one physical point can be both at the same instant.
 
 Each reading carries three channels: `total_kwh`, plus the VNB's own split into
-`grid_kwh` and `community_kwh`. The billing engine does not use that split; it
-reallocates from totals. `billing_readings.reconcile_with_vnb` reports the
-difference between the two allocations, which is small but not zero.
+`grid_kwh` and `community_kwh`. The VNB split is authoritative. The billing
+engine reallocates totals only as an audit calculation. A missing VNB split or
+any aggregate or participant-level difference blocks the draft period.
 
 ### Timezone semantics
 
@@ -108,6 +108,23 @@ it found, rather than the first, so one pass fixes a period:
 
 A member with no production meter is not a gap. That participant simply has a
 zero production column, which the engine needs in order to emit credits.
+
+### Draft billing policy
+
+`billing_runner.run_billing_period` is the production seam. The cron asks it to
+process the previous complete `Europe/Zurich` calendar month. It creates only a
+draft and applies these fail-closed rules:
+
+- one explicit `billing_tariffs` row must cover the complete period
+- internal and grid prices, network level, and distribution model are copied
+  onto the draft; public H4 data and zero defaults are never substitutes
+- incomplete readings or a difference from the VNB allocation persist nothing
+- `(community_id, period_start, period_end)` is unique
+- identical input fingerprints are retry no-ops; changed inputs require review
+- the cron counts work only after `save_billing_period` returns a committed ID
+
+Invoice issuance remains disabled until the LEG and its VNB approve tax, HKN,
+tariff-class, rounding-tolerance, and operational cutoff rules.
 
 ## Public API Reads
 

--- a/store/billing.py
+++ b/store/billing.py
@@ -8,6 +8,7 @@ billing line items, and communities. The connection seam is resolved via
 unchanged and ``database`` can re-export these functions for legacy callers.
 """
 
+import json
 import logging
 
 logger = logging.getLogger(__name__)
@@ -35,8 +36,10 @@ def save_billing_period(
                     (community_id, period_start, period_end, total_production_kwh, total_allocated_kwh,
                      total_surplus_kwh, total_network_discount_chf, distribution_model,
                      network_level, internal_price_chf_per_kwh, grid_fee_chf_per_kwh,
-                     timezone, status)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, 'draft')
+                     timezone, input_fingerprint, source_document_ids,
+                     reconciliation, status)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s,
+                            %s, %s::jsonb, %s::jsonb, 'draft')
                     RETURNING id
                 """,
                     (
@@ -52,9 +55,12 @@ def save_billing_period(
                         summary.get("internal_price_chf_per_kwh"),
                         summary.get("grid_fee_chf_per_kwh"),
                         summary.get("timezone", "Europe/Zurich"),
+                        summary.get("input_fingerprint"),
+                        json.dumps(summary.get("source_document_ids", [])),
+                        json.dumps(summary.get("reconciliation", {})),
                     ),
                 )
-                period_id = cur.fetchone()[0]
+                period_id = cur.fetchone()["id"]
 
                 line_items = summary.get("line_items", [])
                 participants = {
@@ -114,7 +120,7 @@ def save_billing_period(
                 return period_id
     except Exception as e:
         logger.error(f"[DB] Error saving billing period: {e}")
-        return 0
+        raise
 
 
 def get_active_communities() -> list[dict]:
@@ -166,3 +172,44 @@ def get_billing_period(period_id: int) -> dict | None:
     except Exception as e:
         logger.error(f"[DB] Error getting billing period: {e}")
         return None
+
+
+def get_billing_period_for_window(
+    community_id: str, period_start, period_end
+) -> dict | None:
+    """Return the immutable period occupying a community window, if any."""
+    with _get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, input_fingerprint FROM billing_periods
+            WHERE community_id = %s AND period_start = %s AND period_end = %s
+            """,
+            (community_id, period_start, period_end),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None
+
+
+def get_billing_policy(community_id: str, period_start, period_end) -> dict | None:
+    """Return one tariff covering the complete billing period."""
+    with _get_connection() as conn, conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT t.id AS tariff_id, t.internal_price_chf_per_kwh,
+                   t.grid_fee_chf_per_kwh, t.network_level,
+                   CASE c.distribution_model
+                       WHEN 'simple' THEN 'einfach'
+                       ELSE c.distribution_model
+                   END AS distribution_model
+            FROM billing_tariffs t
+            JOIN communities c ON c.community_id = t.community_id
+            WHERE t.community_id = %s AND c.status = 'active'
+              AND t.effective_from <= %s
+              AND (t.effective_to IS NULL OR t.effective_to >= %s)
+            ORDER BY t.effective_from DESC
+            LIMIT 1
+            """,
+            (community_id, period_start, period_end),
+        )
+        row = cur.fetchone()
+        return dict(row) if row else None

--- a/store/schema.py
+++ b/store/schema.py
@@ -447,11 +447,25 @@ def create_tables():
             """)
 
             cur.execute("""
+                CREATE TABLE IF NOT EXISTS billing_tariffs (
+                    id SERIAL PRIMARY KEY,
+                    community_id VARCHAR(64) NOT NULL REFERENCES communities(community_id),
+                    effective_from TIMESTAMPTZ NOT NULL,
+                    effective_to TIMESTAMPTZ,
+                    internal_price_chf_per_kwh DECIMAL(12, 6) NOT NULL CHECK (internal_price_chf_per_kwh >= 0),
+                    grid_fee_chf_per_kwh DECIMAL(12, 6) NOT NULL CHECK (grid_fee_chf_per_kwh >= 0),
+                    network_level VARCHAR(16) NOT NULL CHECK (network_level IN ('same', 'cross')),
+                    created_at TIMESTAMPTZ DEFAULT NOW(),
+                    UNIQUE(community_id, effective_from)
+                )
+            """)
+
+            cur.execute("""
                 CREATE TABLE IF NOT EXISTS billing_periods (
                     id SERIAL PRIMARY KEY,
                     community_id VARCHAR(64) NOT NULL,
-                    period_start TIMESTAMP NOT NULL,
-                    period_end TIMESTAMP NOT NULL,
+                    period_start TIMESTAMPTZ NOT NULL,
+                    period_end TIMESTAMPTZ NOT NULL,
                     total_production_kwh DECIMAL(12, 4) DEFAULT 0,
                     total_allocated_kwh DECIMAL(12, 4) DEFAULT 0,
                     total_surplus_kwh DECIMAL(12, 4) DEFAULT 0,
@@ -461,8 +475,12 @@ def create_tables():
                     internal_price_chf_per_kwh DECIMAL(12, 6),
                     grid_fee_chf_per_kwh DECIMAL(12, 6),
                     timezone VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich',
+                    input_fingerprint VARCHAR(64),
+                    source_document_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    reconciliation JSONB NOT NULL DEFAULT '{}'::jsonb,
                     status VARCHAR(32) DEFAULT 'draft',
-                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+                    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                    UNIQUE(community_id, period_start, period_end)
                 )
             """)
 
@@ -488,7 +506,33 @@ def create_tables():
                 ALTER TABLE billing_periods
                     ADD COLUMN IF NOT EXISTS internal_price_chf_per_kwh DECIMAL(12, 6),
                     ADD COLUMN IF NOT EXISTS grid_fee_chf_per_kwh DECIMAL(12, 6),
-                    ADD COLUMN IF NOT EXISTS timezone VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich'
+                    ADD COLUMN IF NOT EXISTS timezone VARCHAR(64) NOT NULL DEFAULT 'Europe/Zurich',
+                    ADD COLUMN IF NOT EXISTS input_fingerprint VARCHAR(64),
+                    ADD COLUMN IF NOT EXISTS source_document_ids JSONB NOT NULL DEFAULT '[]'::jsonb,
+                    ADD COLUMN IF NOT EXISTS reconciliation JSONB NOT NULL DEFAULT '{}'::jsonb
+            """)
+
+            cur.execute("""
+                DO $$
+                BEGIN
+                    IF EXISTS (
+                        SELECT 1 FROM information_schema.columns
+                        WHERE table_name = 'billing_periods'
+                          AND column_name = 'period_start'
+                          AND data_type = 'timestamp without time zone'
+                    ) THEN
+                        ALTER TABLE billing_periods
+                            ALTER COLUMN period_start TYPE TIMESTAMPTZ
+                                USING period_start AT TIME ZONE 'Europe/Zurich',
+                            ALTER COLUMN period_end TYPE TIMESTAMPTZ
+                                USING period_end AT TIME ZONE 'Europe/Zurich';
+                    END IF;
+                END $$
+            """)
+
+            cur.execute("""
+                CREATE UNIQUE INDEX IF NOT EXISTS uq_billing_period_community_window
+                ON billing_periods (community_id, period_start, period_end)
             """)
 
             cur.execute("""

--- a/tests/test_billing_cron_contract.py
+++ b/tests/test_billing_cron_contract.py
@@ -1,17 +1,12 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
-"""Contract: the billing cron reports only work it actually performs.
+"""Contract: billing cron counts only newly persisted draft periods."""
 
-Billing period generation is implemented in ``billing_engine`` but not yet
-wired to a scheduled run (see the deliberately out of scope list in #262).
-Until it is, ``/api/cron/process-billing`` must say so instead of counting
-active communities as if they had been billed.
-"""
-
-from unittest.mock import patch
+from unittest.mock import call, patch
 
 import pytest
 
 import app as app_module
+import billing_runner
 import database
 
 CRON_SECRET = "test-cron-secret"
@@ -39,29 +34,65 @@ def _post_process_billing(application):
 
 
 class TestBillingCronHonesty:
-    def test_reports_zero_processed_while_billing_runs_are_not_wired(
-        self, app_with_cron_secret
-    ):
+    def test_counts_only_newly_persisted_periods(self, app_with_cron_secret):
         communities = [
             {"community_id": "c1"},
             {"community_id": "c2"},
-            {"community_id": "c3"},
         ]
-        with patch.object(database, "get_active_communities", return_value=communities):
+        with (
+            patch.object(database, "get_active_communities", return_value=communities),
+            patch.object(
+                billing_runner,
+                "previous_complete_month",
+                return_value=("start", "end"),
+            ),
+            patch.object(
+                billing_runner,
+                "run_billing_period",
+                side_effect=(
+                    {"status": "created", "period_id": 1},
+                    {"status": "already_processed", "period_id": 2},
+                ),
+            ) as run,
+        ):
             response = _post_process_billing(app_with_cron_secret)
 
         assert response.status_code == 200
         payload = response.get_json()
-        assert payload["communities"] == 3
-        assert payload["processed"] == 0, (
-            "the cron must not count communities as processed billing runs"
-        )
+        assert payload == {
+            "activated": True,
+            "status": "ok",
+            "communities": 2,
+            "processed": 1,
+            "already_processed": 1,
+            "failed": 0,
+            "failures": [],
+        }
+        assert run.call_args_list == [
+            call("c1", "start", "end"),
+            call("c2", "start", "end"),
+        ]
 
-    def test_states_that_billing_runs_are_not_activated(self, app_with_cron_secret):
-        with patch.object(database, "get_active_communities", return_value=[]):
+    def test_persistence_failure_is_not_counted(self, app_with_cron_secret):
+        with (
+            patch.object(
+                database,
+                "get_active_communities",
+                return_value=[{"community_id": "c1"}],
+            ),
+            patch.object(
+                billing_runner,
+                "previous_complete_month",
+                return_value=("start", "end"),
+            ),
+            patch.object(
+                billing_runner,
+                "run_billing_period",
+                side_effect=billing_runner.BillingRunError("not persisted"),
+            ),
+        ):
             response = _post_process_billing(app_with_cron_secret)
 
         payload = response.get_json()
-        assert payload["activated"] is False
-        assert payload["status"] == "not_activated"
-        assert payload["reason"], "the response explains why nothing ran"
+        assert payload["processed"] == 0
+        assert payload["failed"] == 1

--- a/tests/test_billing_period_core.py
+++ b/tests/test_billing_period_core.py
@@ -48,7 +48,7 @@ class _Cursor:
         self.executed.append((query, params))
 
     def fetchone(self):
-        return (42,)
+        return {"id": 42}
 
     def __enter__(self):
         return self
@@ -362,6 +362,25 @@ def test_schema_keeps_prices_and_signed_line_items_with_the_period():
         assert column in period_block
     for column in ("item_type", "quantity_kwh", "unit_price_chf_per_kwh", "amount_chf"):
         assert column in line_item_block
+
+
+def test_schema_enforces_effective_tariffs_and_one_period_per_window():
+    schema = (PROJECT_ROOT / "store" / "schema.py").read_text(encoding="utf-8")
+    tariff_block = _create_table_block(schema, "billing_tariffs")
+    period_block = _create_table_block(schema, "billing_periods")
+
+    for column in (
+        "effective_from TIMESTAMPTZ",
+        "internal_price_chf_per_kwh",
+        "grid_fee_chf_per_kwh",
+        "network_level",
+    ):
+        assert column in tariff_block
+    for column in ("input_fingerprint", "source_document_ids", "reconciliation"):
+        assert column in period_block
+    for column in ("period_start TIMESTAMPTZ", "period_end TIMESTAMPTZ"):
+        assert column in period_block
+    assert "UNIQUE(community_id, period_start, period_end)" in period_block
 
 
 def test_existing_billing_tables_receive_all_new_columns_additively():

--- a/tests/test_billing_readings.py
+++ b/tests/test_billing_readings.py
@@ -12,6 +12,7 @@ Fixtures are synthetic SDAT-E66 documents. No citizen data enters this suite.
 from copy import deepcopy
 from datetime import datetime, timedelta
 from pathlib import Path
+from types import SimpleNamespace
 from zoneinfo import ZoneInfo
 
 import pandas as pd
@@ -260,6 +261,19 @@ def test_mixed_resolution_is_rejected(monkeypatch, rows):
     assert "mixed_resolution" in _kinds(excinfo)
 
 
+def test_missing_vnb_allocation_is_rejected(monkeypatch, rows):
+    dirty = deepcopy(rows)
+    next(row for row in dirty if row["direction"] == "consumption")["community_kwh"] = (
+        None
+    )
+    _install(monkeypatch, _points(), dirty)
+
+    with pytest.raises(billing_readings.PeriodDataError) as excinfo:
+        billing_readings.load_period_frames(COMMUNITY, PERIOD_START, PERIOD_END)
+
+    assert "missing_vnb_allocation" in _kinds(excinfo)
+
+
 def test_mixed_units_never_reach_the_adapter():
     """The unit gate lives at the parse boundary; readings carry no unit column.
 
@@ -365,6 +379,34 @@ def test_reconciliation_reports_the_gap_to_the_vnb_allocation(monkeypatch, rows)
     assert report["engine_allocated_kwh"] == pytest.approx(1.75)
     assert report["difference_kwh"] == pytest.approx(1.029)
     assert report["per_participant"][BUILDING_A]["vnb_kwh"] == pytest.approx(0.22)
+
+
+def test_reconciliation_uses_six_decimal_charge_quantities():
+    frames = SimpleNamespace(
+        vnb_reference={
+            "community_consumption_kwh": 0.123456,
+            "community_production_kwh": 0.0,
+            "per_participant": {
+                BUILDING_A: {"consumption_kwh": 0.123456, "production_kwh": 0.0},
+            },
+        }
+    )
+    summary = {
+        "total_allocated_kwh": 0.12,
+        "participants": [{"id": BUILDING_A, "allocated_kwh": 0.12}],
+        "line_items": [
+            {
+                "participant_id": BUILDING_A,
+                "item_type": "consumer_charge",
+                "quantity_kwh": 0.123456,
+            }
+        ],
+    }
+
+    report = billing_readings.reconcile_with_vnb(frames, summary)
+
+    assert report["difference_kwh"] == 0
+    assert report["per_participant"][BUILDING_A]["difference_kwh"] == 0
 
 
 def test_nothing_is_persisted_by_the_adapter(monkeypatch, rows):

--- a/tests/test_billing_runner.py
+++ b/tests/test_billing_runner.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""End-to-end contract for one fail-closed billing-period run."""
+
+from datetime import datetime, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+import database
+
+COMMUNITY = "community-a"
+START = datetime(2026, 1, 1, tzinfo=ZoneInfo("Europe/Zurich"))
+END = START + timedelta(minutes=45)
+
+
+def test_run_billing_period_persists_once_and_retries_as_a_noop(monkeypatch):
+    from billing_runner import BillingRunError, run_billing_period
+
+    points = [
+        {
+            "metering_point_id": "CH001",
+            "building_id": "building-a",
+            "member_status": "confirmed",
+        },
+        {
+            "metering_point_id": "CH002",
+            "building_id": "building-a",
+            "member_status": "confirmed",
+        },
+    ]
+    readings = []
+    for offset in range(3):
+        measured_at = START + timedelta(minutes=15 * offset)
+        readings.extend(
+            (
+                {
+                    "metering_point_id": "CH001",
+                    "direction": "consumption",
+                    "measured_at": measured_at,
+                    "resolution_minutes": 15,
+                    "total_kwh": 1.0,
+                    "grid_kwh": 0.5,
+                    "community_kwh": 0.5,
+                    "source_document_id": "E66-CONSUMPTION",
+                },
+                {
+                    "metering_point_id": "CH002",
+                    "direction": "production",
+                    "measured_at": measured_at,
+                    "resolution_minutes": 15,
+                    "total_kwh": 0.5,
+                    "grid_kwh": 0.0,
+                    "community_kwh": 0.5,
+                    "source_document_id": "E66-PRODUCTION",
+                },
+            )
+        )
+
+    policy = {
+        "tariff_id": 7,
+        "internal_price_chf_per_kwh": 0.12,
+        "grid_fee_chf_per_kwh": 0.08,
+        "network_level": "same",
+        "distribution_model": "proportional",
+    }
+    saved = []
+    existing = []
+
+    monkeypatch.setattr(
+        database, "get_community_metering_points", lambda _community: points
+    )
+    monkeypatch.setattr(
+        database,
+        "get_period_readings",
+        lambda _community, _start, _end: readings,
+    )
+    monkeypatch.setattr(
+        database,
+        "get_billing_policy",
+        lambda _community, _start, _end: policy,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        database,
+        "get_billing_period_for_window",
+        lambda _community, _start, _end: existing[0] if existing else None,
+        raising=False,
+    )
+
+    def save(community_id, period_start, period_end, summary):
+        saved.append((community_id, period_start, period_end, summary))
+        return 42
+
+    monkeypatch.setattr(database, "save_billing_period", save)
+
+    created = run_billing_period(COMMUNITY, START, END)
+
+    assert created == {"status": "created", "period_id": 42}
+    assert len(saved) == 1
+    summary = saved[0][3]
+    assert summary["input_fingerprint"]
+    assert summary["source_document_ids"] == [
+        "E66-CONSUMPTION",
+        "E66-PRODUCTION",
+    ]
+    assert summary["reconciliation"]["difference_kwh"] == 0
+    assert summary["reconciliation"]["production_difference_kwh"] == 0
+
+    existing.append({"id": 42, "input_fingerprint": summary["input_fingerprint"]})
+    retried = run_billing_period(COMMUNITY, START, END)
+
+    assert retried == {"status": "already_processed", "period_id": 42}
+    assert len(saved) == 1
+
+    readings[0]["total_kwh"] = 2.0
+    with pytest.raises(BillingRunError, match="inputs changed"):
+        run_billing_period(COMMUNITY, START, END)
+
+    existing.clear()
+    for reading in readings:
+        reading["source_document_id"] = None
+    with pytest.raises(BillingRunError, match="provenance"):
+        run_billing_period(COMMUNITY, START, END)
+
+
+def test_previous_complete_month_uses_zurich_calendar_boundaries():
+    from billing_runner import previous_complete_month
+
+    start, end = previous_complete_month(
+        datetime(2026, 11, 15, tzinfo=ZoneInfo("Europe/Zurich"))
+    )
+
+    assert start == datetime(2026, 10, 1, tzinfo=ZoneInfo("Europe/Zurich"))
+    assert end == datetime(2026, 11, 1, tzinfo=ZoneInfo("Europe/Zurich"))
+    assert start.utcoffset() != end.utcoffset()

--- a/tests/test_store_billing.py
+++ b/tests/test_store_billing.py
@@ -19,6 +19,8 @@ _REEXPORTED = (
     "get_active_communities",
     "get_community_for_building",
     "get_billing_period",
+    "get_billing_period_for_window",
+    "get_billing_policy",
 )
 
 
@@ -93,3 +95,31 @@ def test_get_billing_period_missing_returns_none(monkeypatch):
     monkeypatch.setattr(database, "get_connection", _conn_ctx(cur))
 
     assert billing.get_billing_period(999) is None
+
+
+def test_get_effective_policy_and_existing_period_use_the_connection_seam(monkeypatch):
+    policy = {
+        "tariff_id": 7,
+        "internal_price_chf_per_kwh": 0.12,
+        "grid_fee_chf_per_kwh": 0.08,
+        "network_level": "same",
+        "distribution_model": "proportional",
+    }
+    policy_cur = _FakeCursor(one=policy)
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(policy_cur))
+
+    assert (
+        billing.get_billing_policy("community-a", "2026-01-01", "2026-02-01") == policy
+    )
+    period_cur = _FakeCursor(one={"id": 42, "input_fingerprint": "abc"})
+    monkeypatch.setattr(database, "get_connection", _conn_ctx(period_cur))
+    assert billing.get_billing_period_for_window(
+        "community-a", "2026-01-01", "2026-02-01"
+    ) == {"id": 42, "input_fingerprint": "abc"}
+    assert "billing_tariffs" in policy_cur.executed[0][0]
+    assert policy_cur.executed[0][1] == (
+        "community-a",
+        "2026-01-01",
+        "2026-02-01",
+    )
+    assert "period_start" in period_cur.executed[0][0]


### PR DESCRIPTION
Closes #275

## What changed
- run the previous complete Europe/Zurich month through one fail-closed billing seam
- require explicit effective tariffs, complete VNB allocation, exact reconciliation, and import provenance
- make retries idempotent with a unique period window and immutable input fingerprint
- persist drafts only; invoice issuance remains blocked by #277

## Verification
- `scripts/tdd_cycle.sh gate`
- 997 tests passed; lint and format passed