### PR TITLE
[codex] Reduce CRAP hotspots and harden inputs

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,7 +29,6 @@ import dashboard as dashboard_module
 import data_enricher
 import database as db
 import email_automation
-import geometry
 import leg_registry
 import ml_models
 import registration
@@ -256,44 +255,6 @@ def find_provisional_matches(new_profile):
     }
 
 
-def create_simple_polygon(coords):
-    if len(coords) < 3:
-        if len(coords) == 1:
-            lat, lon = coords[0]
-            o = 0.0005
-            return [
-                [lat - o, lon - o],
-                [lat + o, lon - o],
-                [lat + o, lon + o],
-                [lat - o, lon + o],
-                [lat - o, lon - o],
-            ]
-        elif len(coords) == 2:
-            lat1, lon1 = coords[0]
-            lat2, lon2 = coords[1]
-            o = 0.0003
-            return [
-                [lat1 - o, lon1 - o],
-                [lat2 + o, lon1 - o],
-                [lat2 + o, lon2 + o],
-                [lat1 - o, lon2 + o],
-                [lat1 - o, lon1 - o],
-            ]
-    hull = geometry.convex_hull(coords)
-    if hull is not None:
-        return hull + [hull[0]]
-    lats = [c[0] for c in coords]
-    lons = [c[1] for c in coords]
-    o = 0.0003
-    return [
-        [min(lats) - o, min(lons) - o],
-        [max(lats) + o, min(lons) - o],
-        [max(lats) + o, max(lons) + o],
-        [min(lats) - o, max(lons) + o],
-        [min(lats) - o, min(lons) - o],
-    ]
-
-
 # ===========================
 # Routes
 # ===========================
@@ -487,36 +448,6 @@ def api_get_all_buildings():
     city_id = g.tenant.get("territory") if hasattr(g, "tenant") else None
     locations = collect_building_locations(city_id=city_id)
     return jsonify({"buildings": locations})
-
-
-@main_bp.route("/api/get_all_clusters")
-def api_get_all_clusters():
-    clusters_raw = db.get_all_clusters()
-    clusters = []
-    for ci in clusters_raw:
-        members = ci.get("members", [])
-        if not members or len(members) < 2:
-            continue
-        coords = []
-        member_list = []
-        for mid in members:
-            b = db.get_building(mid)
-            if b and b.get("lat") and b.get("lon"):
-                coords.append([float(b["lat"]), float(b["lon"])])
-                member_list.append(
-                    {"building_id": mid, "lat": float(b["lat"]), "lon": float(b["lon"])}
-                )
-        if len(coords) >= 2:
-            clusters.append(
-                {
-                    "cluster_id": ci.get("cluster_id"),
-                    "members": member_list,
-                    "polygon": create_simple_polygon(coords),
-                    "autarky_percent": float(ci.get("autarky_percent", 0)),
-                    "num_members": len(member_list),
-                }
-            )
-    return jsonify({"clusters": clusters})
 
 
 # --- Check Potential ---

--- a/data_enricher.py
+++ b/data_enricher.py
@@ -65,30 +65,30 @@ def get_address_suggestions(query_string, limit=10, plz_ranges=None):
 
         suggestions = []
         for result in results:
-            attrs = result.get("attrs", {})
+            if not isinstance(result, dict):
+                continue
+            attrs = result.get("attrs")
+            if not isinstance(attrs, dict):
+                continue
             label = attrs.get("label", "")
+            if not isinstance(label, str):
+                continue
 
-            # Filter by PLZ ranges
+            # Determine PLZ: prefer numeric attrs.plz, fall back to label
             plz = attrs.get("plz")
+            plz_int = None
             if plz:
                 try:
                     plz_int = int(plz)
-                    if not _plz_in_ranges(plz_int, plz_ranges):
-                        continue
                 except (ValueError, TypeError):
-                    plz_match = re.search(r"\b(\d{4})\b", label)
-                    if not plz_match:
-                        continue
-                    plz_int = int(plz_match.group(1))
-                    if not _plz_in_ranges(plz_int, plz_ranges):
-                        continue
-            else:
+                    plz_int = None
+            if plz_int is None:
                 plz_match = re.search(r"\b(\d{4})\b", label)
                 if not plz_match:
                     continue
                 plz_int = int(plz_match.group(1))
-                if not _plz_in_ranges(plz_int, plz_ranges):
-                    continue
+            if not _plz_in_ranges(plz_int, plz_ranges):
+                continue
 
             # Entferne HTML-Tags aus dem Label
             if label:
@@ -98,7 +98,7 @@ def get_address_suggestions(query_string, limit=10, plz_ranges=None):
                         "label": clean_label,
                         "lat": attrs.get("lat"),
                         "lon": attrs.get("lon"),
-                        "plz": plz if plz else plz_int,
+                        "plz": plz_int,
                     }
                 )
 

--- a/database.py
+++ b/database.py
@@ -358,24 +358,6 @@ def save_cluster_info(cluster_id: int, info: dict) -> bool:
         return False
 
 
