### PR TITLE
[codex] refactor(templates): remove city overrides

### DIFF
--- a/app.py
+++ b/app.py
@@ -21,7 +21,6 @@ from flask import (
     request,
     send_from_directory,
 )
-from jinja2 import TemplateNotFound
 
 import billing_runner
 import cache as cache_module
@@ -93,18 +92,14 @@ else:
 
 
 def render_city_template(template_name, **kwargs):
-    """Render a per-city template with fallback to default."""
+    """Render the canonical template with tenant context."""
     tenant = getattr(g, "tenant", tenant_module.DEFAULT_TENANT)
     kwargs.setdefault("tenant", tenant)
     kwargs.setdefault("site_url", current_app.config["SITE_URL"])
     kwargs.setdefault(
         "ga4_id", tenant.get("ga4_id") or os.getenv("GA4_MEASUREMENT_ID", "")
     )
-    city_path = f"cities/{tenant['territory']}/{template_name}"
-    try:
-        return render_template(city_path, **kwargs)
-    except TemplateNotFound:
-        return render_template(template_name, **kwargs)
+    return render_template(template_name, **kwargs)
 
 
 @main_bp.after_app_request

--- a/tests/test_canonical_templates.py
+++ b/tests/test_canonical_templates.py
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: AGPL-3.0-or-later
+"""Canonical public template routing."""
+
+from flask import Flask, g
+from jinja2 import DictLoader
+
+import app as app_module
+
+
+def test_tenant_context_cannot_override_the_tracked_template():
+    flask_app = Flask(__name__)
+    flask_app.config["SITE_URL"] = "https://openleg.ch"
+    flask_app.jinja_loader = DictLoader(
+        {
+            "index.html": "canonical|{{ marker }}|{{ tenant.territory }}|{{ site_url }}|{{ ga4_id }}",
+            "cities/zurich/index.html": "legacy tenant override",
+        }
+    )
+    tenant = {"territory": "zurich", "ga4_id": ""}
+
+    with flask_app.test_request_context("/"):
+        g.tenant = tenant
+        result = app_module.render_city_template("index.html", marker="value")
+
+    assert result == "canonical|value|zurich|https://openleg.ch|"

--- a/tests/test_canonical_templates.py
+++ b/tests/test_canonical_templates.py
@@ -16,10 +16,10 @@ def test_tenant_context_cannot_override_the_tracked_template():
             "cities/zurich/index.html": "legacy tenant override",
         }
     )
-    tenant = {"territory": "zurich", "ga4_id": ""}
+    tenant = {"territory": "zurich", "ga4_id": "G-TENANT"}
 
     with flask_app.test_request_context("/"):
         g.tenant = tenant
         result = app_module.render_city_template("index.html", marker="value")
 
-    assert result == "canonical|value|zurich|https://openleg.ch|"
+    assert result == "canonical|value|zurich|https://openleg.ch|G-TENANT"


### PR DESCRIPTION
Closes #309

## What changed

- Remove untracked per-city template lookup.
- Keep tenant, analytics, and site context on canonical templates.
- Add a real competing-template regression test.

## TDD evidence

- [x] RED: tenant selected `cities/zurich/index.html`
- [x] GREEN: canonical template wins
- [x] Refactor: one function simplified; unused import removed
- [x] `scripts/tdd_cycle.sh gate`: 1,089 tests; ruff clean

## Review and QA

- [x] Every hunk reviewed
- [ ] CodeRabbit rerun clean
- [x] Browser QA deferred until immutable deploy
- [x] No motion/overflow impact

## Public repository safety

- [x] No secrets, host details, or private ops notes
- [x] No citizen or identifying smart-meter data
- [x] No user-facing copy changed

## Execution fallback

- Kimi Code unavailable: expired API credential (`401`)
- Claude Code used per `AGENTS.md` fallback policy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * City pages now consistently use the canonical tracked template.
  * Tenant-specific template settings can no longer override canonical page content.
  * Tenant details, site URL, and GA4 configuration remain available when pages are rendered.

* **Tests**
  * Added regression coverage confirming canonical template selection and preservation of tenant and site configuration values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->