### PR TITLE
[codex] fix(container): upgrade vendored build dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# CVE-2026-23949 (jaraco.context), CVE-2026-24049 (wheel): upgrade the
+# base-image package that vendors both dependencies.
+RUN pip install --no-cache-dir --upgrade "setuptools>=84.0.0"
+
 COPY *.py ./
 COPY store/ store/
 COPY templates/ templates/

--- a/tests/test_deployment.py
+++ b/tests/test_deployment.py
@@ -135,3 +135,11 @@ class TestDockerfile:
 
     def test_gthread_workers(self):
         assert "gthread" in self.content
+
+    def test_explicitly_upgrades_cve_vulnerable_build_deps(self):
+        """Issue #307: Trivy blocked vendored jaraco.context and wheel.
+
+        Setuptools 84 removes the vulnerable jaraco.context copy and vendors a
+        fixed wheel version.
+        """
+        assert "setuptools>=84.0.0" in self.content


### PR DESCRIPTION
Closes #307

## What changed

- Upgrade runtime `setuptools` to `>=84.0.0`, removing vulnerable vendored `jaraco.context` and `wheel` copies.
- Add a Dockerfile regression contract.

## TDD evidence

- [x] RED: focused deployment test failed before the Dockerfile change
- [x] GREEN: 21 focused deployment tests pass
- [x] Refactor: two-file, 12-line YAGNI diff
- [x] `scripts/tdd_cycle.sh gate` passes: 1,088 tests; ruff clean

## Review and QA

- [x] I reviewed every changed hunk
- [x] CodeRabbit has no unresolved findings
- [x] User-facing browser testing is not applicable to this container-only change
- [x] Keyboard, motion, and overflow checks are not applicable
- [x] Local Trivy 0.70.0 image scan reports 0 HIGH/CRITICAL findings

## Public repository safety

- [x] This change contains no secrets, production host details or private operations notes
- [x] This change contains no citizen data or identifying smart-meter data
- [x] Documentation and user-facing German use Swiss High German

## Execution fallback

- Kimi Code unavailable: expired API credential (`401`)
- Claude Code used per `AGENTS.md` fallback policy