-def get_all_clusters() -> list[dict]:
-    """Get all clusters with their info."""
-    try:
-        with get_connection() as conn:
-            with conn.cursor() as cur:
-                cur.execute("""
-                    SELECT ci.cluster_id, ci.autarky_percent, ci.num_members, ci.polygon,
-                           array_agg(c.building_id) as members
-                    FROM cluster_info ci
-                    LEFT JOIN clusters c ON ci.cluster_id = c.cluster_id
-                    GROUP BY ci.cluster_id, ci.autarky_percent, ci.num_members, ci.polygon
-                """)
-                return [dict(row) for row in cur.fetchall()]
-    except Exception as e:
-        logger.error(f"[DB] Error getting clusters: {e}")
-        return []
-
-
 # === Referral Operations ===
 
 

--- a/formation_wizard.py
+++ b/formation_wizard.py
@@ -394,11 +394,12 @@ def get_community_status(db, community_id: str) -> dict | None:
             if not row:
                 return None
 
+            # Normalize NULL aggregate to an empty list and use it consistently.
+            members = row["members"] or []
+
             # Calculate readiness score
-            confirmed_count = sum(
-                1 for m in row["members"] if m["status"] == "confirmed"
-            )
-            total_count = len(row["members"])
+            confirmed_count = sum(1 for m in members if m["status"] == "confirmed")
+            total_count = len(members)
 
             readiness_score = 0
             if confirmed_count >= FORMATION_CONFIG["min_community_size"]:
@@ -434,7 +435,7 @@ def get_community_status(db, community_id: str) -> dict | None:
                     "invited": total_count - confirmed_count,
                 },
                 "readiness_score": readiness_score,
-                "members": row["members"],
+                "members": members,
                 "documents": None,
                 "next_steps": _get_next_steps(row["status"], confirmed_count),
             }
@@ -443,37 +444,37 @@ def get_community_status(db, community_id: str) -> dict | None:
         return None
 
 
+NEXT_STEPS_BY_STATUS = {
+    FormationStatus.FORMATION_STARTED.value: [
+        "Erstellen Sie die Rechtsdokumente.",
+        "Prüfen Sie die Gemeinschaftsvereinbarung.",
+    ],
+    FormationStatus.DOCUMENTS_GENERATED.value: [
+        "Holen Sie die Unterschriften aller Mitglieder ein.",
+        "Prüfen Sie die Teilnehmerverträge.",
+    ],
+    FormationStatus.SIGNATURES_PENDING.value: [
+        "Reichen Sie die Anmeldung beim VNB ein.",
+    ],
+    FormationStatus.DSO_SUBMITTED.value: [
+        "Warten Sie auf die Genehmigung des VNB. Dies kann bis zu 30 Tage dauern.",
+    ],
+    FormationStatus.DSO_APPROVED.value: [
+        "Legen Sie das Aktivierungsdatum fest.",
+        "Konfigurieren Sie die Abrechnung.",
+    ],
+}
+
+
 def _get_next_steps(status: str, confirmed_count: int) -> list[str]:
     """Get recommended next steps based on status."""
-    steps = []
-
     if status == FormationStatus.INTERESTED.value:
-        if confirmed_count < FORMATION_CONFIG["min_community_size"]:
-            steps.append(
-                f"Invite at least {FORMATION_CONFIG['min_community_size'] - confirmed_count} more neighbors"
-            )
-        else:
-            steps.append("Start formation process")
+        missing = FORMATION_CONFIG["min_community_size"] - confirmed_count
+        if missing > 0:
+            return [f"Laden Sie mindestens {missing} weitere Nachbarn ein."]
+        return ["Starten Sie den Gründungsprozess."]
 
-    elif status == FormationStatus.FORMATION_STARTED.value:
-        steps.append("Generate legal documents")
-        steps.append("Review community agreement")
-
-    elif status == FormationStatus.DOCUMENTS_GENERATED.value:
-        steps.append("Collect signatures from all members")
-        steps.append("Review participant contracts")
-
-    elif status == FormationStatus.SIGNATURES_PENDING.value:
-        steps.append("Submit DSO notification")
-
-    elif status == FormationStatus.DSO_SUBMITTED.value:
-        steps.append("Wait for DSO approval (up to 30 days)")
-
-    elif status == FormationStatus.DSO_APPROVED.value:
-        steps.append("Set activation date")
-        steps.append("Configure billing")
-
-    return steps
+    return list(NEXT_STEPS_BY_STATUS.get(status, []))
 
 
 def get_user_communities(db, building_id: str) -> list[dict]:

--- a/public_data.py
+++ b/public_data.py
@@ -115,60 +115,89 @@ ENERGIE_REPORTER_URL = (
 )
 
 
