### PR TITLE
[codex] Clarify public handoff boundary

### DIFF
--- a/docs/repo-boundary.md
+++ b/docs/repo-boundary.md
@@ -20,4 +20,5 @@ configuration, host inventory, incident notes, or secret-handling procedures.
 ## Rule of Thumb
 
 - Put reusable product code, tests, and public docs in `openleg`.
-- Put private operations and internal planning in a separate private repository.
+- Keep local handoff notes untracked.
+- Put production status, incident logs, operations, and internal planning in `openleg-ops`.


### PR DESCRIPTION
Closes #311

## Summary
- keep local handoff notes untracked
- route durable production status and incident history to private `openleg-ops`
- avoid adding another public status document

The ignored local `handoff.md` was also reduced from stale secret-adjacent operational notes to a 13-line public-safe local handoff.

## Verification
- `scripts/tdd_cycle.sh gate`
- 1089 tests passed
- Ruff checks passed

Kimi produced the simplified local handoff; the orchestrator kept the tracked diff to one boundary rule.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified repository boundaries for local handoff notes.
  * Specified that production status, incident logs, operations, and internal planning belong in the designated operations repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->