+def _first_value(row: dict, *keys: str):
+    for key in keys:
+        value = row.get(key)
+        if value:
+            return value
+    return None
+
+
+def _fetch_ckan_rows(dataset_url: str, preferred_names: tuple[str, ...] = ()):
+    response = requests.get(dataset_url, timeout=15)
+    response.raise_for_status()
+    resources = response.json().get("result", {}).get("resources", [])
+    csv_resources = [
+        resource
+        for resource in resources
+        if resource.get("format", "").upper() == "CSV"
+    ]
+    resource = next(
+        (
+            candidate
+            for candidate in csv_resources
+            if any(
+                name in (candidate.get("name") or "").lower()
+                for name in preferred_names
+            )
+        ),
+        csv_resources[0] if csv_resources else None,
+    )
+    csv_url = resource.get("url") if resource else None
+    if not csv_url:
+        return None
+
+    csv_response = requests.get(csv_url, timeout=30)
+    csv_response.raise_for_status()
+    csv_response.encoding = csv_response.apparent_encoding or "utf-8"
+    return list(csv.DictReader(io.StringIO(csv_response.text), delimiter=";"))
+
+
 def fetch_energie_reporter() -> list[dict]:
     """Download Energie Reporter data from opendata.swiss and parse into per-municipality dicts."""
     try:
-        # Get dataset metadata to find CSV resource
-        resp = requests.get(ENERGIE_REPORTER_URL, timeout=15)
-        resp.raise_for_status()
-        pkg = resp.json().get("result", {})
-        csv_url = None
-        for resource in pkg.get("resources", []):
-            if resource.get("format", "").upper() == "CSV":
-                csv_url = resource.get("url")
-                break
-
-        if not csv_url:
+        rows = _fetch_ckan_rows(ENERGIE_REPORTER_URL)
+        if rows is None:
             logger.warning("[PUBLIC_DATA] Energie Reporter: no CSV resource found")
             return []
 
-        csv_resp = requests.get(csv_url, timeout=30)
-        csv_resp.raise_for_status()
-        csv_resp.encoding = csv_resp.apparent_encoding or "utf-8"
-
-        reader = csv.DictReader(io.StringIO(csv_resp.text), delimiter=";")
         results = []
-        for row in reader:
-            bfs = _safe_int(
-                row.get("BFS_NR") or row.get("bfs_nr") or row.get("gemeinde_bfs")
-            )
+        for row in rows:
+            bfs = _safe_int(_first_value(row, "BFS_NR", "bfs_nr", "gemeinde_bfs"))
             if not bfs:
                 continue
             results.append(
                 {
                     "bfs_number": bfs,
-                    "name": row.get("GEMEINDENAME")
-                    or row.get("gemeindename")
-                    or row.get("name", ""),
-                    "kanton": row.get("KANTON") or row.get("kanton", ""),
+                    "name": _first_value(row, "GEMEINDENAME", "gemeindename", "name")
+                    or "",
+                    "kanton": _first_value(row, "KANTON", "kanton") or "",
                     "solar_potential_pct": _safe_float(
-                        row.get("anteil_dachflaechen_solar")
-                        or row.get("solar_potential_pct")
+                        _first_value(
+                            row, "anteil_dachflaechen_solar", "solar_potential_pct"
+                        )
                     ),
                     "ev_share_pct": _safe_float(
-                        row.get("anteil_ev") or row.get("ev_share_pct")
+                        _first_value(row, "anteil_ev", "ev_share_pct")
                     ),
                     "renewable_heating_pct": _safe_float(
-                        row.get("anteil_erneuerbar_heizen")
-                        or row.get("renewable_heating_pct")
+                        _first_value(
+                            row, "anteil_erneuerbar_heizen", "renewable_heating_pct"
+                        )
                     ),
                     "electricity_consumption_mwh": _safe_float(
-                        row.get("stromverbrauch_mwh")
-                        or row.get("electricity_consumption_mwh")
+                        _first_value(
+                            row,
+                            "stromverbrauch_mwh",
+                            "electricity_consumption_mwh",
+                        )
                     ),
                     "renewable_production_mwh": _safe_float(
-                        row.get("erneuerbare_produktion_mwh")
-                        or row.get("renewable_production_mwh")
+                        _first_value(
+                            row,
+                            "erneuerbare_produktion_mwh",
+                            "renewable_production_mwh",
+                        )
                     ),
                 }
             )
@@ -189,59 +218,39 @@ SONNENDACH_URL = "https://opendata.swiss/api/3/action/package_show?id=sonnendach
 def fetch_sonnendach_municipal() -> list[dict]:
     """Download municipal-level solar potential from opendata.swiss."""
     try:
-        resp = requests.get(SONNENDACH_URL, timeout=15)
-        resp.raise_for_status()
-        pkg = resp.json().get("result", {})
-        csv_url = None
-        for resource in pkg.get("resources", []):
-            fmt = resource.get("format", "").upper()
-            name = (resource.get("name") or "").lower()
-            if fmt == "CSV" and (
-                "gemeinde" in name or "municipal" in name or "kommun" in name
-            ):
-                csv_url = resource.get("url")
-                break
-        # Fallback: any CSV
-        if not csv_url:
-            for resource in pkg.get("resources", []):
-                if resource.get("format", "").upper() == "CSV":
-                    csv_url = resource.get("url")
-                    break
-
-        if not csv_url:
+        rows = _fetch_ckan_rows(
+            SONNENDACH_URL, preferred_names=("gemeinde", "municipal", "kommun")
+        )
+        if rows is None:
             logger.warning("[PUBLIC_DATA] Sonnendach: no CSV resource found")
             return []
 
-        csv_resp = requests.get(csv_url, timeout=30)
-        csv_resp.raise_for_status()
-        csv_resp.encoding = csv_resp.apparent_encoding or "utf-8"
-
-        reader = csv.DictReader(io.StringIO(csv_resp.text), delimiter=";")
         results = []
-        for row in reader:
-            bfs = _safe_int(
-                row.get("BFS_NR") or row.get("bfs_nr") or row.get("gemeinde_bfs")
-            )
+        for row in rows:
+            bfs = _safe_int(_first_value(row, "BFS_NR", "bfs_nr", "gemeinde_bfs"))
             if not bfs:
                 continue
             results.append(
                 {
                     "bfs_number": bfs,
                     "total_roof_area_m2": _safe_float(
-                        row.get("dachflaeche_total_m2") or row.get("total_roof_area_m2")
+                        _first_value(row, "dachflaeche_total_m2", "total_roof_area_m2")
                     ),
                     "suitable_roof_area_m2": _safe_float(
-                        row.get("dachflaeche_geeignet_m2")
-                        or row.get("suitable_roof_area_m2")
+                        _first_value(
+                            row,
+                            "dachflaeche_geeignet_m2",
+                            "suitable_roof_area_m2",
+                        )
                     ),
                     "potential_kwh_year": _safe_float(
-                        row.get("potenzial_kwh_jahr") or row.get("potential_kwh_year")
+                        _first_value(row, "potenzial_kwh_jahr", "potential_kwh_year")
                     ),
                     "potential_kwp": _safe_float(
-                        row.get("potenzial_kwp") or row.get("potential_kwp")
+                        _first_value(row, "potenzial_kwp", "potential_kwp")
                     ),
                     "utilization_pct": _safe_float(
-                        row.get("auslastung_pct") or row.get("utilization_pct")
+                        _first_value(row, "auslastung_pct", "utilization_pct")
                     ),
                 }
             )
@@ -296,62 +305,6 @@ def compute_energy_transition_score(profile: dict) -> float:
 
     score = (solar * 30) + (ev * 20) + (heating * 25) + (prod_ratio * 25)
     return round(score, 1)
-
-
-# === Orchestration ===
-
-
-def refresh_municipality(bfs_number: int, year: int = 2026) -> dict:
-    """Fetch all sources for one municipality, compute derived fields."""
-    import database as db
-
-    result = {"bfs_number": bfs_number, "sources": {}}
-
-    # ElCom tariffs
-    tariffs = fetch_elcom_tariffs(bfs_number, year)
-    if tariffs:
-        saved = db.save_elcom_tariffs(tariffs)
-        result["sources"]["elcom"] = {"records": len(tariffs), "saved": saved}
-
-    # Find H4 tariff for value-gap calculation
-    h4 = next((t for t in tariffs if t.get("category", "").startswith("H4")), None)
-    value_gap = compute_leg_value_gap(h4) if h4 else {"annual_savings_chf": 0}
-
-    # Get existing profile or create stub
-    existing = db.get_municipality_profile(bfs_number)
-    profile = {
-        "bfs_number": bfs_number,
-        "name": existing.get("name", "") if existing else "",
-        "kanton": existing.get("kanton", "ZH") if existing else "ZH",
-        "population": existing.get("population") if existing else None,
-        "solar_potential_pct": existing.get("solar_potential_pct")
-        if existing
-        else None,
-        "solar_installed_kwp": existing.get("solar_installed_kwp")
-        if existing
-        else None,
-        "ev_share_pct": existing.get("ev_share_pct") if existing else None,
-        "renewable_heating_pct": existing.get("renewable_heating_pct")
-        if existing
-        else None,
-        "electricity_consumption_mwh": existing.get("electricity_consumption_mwh")
-        if existing
-        else None,
-        "renewable_production_mwh": existing.get("renewable_production_mwh")
-        if existing
-        else None,
-        "leg_value_gap_chf": value_gap.get("annual_savings_chf", 0),
-        "data_sources": {
-            "elcom": True,
-            "last_refresh": datetime.now(timezone.utc).isoformat(),
-        },
-    }
-    profile["energy_transition_score"] = compute_energy_transition_score(profile)
-    db.save_municipality_profile(profile)
-    result["profile"] = profile
-    result["value_gap"] = value_gap
-
-    return result
 
 
 def refresh_canton(kanton: str = "ZH", year: int = 2026) -> dict:

--- a/security_utils.py
+++ b/security_utils.py
@@ -6,7 +6,6 @@ Provides input validation, sanitization, and security helpers
 
 import logging
 import re
-from urllib.parse import urlparse
 
 import bleach
 from email_validator import EmailNotValidError, validate_email
@@ -134,7 +133,7 @@ def validate_phone(phone):
 
     # Swiss phone numbers: +41... or 0...
     if not re.match(r"^(\+41|0041|0)\d{9}$", normalized):
-        return False, None, "Ungültige Schweizer Telefonnummer"
+        return False, None, "Geben Sie eine gültige Schweizer Telefonnummer ein."
 
     # Normalize to +41 format
     if normalized.startswith("0041"):
@@ -217,66 +216,6 @@ def validate_token(token):
         return False, "Ungültiges Token-Format"
 
     return True, None
-
-
-def is_safe_redirect_url(url, allowed_hosts=None):
-    """
-    Check if redirect URL is safe (prevents open redirect vulnerabilities)
-
-    Args:
-        url: URL to check
-        allowed_hosts: List of allowed hostnames
-
-    Returns:
-        bool: True if URL is safe
-    """
-    if not url:
-        return True
-
-    # Parse URL
-    try:
-        parsed = urlparse(url)
-    except Exception:
-        return False
-
-    # Relative URLs are safe
-    if not parsed.netloc:
-        return True
-
-    # Check against allowed hosts
-    if allowed_hosts:
-        return parsed.netloc in allowed_hosts
-
-    return False
-
-
-def sanitize_json_output(data):
-    """
-    Sanitize data before JSON output
-    Prevents potential XSS in JSON responses
-
-    Args:
-        data: Dictionary or list to sanitize
-
-    Returns:
-        Sanitized data
-    """
-    if isinstance(data, dict):
-        return {k: sanitize_json_output(v) for k, v in data.items()}
-    elif isinstance(data, list):
-        return [sanitize_json_output(item) for item in data]
-    elif isinstance(data, str):
-        # Escape HTML special characters in strings
-        return (
-            data.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace('"', "&quot;")
-            .replace("'", "&#x27;")
-            .replace("/", "&#x2F;")
-        )
-    else:
-        return data
 
 
 def check_request_size(request, max_content_length=1024 * 1024):

--- a/tests/test_data_enricher.py
+++ b/tests/test_data_enricher.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+from unittest.mock import MagicMock, patch
+
+import data_enricher
+
+
+def test_get_address_suggestions_skips_malformed_and_recovers_plz_from_label():
+    """Malformed entries must not crash the parser; a non-string label and a
+    later valid result with an invalid attrs.plz and HTML in the label must be
+    recovered from the label.
+    """
+    mock_response = MagicMock()
+    mock_response.json.return_value = {
+        "results": [
+            "not-a-dict-result",
+            {"attrs": "not-a-dict-attrs"},
+            {"attrs": {"label": 123}},
+            {
+                "attrs": {
+                    "label": "<b>Seestrasse 12</b>, <i>8700</i> Küsnacht ZH",
+                    "lat": 47.319,
+                    "lon": 8.584,
+                    "plz": "invalid",
+                }
+            },
+        ]
+    }
+
+    with patch("data_enricher.requests.get", return_value=mock_response) as mock_get:
+        suggestions = data_enricher.get_address_suggestions("Seestrasse")
+
+    mock_get.assert_called_once()
+    assert suggestions == [
+        {
+            "label": "Seestrasse 12, 8700 Küsnacht ZH",
+            "lat": 47.319,
+            "lon": 8.584,
+            "plz": 8700,
+        }
+    ]

--- a/tests/test_formation_wizard.py
+++ b/tests/test_formation_wizard.py
@@ -1,0 +1,115 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Tests for formation_wizard public seams."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+import formation_wizard
+
+
+def _make_mock_db(row):
+    """Return a mock db module whose get_connection/cursor seam yields row."""
+    mock_cur = MagicMock()
+    mock_cur.fetchone.return_value = row
+    cur_cm = MagicMock()
+    cur_cm.__enter__ = MagicMock(return_value=mock_cur)
+    cur_cm.__exit__ = MagicMock(return_value=False)
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = cur_cm
+    conn_cm = MagicMock()
+    conn_cm.__enter__ = MagicMock(return_value=mock_conn)
+    conn_cm.__exit__ = MagicMock(return_value=False)
+    mock_db = MagicMock()
+    mock_db.get_connection.return_value = conn_cm
+    return mock_db
+
+
+def test_get_community_status_normalizes_none_members_to_empty_list():
+    """PostgreSQL array_agg with FILTER returns NULL for zero members.
+
+    The function must still return the community, normalize members to [],
+    and report member_count total/confirmed/invited all zero.
+    """
+    community_id = "c0ffee"
+    row = {
+        "community_id": community_id,
+        "name": "LEG Musterweg",
+        "status": "interested",
+        "distribution_model": "simple",
+        "admin_building_id": "b-admin",
+        "created_at": None,
+        "formation_started_at": None,
+        "dso_submitted_at": None,
+        "members": None,
+    }
+    mock_db = _make_mock_db(row)
+
+    result = formation_wizard.get_community_status(mock_db, community_id)
+
+    assert result is not None
+    assert result["community_id"] == community_id
+    assert result["members"] == []
+    assert result["member_count"] == {"total": 0, "confirmed": 0, "invited": 0}
+
+
+@pytest.mark.parametrize(
+    "status, expected_next_steps",
+    [
+        (
+            "interested",
+            ["Laden Sie mindestens 3 weitere Nachbarn ein."],
+        ),
+        (
+            "formation_started",
+            [
+                "Erstellen Sie die Rechtsdokumente.",
+                "Prüfen Sie die Gemeinschaftsvereinbarung.",
+            ],
+        ),
+        (
+            "documents_generated",
+            [
+                "Holen Sie die Unterschriften aller Mitglieder ein.",
+                "Prüfen Sie die Teilnehmerverträge.",
+            ],
+        ),
+        (
+            "signatures_pending",
+            ["Reichen Sie die Anmeldung beim VNB ein."],
+        ),
+        (
+            "dso_submitted",
+            [
+                "Warten Sie auf die Genehmigung des VNB. Dies kann bis zu 30 Tage dauern."
+            ],
+        ),
+        (
+            "dso_approved",
+            [
+                "Legen Sie das Aktivierungsdatum fest.",
+                "Konfigurieren Sie die Abrechnung.",
+            ],
+        ),
+    ],
+)
+def test_get_community_status_next_steps(status, expected_next_steps):
+    """get_community_status reports the correct next steps per workflow status."""
+    community_id = "c0ffee"
+    row = {
+        "community_id": community_id,
+        "name": "LEG Musterweg",
+        "status": status,
+        "distribution_model": "simple",
+        "admin_building_id": "b-admin",
+        "created_at": None,
+        "formation_started_at": None,
+        "dso_submitted_at": None,
+        "members": [],
+    }
+    mock_db = _make_mock_db(row)
+
+    result = formation_wizard.get_community_status(mock_db, community_id)
+
+    assert result is not None
+    assert result["next_steps"] == expected_next_steps

--- a/tests/test_geometry_hull.py
+++ b/tests/test_geometry_hull.py
@@ -7,9 +7,6 @@ produced is pinned here and served by ``geometry.convex_hull``.
 """
 
 import os
-from unittest.mock import patch
-
-import pytest
 
 PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
@@ -53,43 +50,6 @@ class TestConvexHull:
         assert hull is not None
         assert all(isinstance(point, list) for point in hull)
         assert all(len(point) == 2 for point in hull)
-
-
-class TestClusterPolygon:
-    @pytest.fixture
-    def create_simple_polygon(self):
-        with patch("database.is_db_available", return_value=True):
-            import app as app_module
-
-        return app_module.create_simple_polygon
-
-    def test_polygon_closes_the_hull_ring(self, create_simple_polygon):
-        polygon = create_simple_polygon(SQUARE + [INTERIOR])
-
-        assert len(polygon) == 5
-        assert polygon[0] == polygon[-1]
-        assert INTERIOR not in polygon
-        assert {tuple(point) for point in polygon[:-1]} == {tuple(p) for p in SQUARE}
-
-    def test_polygon_falls_back_to_a_padded_box_when_the_hull_degenerates(
-        self, create_simple_polygon
-    ):
-        polygon = create_simple_polygon(COLLINEAR)
-
-        assert len(polygon) == 5
-        assert polygon[0] == polygon[-1]
-        lats = [point[0] for point in polygon]
-        lons = [point[1] for point in polygon]
-        assert min(lats) == pytest.approx(47.0 - 0.0003)
-        assert max(lats) == pytest.approx(47.002 + 0.0003)
-        assert min(lons) == pytest.approx(8.0 - 0.0003)
-        assert max(lons) == pytest.approx(8.002 + 0.0003)
-
-    def test_single_and_paired_coordinates_keep_their_shapes(
-        self, create_simple_polygon
-    ):
-        assert len(create_simple_polygon([[47.0, 8.0]])) == 5
-        assert len(create_simple_polygon([[47.0, 8.0], [47.01, 8.01]])) == 5
 
 
 class TestSciPyIsGone:

--- a/tests/test_public_data.py
+++ b/tests/test_public_data.py
@@ -126,6 +126,98 @@ class TestFetchElcom:
         assert fetch_elcom_tariffs(261, 2026) == []
 
 
+class TestFetchCkanData:
+    @patch("public_data.requests.get")
+    def test_energie_reporter_uses_csv_resource_and_normalizes_aliases(self, mock_get):
+        from public_data import ENERGIE_REPORTER_URL, fetch_energie_reporter
+
+        metadata = MagicMock()
+        metadata.json.return_value = {
+            "result": {
+                "resources": [
+                    {"format": "JSON", "url": "https://example.test/data.json"},
+                    {"format": "csv", "url": "https://example.test/data.csv"},
+                ]
+            }
+        }
+        csv_response = MagicMock(
+            text=(
+                "bfs_nr;gemeindename;kanton;solar_potential_pct;ev_share_pct;"
+                "renewable_heating_pct;electricity_consumption_mwh;"
+                "renewable_production_mwh\n"
+                "4021;Baden;AG;48,5;12;31;1000;250\n"
+                ";Ignored;AG;1;2;3;4;5\n"
+            ),
+            apparent_encoding="utf-8",
+        )
+        mock_get.side_effect = [metadata, csv_response]
+
+        result = fetch_energie_reporter()
+
+        assert result == [
+            {
+                "bfs_number": 4021,
+                "name": "Baden",
+                "kanton": "AG",
+                "solar_potential_pct": 48.5,
+                "ev_share_pct": 12.0,
+                "renewable_heating_pct": 31.0,
+                "electricity_consumption_mwh": 1000.0,
+                "renewable_production_mwh": 250.0,
+            }
+        ]
+        assert mock_get.call_args_list[0].args == (ENERGIE_REPORTER_URL,)
+        assert mock_get.call_args_list[1].args == ("https://example.test/data.csv",)
+
+    @patch("public_data.requests.get")
+    def test_sonnendach_prefers_municipal_csv(self, mock_get):
+        from public_data import SONNENDACH_URL, fetch_sonnendach_municipal
+
+        metadata = MagicMock()
+        metadata.json.return_value = {
+            "result": {
+                "resources": [
+                    {
+                        "format": "CSV",
+                        "name": "Buildings",
+                        "url": "https://example.test/buildings.csv",
+                    },
+                    {
+                        "format": "CSV",
+                        "name": "Gemeinden",
+                        "url": "https://example.test/municipalities.csv",
+                    },
+                ]
+            }
+        }
+        csv_response = MagicMock(
+            text=(
+                "BFS_NR;dachflaeche_total_m2;dachflaeche_geeignet_m2;"
+                "potenzial_kwh_jahr;potenzial_kwp;auslastung_pct\n"
+                "4021;500;250;200000;180;8,3\n"
+            ),
+            apparent_encoding="utf-8",
+        )
+        mock_get.side_effect = [metadata, csv_response]
+
+        result = fetch_sonnendach_municipal()
+
+        assert result == [
+            {
+                "bfs_number": 4021,
+                "total_roof_area_m2": 500.0,
+                "suitable_roof_area_m2": 250.0,
+                "potential_kwh_year": 200000.0,
+                "potential_kwp": 180.0,
+                "utilization_pct": 8.3,
+            }
+        ]
+        assert mock_get.call_args_list[0].args == (SONNENDACH_URL,)
+        assert mock_get.call_args_list[1].args == (
+            "https://example.test/municipalities.csv",
+        )
+
+
 class TestSafeHelpers:
     def test_safe_int(self):
         from public_data import _safe_int

--- a/tests/test_public_hardening.py
+++ b/tests/test_public_hardening.py
@@ -83,6 +83,15 @@ def test_cron_endpoints_fail_closed_without_secret(app_without_cron_secret):
         )
 
 
+def test_get_all_clusters_returns_404(app_without_cron_secret):
+    client = app_without_cron_secret.app.test_client()
+    response = client.get("/api/get_all_clusters")
+    assert response.status_code == 404, (
+        f"GET /api/get_all_clusters must be disabled to avoid exposing "
+        f"cross-tenant citizen cluster data, got {response.status_code}"
+    )
+
+
 def test_deepsign_webhook_rejects_unsigned_when_secret_set(app_with_deepsign_secret):
     client = app_with_deepsign_secret.app.test_client()
     response = client.post(

--- a/tests/test_utility_portal.py
+++ b/tests/test_utility_portal.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Utility portal HTTP interface tests."""
+
+from unittest.mock import patch
+
+from flask import Flask
+
+import utility_portal
+
+
+def _client():
+    app = Flask(__name__)
+    app.config.update(TESTING=True, SECRET_KEY="test-secret")
+    app.register_blueprint(utility_portal.utility_bp)
+    return app.test_client()
+
+
+def test_registration_rejects_non_json_with_json_error():
+    response = _client().post(
+        "/utility/register", data="not-json", content_type="text/plain"
+    )
+
+    assert response.status_code == 400
+    assert response.is_json
+    assert response.get_json() == {"error": "Geben Sie Firmenname und E-Mail ein."}
+
+
+def test_login_rejects_non_json_with_json_error():
+    response = _client().post(
+        "/utility/login", data="not-json", content_type="text/plain"
+    )
+
+    assert response.status_code == 400
+    assert response.is_json
+    assert response.get_json() == {"error": "E-Mail-Adresse ist erforderlich"}
+
+
+def test_registration_rejects_non_object_json():
+    response = _client().post("/utility/register", json=["invalid"])
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Geben Sie Firmenname und E-Mail ein."}
+
+
+def test_login_rejects_non_string_email():
+    response = _client().post("/utility/login", json={"email": ["invalid"]})
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "E-Mail-Adresse ist erforderlich"}
+
+
+def test_registration_rejects_invalid_phone_before_writing():
+    with (
+        patch.object(
+            utility_portal.db, "get_utility_client_by_email", return_value=None
+        ),
+        patch.object(utility_portal.db, "save_utility_client") as save_client,
+        patch.object(utility_portal, "_send_magic_link") as send_magic_link,
+    ):
+        response = _client().post(
+            "/utility/register",
+            json={
+                "company_name": "Regionalwerke AG Baden",
+                "contact_email": "kontakt@example.com",
+                "contact_phone": "definitely-not-a-phone",
+            },
+        )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Geben Sie eine gültige Schweizer Telefonnummer ein."
+    }
+    save_client.assert_not_called()
+    send_magic_link.assert_not_called()

--- a/utility_portal.py
+++ b/utility_portal.py
@@ -35,6 +35,11 @@ SITE_URL = os.getenv("APP_BASE_URL", "http://localhost:5003").rstrip("/")
 MAGIC_LINK_TTL = 900  # 15 minutes
 
 
+def _text_field(data, key):
+    value = data.get(key)
+    return value.strip() if isinstance(value, str) else ""
+
+
 def _get_current_client():
     """Get current logged-in utility client from session."""
     client_id = session.get("utility_client_id")
@@ -69,17 +74,19 @@ def register_page():
 
 @utility_bp.route("/register", methods=["POST"])
 def register():
-    data = request.json or request.form.to_dict()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        data = {}
 
-    company_name = (data.get("company_name") or "").strip()
-    contact_name = (data.get("contact_name") or "").strip()
-    contact_email = (data.get("contact_email") or "").strip()
-    contact_phone = (data.get("contact_phone") or "").strip()
-    vnb_name = (data.get("vnb_name") or "").strip()
-    kanton = (data.get("kanton") or "").strip().upper()[:2]
+    company_name = _text_field(data, "company_name")
+    contact_name = _text_field(data, "contact_name")
+    contact_email = _text_field(data, "contact_email")
+    contact_phone = _text_field(data, "contact_phone")
+    vnb_name = _text_field(data, "vnb_name")
+    kanton = _text_field(data, "kanton").upper()[:2]
 
     if not company_name or not contact_email:
-        return jsonify({"error": "Firmenname und E-Mail sind erforderlich."}), 400
+        return jsonify({"error": "Geben Sie Firmenname und E-Mail ein."}), 400
 
     is_valid, normalized, error = security_utils.validate_email_address(contact_email)
     if not is_valid:
@@ -94,11 +101,12 @@ def register():
         ), 409
 
     if contact_phone:
-        is_valid_phone, normalized_phone, _phone_error = security_utils.validate_phone(
+        is_valid_phone, normalized_phone, phone_error = security_utils.validate_phone(
             contact_phone
         )
-        if is_valid_phone:
-            contact_phone = normalized_phone
+        if not is_valid_phone:
+            return jsonify({"error": phone_error}), 400
+        contact_phone = normalized_phone
 
     population = None
     pop_raw = data.get("population")
@@ -175,8 +183,10 @@ def login_page():
 
 @utility_bp.route("/login", methods=["POST"])
 def login_submit():
-    data = request.json or request.form.to_dict()
-    email = (data.get("email") or "").strip()
+    data = request.get_json(silent=True)
+    if not isinstance(data, dict):
+        data = {}
+    email = _text_field(data, "email")
 
     is_valid, normalized, error = security_utils.validate_email_address(email)
     if not is_valid:


### PR DESCRIPTION
## Summary

- add focused regressions for malformed public inputs and upstream responses
- simplify duplicated public-data and formation-status logic
- remove unused cross-tenant cluster read surface and dead helpers
- reduce production CRAP hotspots above 30 from 22 to 12

## Impact

Malformed JSON, scalar payloads, invalid phone numbers, malformed Swisstopo results, and nullable formation members now fail safely. The unused global cluster endpoint no longer exposes citizen cluster data.

## Validation

- `scripts/tdd_cycle.sh gate`: 1,010 passed
- Ruff check and format: clean
- CodeRabbit CLI: 0 findings on the completed slice
- production branch coverage: 71.4%

Closes #303


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Address suggestions now handle incomplete results more reliably, including postal codes embedded in labels.
  - Improved municipal energy and solar data retrieval, parsing, and field compatibility.
  - Community status updates now provide clearer next-step guidance and handle missing member information safely.
  - Registration and login validation now reject malformed JSON, invalid fields, and invalid Swiss phone numbers.
  - Restricted access to cluster data to prevent unauthorized exposure.

- **Tests**
  - Added coverage for address parsing, municipal data imports, workflow transitions, security, and portal validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->